### PR TITLE
feat: add multiple ids to be selected in asset chooser

### DIFF
--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -344,8 +344,11 @@ export class AppBridgeBlock {
                   projectTypes: options.projectTypes?.map((value) => projectTypesMap[value]),
                   multiSelectionAllowed: options.multiSelection,
                   filters: [
-                      ...(options.selectedValueId !== undefined
+                      ...('selectedValueId' in options
                           ? [{ key: 'id', values: [options.selectedValueId], inverted: true }]
+                          : []),
+                      ...('selectedValueIds' in options
+                          ? [{ key: 'id', values: options.selectedValueIds, inverted: true }]
                           : []),
                       ...(options.extensions ? [{ key: 'ext', values: options.extensions }] : []),
                       ...(options.objectTypes ? [{ key: 'object_type', values: options.objectTypes }] : []),

--- a/packages/app-bridge/src/types/Terrific.ts
+++ b/packages/app-bridge/src/types/Terrific.ts
@@ -42,10 +42,16 @@ export enum AssetChooserObjectType {
 }
 
 export type AssetChooserOptions = {
-    selectedValueId?: number | string;
     projectTypes?: AssetChooserProjectType[];
     objectTypes?: AssetChooserObjectType[];
     multiSelection?: boolean;
     extensions?: (FileExtension | string)[];
     urlContains?: string;
-};
+} & (
+    | {
+          selectedValueId?: number | string;
+      }
+    | {
+          selectedValueIds?: (number | string)[];
+      }
+);


### PR DESCRIPTION
Added
```ts
appBridge.openAssetChooser(
    (result) => {
        const assetsId = result.map((asset) => asset.id);
        // [...]
        appBridge.closeAssetChooser();
    },
    {
        selectedValueIds: [1, 2, 3],
    }
);
```

To test:
Build App Bridge with `pnpm build`
Link in your block `app-bridge`, `pnpm link <path to brand-sdk repo>/packages/app-bridge`
