### PR TITLE
Enable `userBrandChooser` on asset chooser

### DIFF
--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -344,6 +344,7 @@ export class AppBridgeBlock {
 
         const assetChooserOptions = options
             ? {
+                  userBrandChooser: true,
                   brandId: window.application.sandbox.config.context.brand.id,
                   projectTypes: options.projectTypes?.map((value) => projectTypesMap[value]),
                   multiSelectionAllowed: options.multiSelection,


### PR DESCRIPTION
This PR enabled the brand chooser in the brand SDK (so basically it enables the brand chooser in the asset chooser for custom blocks).