### PR TITLE
fix: deploy command on windows

### DIFF
--- a/.changeset/four-cooks-trade.md
+++ b/.changeset/four-cooks-trade.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+Fix path issue on Windows when deploying the app

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -64,10 +64,10 @@ export const createDeployment = async (
 
             if (!noVerify) {
                 Logger.info('Performing type checks...');
-                await promiseExec(`cd ${projectPath} && ./node_modules/.bin/tsc --noEmit`);
+                await promiseExec('npx tsc --noEmit');
 
                 Logger.info('Performing eslint checks...');
-                await promiseExec(`cd ${projectPath} && ./node_modules/.bin/eslint src`);
+                await promiseExec('npx eslint src');
             }
 
             try {


### PR DESCRIPTION
Windows users couldn't execute the `./node_modules/[...]` command due to slashes instead of backslashes