### PR TITLE
fix: read block settings from data object

### DIFF
--- a/packages/app-bridge/src/AppBridgeBlock.spec.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.spec.ts
@@ -543,4 +543,34 @@ describe('AppBridgeBlockTest', () => {
 
         expect(emitterEmitStub).toHaveBeenCalledWith('AppBridge:ViewerOpened', { token: asset.token });
     });
+
+    it('should returns the block settings', async () => {
+        const settings = { foo: 'bar', bar: { foo: 1 } };
+        const mockHttpClientGet = vi.fn().mockReturnValue({
+            result: {
+                success: true,
+                data: { settings },
+            },
+        });
+        HttpClient.get = mockHttpClientGet;
+
+        const appBridge = new AppBridgeBlock(BLOCK_ID, SECTION_ID);
+        const result = await appBridge.getBlockSettings();
+
+        expect(result).toEqual(settings);
+    });
+
+    it('should throw if it can not get the block settings', async () => {
+        const mockHttpClientGet = vi.fn().mockReturnValue({
+            result: {
+                success: false,
+                data: 'das ist kaputt',
+            },
+        });
+        HttpClient.get = mockHttpClientGet;
+
+        const appBridge = new AppBridgeBlock(BLOCK_ID, SECTION_ID);
+
+        await expect(() => appBridge.getBlockSettings()).rejects.toThrowError();
+    });
 });

--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -272,7 +272,7 @@ export class AppBridgeBlock {
             throw new Error('Could not get the block settings');
         }
 
-        return responseJson.settings as T;
+        return (responseJson.data?.settings ?? responseJson.settings) as T;
     }
 
     // TODO: add tests (https://app.clickup.com/t/2qagxm6)

--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -252,27 +252,18 @@ export class AppBridgeBlock {
         return `/api/color/export/${blockReferenceToken}/zip/${selectedColorPalettes.join(',')}`;
     }
 
-    // TODO: add tests (https://app.clickup.com/t/2qagxm6)
     public async getBlockSettings<T = Record<string, unknown>>(): Promise<T> {
         const translationLanguage = this.getTranslationLanguage();
         const translationLanguageSuffix = translationLanguage ? `&lang=${translationLanguage}` : '';
-        const response = await window.fetch(
+        const { result } = await HttpClient.get<{ settings: T }>(
             `/api/document/block/${this.blockId}?settings_only=true${translationLanguageSuffix}`,
-            {
-                headers: {
-                    'x-csrf-token': (document.getElementsByName('x-csrf-token')[0] as HTMLMetaElement).content,
-                    'Content-Type': 'application/json',
-                },
-            },
         );
 
-        const responseJson = await response.json();
-
-        if (!responseJson.success) {
+        if (!result.success) {
             throw new Error('Could not get the block settings');
         }
 
-        return (responseJson.data?.settings ?? responseJson.settings) as T;
+        return result.data.settings;
     }
 
     // TODO: add tests (https://app.clickup.com/t/2qagxm6)


### PR DESCRIPTION
This would go with https://github.com/Frontify/clarify/pull/14221

Basically we want to move the data return to be compatible with new endpoints (everything should be inside "data") => therefore we need the FE to expect the data from this legacy endpoint to be in data.

This is temporarily working with the old structure as well (can be removed after we deploy the clarify PR to all instances)