### PR TITLE
Provide types to 3rd party developers for easier development process

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,5 +44,5 @@ export interface Editor {
 }
 
 export interface HttpClient {
-    get: (url: string, options?: any) => Promise<any>;
+    get: <T>(url: string, options?: Record<string, unknown>) => Promise<T>;
 }


### PR DESCRIPTION
Usage:

```typescript
import { Asset, AssetChooser, AssetChooserResult, AssetChooserFilter, Editor, HttpClient, Context } from "frontify-block-cli/types";
```