### PR TITLE
feat: Add cover page translations

### DIFF
--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -276,7 +276,7 @@ export class AppBridgeTheme {
      * @deprecated legacy method, should be removed once new endpoint is available
      */
     public async updateLegacyCoverPage(coverPage: CoverPageUpdateLegacy) {
-        return updateLegacyCoverPage({ ...coverPage, portalId: this.getPortalId() });
+        return updateLegacyCoverPage({ ...coverPage, portalId: this.getPortalId() }, this.getTranslationLanguage());
     }
 
     public async deleteCoverPage() {
@@ -292,7 +292,7 @@ export class AppBridgeTheme {
     }
 
     public getCoverPage(): Promise<CoverPage> {
-        return getCoverPage(this.getPortalId());
+        return getCoverPage(this.getPortalId(), this.getTranslationLanguage());
     }
 
     public getBrandportalLink(): Promise<BrandportalLink> {

--- a/packages/app-bridge/src/repositories/CoverPageRepository.ts
+++ b/packages/app-bridge/src/repositories/CoverPageRepository.ts
@@ -44,17 +44,20 @@ export const updateLegacyCoverPage = async (
     coverPage: CoverPageUpdateLegacy & {
         portalId: number;
     },
+    language = '',
 ): Promise<CoverPageUpdateLegacy> => {
-    const { result } = await HttpClient.post<CoverPageUpdateLegacy>(
-        `/api/hub/settings/${coverPage.portalId}`,
-        coverPage,
-    );
+    const { result } = await HttpClient.post<CoverPageUpdateLegacy>(`/api/hub/settings/${coverPage.portalId}`, {
+        ...coverPage,
+        ...(language && { language }),
+    });
 
     return result as unknown as CoverPageUpdateLegacy;
 };
 
-export const getCoverPage = async (hubId: number): Promise<CoverPage> => {
-    const { result } = await HttpClient.get<CoverPageApi>(`/api/document/navigation/${hubId}`);
+export const getCoverPage = async (hubId: number, language = ''): Promise<CoverPage> => {
+    const languageQuery = language.length > 0 ? `?language=${language}` : '';
+
+    const { result } = await HttpClient.get<CoverPageApi>(`/api/document/navigation/${hubId}${languageQuery}`);
 
     return mapToCoverPage(<CoverPageApi>(<unknown>result));
 };


### PR DESCRIPTION
Same as the previous one, just for the cover page endpoints