### PR TITLE
feat: add async heading option for section

### DIFF
--- a/.changeset/red-wasps-tap.md
+++ b/.changeset/red-wasps-tap.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": patch
+---
+
+SectionHeadingBlock now supports an asynchronous label type

--- a/packages/sidebar-settings/src/blocks/sectionHeading.ts
+++ b/packages/sidebar-settings/src/blocks/sectionHeading.ts
@@ -13,9 +13,4 @@ export type SectionHeadingBlock<AppBridge> = {
      * The list of blocks that make up the section.
      */
     blocks: SettingBlock<AppBridge>[];
-
-    /**
-     * The label of the section.
-     */
-    label?: string;
 } & BaseBlock<AppBridge>;


### PR DESCRIPTION
Add the possibility of having a heading that is asynchronously determined