### PR TITLE
feat: add AppBridgeBase

### DIFF
--- a/.changeset/rude-garlics-notice.md
+++ b/.changeset/rude-garlics-notice.md
@@ -1,5 +1,0 @@
----
-"@frontify/app-bridge": minor
----
-
-Introduce AppBridgeBase to provide shared functionalities between AppBridgeBlock and AppBridgeTheme

--- a/.changeset/rude-garlics-notice.md
+++ b/.changeset/rude-garlics-notice.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": minor
+---
+
+Introduce AppBridgeBase to provide shared functionalities between AppBridgeBlock and AppBridgeTheme

--- a/packages/app-bridge/src/AppBridgeBase.ts
+++ b/packages/app-bridge/src/AppBridgeBase.ts
@@ -1,0 +1,41 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import {
+    Color,
+    ColorPalette,
+    Document,
+    DocumentCategory,
+    DocumentGroup,
+    DocumentPage,
+    DocumentPageTargets,
+    DocumentSection,
+    DocumentTargets,
+} from './types';
+
+export interface AppBridgeBase {
+    getProjectId(): number;
+
+    getEditorState(): boolean;
+
+    getTranslationLanguage(): string;
+
+    getColorPalettes(): Promise<ColorPalette[]>;
+
+    getColorsByColorPaletteId(colorPaletteId: number): Promise<Color[]>;
+
+    getAllDocuments(): Promise<Document[]>;
+
+    getDocumentGroups(): Promise<DocumentGroup[]>;
+
+    getDocumentPagesByDocumentId(documentId: number): Promise<DocumentPage[]>;
+
+    getDocumentCategoriesByDocumentId(documentId: number): Promise<DocumentCategory[]>;
+
+    getUncategorizedPagesByDocumentId(documentId: number): Promise<DocumentPage[]>;
+
+    getDocumentSectionsByDocumentPageId(documentPageId: number): Promise<DocumentSection[]>;
+
+    getDocumentTargets(documentId: number): Promise<DocumentTargets>;
+
+    getDocumentPageTargets(documentPageId: number): Promise<DocumentPageTargets>;
+}

--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { AppBridgeBase } from './AppBridgeBase';
 import type {
     Asset,
     AssetChooserOptions,
@@ -13,16 +14,10 @@ import type {
     User,
 } from './types';
 
-export interface AppBridgeBlock {
+export interface AppBridgeBlock extends AppBridgeBase {
     getBlockId(): number;
 
     getSectionId(): number | undefined;
-
-    getProjectId(): number;
-
-    getTranslationLanguage(): string;
-
-    getEditorState(): boolean;
 
     getBlockAssets(): Promise<Record<string, Asset[]>>;
 
@@ -50,11 +45,7 @@ export interface AppBridgeBlock {
      */
     getAvailablePalettes(): Promise<ColorPalette[]>;
 
-    getColorPalettes(): Promise<ColorPalette[]>;
-
     getColorPalettesWithColors(colorPaletteIds?: number[]): Promise<ColorPalette[]>;
-
-    getColorsByColorPaletteId(colorPaletteId: number): Promise<Color[]>;
 
     createColorPalette(colorPaletteCreate: ColorPaletteCreate): Promise<ColorPalette>;
 

--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -21,11 +21,9 @@ import type {
     DocumentPage,
     DocumentPageCreate,
     DocumentPageDuplicate,
-    DocumentPageTargets,
     DocumentPageUpdate,
     DocumentStandardCreate,
     DocumentStandardUpdate,
-    DocumentTargets,
     TargetsUpdate,
 } from './types';
 

--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -1,9 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { AppBridgeBase } from './AppBridgeBase';
 import type {
     BrandportalLink,
-    Color,
-    ColorPalette,
     CoverPage,
     CoverPageCreate,
     CoverPageUpdate,
@@ -24,25 +23,18 @@ import type {
     DocumentPageDuplicate,
     DocumentPageTargets,
     DocumentPageUpdate,
-    DocumentSection,
     DocumentStandardCreate,
     DocumentStandardUpdate,
     DocumentTargets,
     TargetsUpdate,
 } from './types';
 
-export interface AppBridgeTheme {
+export interface AppBridgeTheme extends AppBridgeBase {
     getPortalId(): number;
-
-    getProjectId(): number;
 
     getBrandId(): number;
 
-    getEditorState(): boolean;
-
     openNavigationManager(): void;
-
-    getTranslationLanguage(): string;
 
     getCoverPageSettings<Settings>(): Promise<Settings>;
 
@@ -142,27 +134,7 @@ export interface AppBridgeTheme {
 
     getUngroupedDocuments(): Promise<Document[]>;
 
-    getAllDocuments(): Promise<Document[]>;
-
-    getDocumentGroups(): Promise<DocumentGroup[]>;
-
-    getDocumentPagesByDocumentId(documentId: number): Promise<DocumentPage[]>;
-
-    getDocumentCategoriesByDocumentId(documentId: number): Promise<DocumentCategory[]>;
-
-    getUncategorizedPagesByDocumentId(documentId: number): Promise<DocumentPage[]>;
-
-    getDocumentSectionsByDocumentPageId(documentPageId: number): Promise<DocumentSection[]>;
-
-    getColorPalettes(): Promise<ColorPalette[]>;
-
-    getColorsByColorPaletteId(colorPaletteId: number): Promise<Color[]>;
-
-    getDocumentTargets(documentId: number): Promise<DocumentTargets>;
-
     updateDocumentTargets(targetIds: number[], documentIds: number[]): Promise<TargetsUpdate>;
-
-    getDocumentPageTargets(documentPageId: number): Promise<DocumentPageTargets>;
 
     updateDocumentPageTargets(targetIds: number[], documentPageIds: number[]): Promise<TargetsUpdate>;
 }

--- a/packages/app-bridge/src/index.ts
+++ b/packages/app-bridge/src/index.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+export * from './AppBridgeBase';
 export * from './AppBridgeBlock';
 export * from './AppBridgeCreateAsset';
 export * from './AppBridgeTheme';

--- a/packages/app-bridge/src/react/useBlockAssets.ts
+++ b/packages/app-bridge/src/react/useBlockAssets.ts
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from 'react';
 
+import type { AppBridgeBlock } from '../AppBridgeBlock';
 import type { Asset } from '../types';
 import { compareObjects } from '../utilities';
-import type { AppBridgeBlock } from '../AppBridgeBlock';
 
 export const useBlockAssets = (appBridge: AppBridgeBlock) => {
     const blockId = appBridge.getBlockId();
@@ -42,6 +42,7 @@ export const useBlockAssets = (appBridge: AppBridgeBlock) => {
             componentMounted = false;
             window.emitter.off('AppBridge:BlockAssetsUpdated', updateBlockAssetsFromEvent);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [appBridge]);
 
     const emitUpdatedBlockAssets = async () => {

--- a/packages/app-bridge/src/react/useBlockAssets.ts
+++ b/packages/app-bridge/src/react/useBlockAssets.ts
@@ -42,7 +42,6 @@ export const useBlockAssets = (appBridge: AppBridgeBlock) => {
             componentMounted = false;
             window.emitter.off('AppBridge:BlockAssetsUpdated', updateBlockAssetsFromEvent);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [appBridge]);
 
     const emitUpdatedBlockAssets = async () => {

--- a/packages/app-bridge/src/react/useDocumentCategories.ts
+++ b/packages/app-bridge/src/react/useDocumentCategories.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { AppBridgeBase } from '../AppBridgeBase';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 import type { DocumentCategory, EmitterAction } from '../types';
 
 type DocumentPageEvent = {
@@ -12,7 +13,7 @@ type DocumentPageEvent = {
 
 const sortDocumentCategories = (a: DocumentCategory, b: DocumentCategory) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocumentCategories = (appBridge: AppBridgeBase, documentId: number) => {
+export const useDocumentCategories = (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {
     const [documentCategories, setDocumentCategories] = useState<Map<number, DocumentCategory>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -133,7 +134,7 @@ const actionHandlers = {
     default: (categories: Map<number, DocumentCategory>) => categories,
 };
 
-const fetchDocumentCategories = async (appBridge: AppBridgeBase, documentId: number) => {
+const fetchDocumentCategories = async (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {
     const categories = await appBridge.getDocumentCategoriesByDocumentId(documentId);
 
     return new Map(categories.map((category) => [category.id, category]));

--- a/packages/app-bridge/src/react/useDocumentCategories.ts
+++ b/packages/app-bridge/src/react/useDocumentCategories.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import type { AppBridgeBase } from '../AppBridgeBase';
 import type { DocumentCategory, EmitterAction } from '../types';
 
 type DocumentPageEvent = {
@@ -12,7 +12,7 @@ type DocumentPageEvent = {
 
 const sortDocumentCategories = (a: DocumentCategory, b: DocumentCategory) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocumentCategories = (appBridge: AppBridgeTheme, documentId: number) => {
+export const useDocumentCategories = (appBridge: AppBridgeBase, documentId: number) => {
     const [documentCategories, setDocumentCategories] = useState<Map<number, DocumentCategory>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -133,7 +133,7 @@ const actionHandlers = {
     default: (categories: Map<number, DocumentCategory>) => categories,
 };
 
-const fetchDocumentCategories = async (appBridge: AppBridgeTheme, documentId: number) => {
+const fetchDocumentCategories = async (appBridge: AppBridgeBase, documentId: number) => {
     const categories = await appBridge.getDocumentCategoriesByDocumentId(documentId);
 
     return new Map(categories.map((category) => [category.id, category]));

--- a/packages/app-bridge/src/react/useDocumentGroups.ts
+++ b/packages/app-bridge/src/react/useDocumentGroups.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { AppBridgeBase } from '../AppBridgeBase';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 import type { DocumentGroup, EmitterAction } from '../types';
 
 type DocumentEvent = {
@@ -11,7 +12,7 @@ type DocumentEvent = {
 };
 const sortDocumentGroups = (a: DocumentGroup, b: DocumentGroup) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocumentGroups = (appBridge: AppBridgeBase) => {
+export const useDocumentGroups = (appBridge: AppBridgeBlock | AppBridgeTheme) => {
     const [documentGroups, setDocumentGroups] = useState<Map<number, DocumentGroup>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -143,7 +144,7 @@ const actionHandlers = {
     default: (groups: Map<number, DocumentGroup>) => groups,
 };
 
-const fetchDocumentGroups = async (appBridge: AppBridgeBase) => {
+const fetchDocumentGroups = async (appBridge: AppBridgeBlock | AppBridgeTheme) => {
     const documentGroups = await appBridge.getDocumentGroups();
 
     return new Map(documentGroups.map((group) => [group.id, group]));

--- a/packages/app-bridge/src/react/useDocumentGroups.ts
+++ b/packages/app-bridge/src/react/useDocumentGroups.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import type { AppBridgeBase } from '../AppBridgeBase';
 import type { DocumentGroup, EmitterAction } from '../types';
 
 type DocumentEvent = {
@@ -11,7 +11,7 @@ type DocumentEvent = {
 };
 const sortDocumentGroups = (a: DocumentGroup, b: DocumentGroup) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocumentGroups = (appBridge: AppBridgeTheme) => {
+export const useDocumentGroups = (appBridge: AppBridgeBase) => {
     const [documentGroups, setDocumentGroups] = useState<Map<number, DocumentGroup>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -143,7 +143,7 @@ const actionHandlers = {
     default: (groups: Map<number, DocumentGroup>) => groups,
 };
 
-const fetchDocumentGroups = async (appBridge: AppBridgeTheme) => {
+const fetchDocumentGroups = async (appBridge: AppBridgeBase) => {
     const documentGroups = await appBridge.getDocumentGroups();
 
     return new Map(documentGroups.map((group) => [group.id, group]));

--- a/packages/app-bridge/src/react/useDocumentPageTargets.spec.ts
+++ b/packages/app-bridge/src/react/useDocumentPageTargets.spec.ts
@@ -3,8 +3,7 @@
 import { act, renderHook } from '@testing-library/react';
 import mitt from 'mitt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import { AppBridgeBase } from '../AppBridgeBase';
 
 import { DocumentPageTargetsDummy } from '../tests';
 import { useDocumentPageTargets } from './useDocumentPageTargets';
@@ -12,7 +11,7 @@ import { useDocumentPageTargets } from './useDocumentPageTargets';
 const DOCUMENT_PAGE_ID = 345;
 
 describe('useDocumentPageTargets', () => {
-    const appBridge: AppBridgeTheme = {} as AppBridgeTheme;
+    const appBridge: AppBridgeBase = {} as AppBridgeBase;
 
     beforeEach(() => {
         window.emitter = mitt();

--- a/packages/app-bridge/src/react/useDocumentPageTargets.spec.ts
+++ b/packages/app-bridge/src/react/useDocumentPageTargets.spec.ts
@@ -3,7 +3,8 @@
 import { act, renderHook } from '@testing-library/react';
 import mitt from 'mitt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AppBridgeBase } from '../AppBridgeBase';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 
 import { DocumentPageTargetsDummy } from '../tests';
 import { useDocumentPageTargets } from './useDocumentPageTargets';
@@ -11,7 +12,7 @@ import { useDocumentPageTargets } from './useDocumentPageTargets';
 const DOCUMENT_PAGE_ID = 345;
 
 describe('useDocumentPageTargets', () => {
-    const appBridge: AppBridgeBase = {} as AppBridgeBase;
+    const appBridge: AppBridgeBlock | AppBridgeTheme = {} as AppBridgeBlock | AppBridgeTheme;
 
     beforeEach(() => {
         window.emitter = mitt();

--- a/packages/app-bridge/src/react/useDocumentPageTargets.tsx
+++ b/packages/app-bridge/src/react/useDocumentPageTargets.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react';
 import { DocumentPageTargets } from '../types';
 
-import type { AppBridgeBase } from '../AppBridgeBase';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 
 export type UseDocumentPageTargetsReturnType = {
     documentPageTargets: Nullable<DocumentPageTargets>;
@@ -18,7 +19,10 @@ export type DocumentPageTargetEvent = {
     };
 };
 
-export const useDocumentPageTargets = (appBridge: AppBridgeBase, id: number): UseDocumentPageTargetsReturnType => {
+export const useDocumentPageTargets = (
+    appBridge: AppBridgeBlock | AppBridgeTheme,
+    id: number,
+): UseDocumentPageTargetsReturnType => {
     const [documentPageTargets, setDocumentPageTargets] = useState<Nullable<DocumentPageTargets>>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
 

--- a/packages/app-bridge/src/react/useDocumentPageTargets.tsx
+++ b/packages/app-bridge/src/react/useDocumentPageTargets.tsx
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useEffect, useState } from 'react';
-
-import { AppBridgeTheme } from '../AppBridgeTheme';
 import { DocumentPageTargets } from '../types';
+
+import type { AppBridgeBase } from '../AppBridgeBase';
 
 export type UseDocumentPageTargetsReturnType = {
     documentPageTargets: Nullable<DocumentPageTargets>;
@@ -18,7 +18,7 @@ export type DocumentPageTargetEvent = {
     };
 };
 
-export const useDocumentPageTargets = (appBridge: AppBridgeTheme, id: number): UseDocumentPageTargetsReturnType => {
+export const useDocumentPageTargets = (appBridge: AppBridgeBase, id: number): UseDocumentPageTargetsReturnType => {
     const [documentPageTargets, setDocumentPageTargets] = useState<Nullable<DocumentPageTargets>>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
 

--- a/packages/app-bridge/src/react/useDocumentPages.ts
+++ b/packages/app-bridge/src/react/useDocumentPages.ts
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useCallback, useEffect, useState } from 'react';
-
-import type { AppBridgeTheme } from '../AppBridgeTheme';
-import type { DocumentPage, EmitterAction } from '../types';
 import { DocumentPageTargetEvent } from './useDocumentPageTargets';
+
+import type { AppBridgeBase } from '../AppBridgeBase';
+import type { DocumentPage, EmitterAction } from '../types';
 
 export type DocumentPageEvent = {
     action: EmitterAction;
@@ -13,7 +13,7 @@ export type DocumentPageEvent = {
 
 const sortDocumentPages = (a: DocumentPage, b: DocumentPage) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocumentPages = (appBridge: AppBridgeTheme, documentId: number) => {
+export const useDocumentPages = (appBridge: AppBridgeBase, documentId: number) => {
     const [pages, setPages] = useState<Map<number, DocumentPage>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -77,7 +77,7 @@ export const useDocumentPages = (appBridge: AppBridgeTheme, documentId: number) 
     return { pages, getCategorizedPages, getUncategorizedPages, refetch, isLoading };
 };
 
-const fetchDocumentPages = async (appBridge: AppBridgeTheme, documentId: number) => {
+const fetchDocumentPages = async (appBridge: AppBridgeBase, documentId: number) => {
     const pages = await appBridge.getDocumentPagesByDocumentId(documentId);
 
     return new Map(pages.map((page) => [page.id, page]));

--- a/packages/app-bridge/src/react/useDocumentPages.ts
+++ b/packages/app-bridge/src/react/useDocumentPages.ts
@@ -3,8 +3,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { DocumentPageTargetEvent } from './useDocumentPageTargets';
 
-import type { AppBridgeBase } from '../AppBridgeBase';
 import type { DocumentPage, EmitterAction } from '../types';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 
 export type DocumentPageEvent = {
     action: EmitterAction;
@@ -13,7 +14,7 @@ export type DocumentPageEvent = {
 
 const sortDocumentPages = (a: DocumentPage, b: DocumentPage) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocumentPages = (appBridge: AppBridgeBase, documentId: number) => {
+export const useDocumentPages = (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {
     const [pages, setPages] = useState<Map<number, DocumentPage>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -77,7 +78,7 @@ export const useDocumentPages = (appBridge: AppBridgeBase, documentId: number) =
     return { pages, getCategorizedPages, getUncategorizedPages, refetch, isLoading };
 };
 
-const fetchDocumentPages = async (appBridge: AppBridgeBase, documentId: number) => {
+const fetchDocumentPages = async (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {
     const pages = await appBridge.getDocumentPagesByDocumentId(documentId);
 
     return new Map(pages.map((page) => [page.id, page]));

--- a/packages/app-bridge/src/react/useDocumentSection.ts
+++ b/packages/app-bridge/src/react/useDocumentSection.ts
@@ -2,10 +2,10 @@
 
 import { useEffect, useState } from 'react';
 
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import type { AppBridgeBase } from '../AppBridgeBase';
 import type { DocumentSection } from '../types';
 
-export const useDocumentSection = (appBridge: AppBridgeTheme, documentPageId: number) => {
+export const useDocumentSection = (appBridge: AppBridgeBase, documentPageId: number) => {
     const [documentSections, setDocumentSections] = useState<DocumentSection[]>([]);
 
     useEffect(() => {

--- a/packages/app-bridge/src/react/useDocumentSection.ts
+++ b/packages/app-bridge/src/react/useDocumentSection.ts
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from 'react';
 
-import type { AppBridgeBase } from '../AppBridgeBase';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 import type { DocumentSection } from '../types';
 
-export const useDocumentSection = (appBridge: AppBridgeBase, documentPageId: number) => {
+export const useDocumentSection = (appBridge: AppBridgeBlock | AppBridgeTheme, documentPageId: number) => {
     const [documentSections, setDocumentSections] = useState<DocumentSection[]>([]);
 
     useEffect(() => {

--- a/packages/app-bridge/src/react/useDocumentTargets.spec.ts
+++ b/packages/app-bridge/src/react/useDocumentTargets.spec.ts
@@ -4,7 +4,8 @@ import { act, renderHook } from '@testing-library/react';
 import mitt from 'mitt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { AppBridgeBase } from '../AppBridgeBase';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 
 import { DocumentTargetsDummy } from '../tests';
 import { useDocumentTargets } from './useDocumentTargets';
@@ -12,7 +13,7 @@ import { useDocumentTargets } from './useDocumentTargets';
 const DOCUMENT_ID = 92341;
 
 describe('useDocumentTargets', () => {
-    const appBridge: AppBridgeBase = {} as AppBridgeBase;
+    const appBridge: AppBridgeBlock | AppBridgeTheme = {} as AppBridgeBlock | AppBridgeTheme;
 
     beforeEach(() => {
         window.emitter = mitt();

--- a/packages/app-bridge/src/react/useDocumentTargets.spec.ts
+++ b/packages/app-bridge/src/react/useDocumentTargets.spec.ts
@@ -4,7 +4,7 @@ import { act, renderHook } from '@testing-library/react';
 import mitt from 'mitt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import type { AppBridgeBase } from '../AppBridgeBase';
 
 import { DocumentTargetsDummy } from '../tests';
 import { useDocumentTargets } from './useDocumentTargets';
@@ -12,7 +12,7 @@ import { useDocumentTargets } from './useDocumentTargets';
 const DOCUMENT_ID = 92341;
 
 describe('useDocumentTargets', () => {
-    const appBridge: AppBridgeTheme = {} as AppBridgeTheme;
+    const appBridge: AppBridgeBase = {} as AppBridgeBase;
 
     beforeEach(() => {
         window.emitter = mitt();

--- a/packages/app-bridge/src/react/useDocumentTargets.tsx
+++ b/packages/app-bridge/src/react/useDocumentTargets.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from 'react';
 
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 import type { DocumentTargets } from '../types';
-import type { AppBridgeBase } from '../AppBridgeBase';
 
 export type UseDocumentTargetsReturnType = {
     documentTargets: Nullable<DocumentTargets>;
@@ -18,7 +19,10 @@ type DocumentTargetEvent = {
     };
 };
 
-export const useDocumentTargets = (appBridge: AppBridgeBase, id: number): UseDocumentTargetsReturnType => {
+export const useDocumentTargets = (
+    appBridge: AppBridgeBlock | AppBridgeTheme,
+    id: number,
+): UseDocumentTargetsReturnType => {
     const [documentTargets, setDocumentTargets] = useState<Nullable<DocumentTargets>>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
 

--- a/packages/app-bridge/src/react/useDocumentTargets.tsx
+++ b/packages/app-bridge/src/react/useDocumentTargets.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState } from 'react';
 
-import { AppBridgeTheme } from '../AppBridgeTheme';
-import { DocumentTargets } from '../types';
+import type { DocumentTargets } from '../types';
+import type { AppBridgeBase } from '../AppBridgeBase';
 
 export type UseDocumentTargetsReturnType = {
     documentTargets: Nullable<DocumentTargets>;
@@ -18,7 +18,7 @@ type DocumentTargetEvent = {
     };
 };
 
-export const useDocumentTargets = (appBridge: AppBridgeTheme, id: number): UseDocumentTargetsReturnType => {
+export const useDocumentTargets = (appBridge: AppBridgeBase, id: number): UseDocumentTargetsReturnType => {
     const [documentTargets, setDocumentTargets] = useState<Nullable<DocumentTargets>>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
 

--- a/packages/app-bridge/src/react/useDocuments.ts
+++ b/packages/app-bridge/src/react/useDocuments.ts
@@ -2,12 +2,13 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { AppBridgeBase } from '../AppBridgeBase';
+import type { AppBridgeBlock } from '../AppBridgeBlock';
+import type { AppBridgeTheme } from '../AppBridgeTheme';
 import type { Document } from '../types';
 
 const sortDocuments = (a: Document, b: Document) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocuments = (appBridge: AppBridgeBase) => {
+export const useDocuments = (appBridge: AppBridgeBlock | AppBridgeTheme) => {
     const [documents, setDocuments] = useState<Map<number, Document>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -63,7 +64,7 @@ export const useDocuments = (appBridge: AppBridgeBase) => {
     return { documents, getUngroupedDocuments, getGroupedDocuments, refetch, isLoading };
 };
 
-const fetchDocuments = async (appBridge: AppBridgeBase) => {
+const fetchDocuments = async (appBridge: AppBridgeBlock | AppBridgeTheme) => {
     const [groups, documents] = await Promise.all([appBridge.getDocumentGroups(), appBridge.getAllDocuments()]);
 
     // TODO: has to be done like this as BE does not support returning documentGroupId in documents. Remove it once it is supported

--- a/packages/app-bridge/src/react/useDocuments.ts
+++ b/packages/app-bridge/src/react/useDocuments.ts
@@ -2,12 +2,12 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import type { AppBridgeBase } from '../AppBridgeBase';
 import type { Document } from '../types';
 
 const sortDocuments = (a: Document, b: Document) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocuments = (appBridge: AppBridgeTheme) => {
+export const useDocuments = (appBridge: AppBridgeBase) => {
     const [documents, setDocuments] = useState<Map<number, Document>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -63,7 +63,7 @@ export const useDocuments = (appBridge: AppBridgeTheme) => {
     return { documents, getUngroupedDocuments, getGroupedDocuments, refetch, isLoading };
 };
 
-const fetchDocuments = async (appBridge: AppBridgeTheme) => {
+const fetchDocuments = async (appBridge: AppBridgeBase) => {
     const [groups, documents] = await Promise.all([appBridge.getDocumentGroups(), appBridge.getAllDocuments()]);
 
     // TODO: has to be done like this as BE does not support returning documentGroupId in documents. Remove it once it is supported

--- a/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
@@ -140,5 +140,16 @@ export const getAppBridgeBlockStub = ({
         getTemplateById: stub<Parameters<AppBridgeBlock['getTemplateById']>>().resolves({} as Template),
         openAssetViewer: stub<Parameters<AppBridgeBlock['openAssetViewer']>>(),
         updateBlockSettings: stub<Parameters<AppBridgeBlock['updateBlockSettings']>>().resolves(),
+        getAllDocuments: stub<Parameters<AppBridgeBlock['getAllDocuments']>>().resolves(),
+        getDocumentGroups: stub<Parameters<AppBridgeBlock['getDocumentGroups']>>().resolves(),
+        getDocumentPagesByDocumentId: stub<Parameters<AppBridgeBlock['getDocumentPagesByDocumentId']>>().resolves(),
+        getDocumentCategoriesByDocumentId:
+            stub<Parameters<AppBridgeBlock['getDocumentCategoriesByDocumentId']>>().resolves(),
+        getUncategorizedPagesByDocumentId:
+            stub<Parameters<AppBridgeBlock['getUncategorizedPagesByDocumentId']>>().resolves(),
+        getDocumentSectionsByDocumentPageId:
+            stub<Parameters<AppBridgeBlock['getDocumentSectionsByDocumentPageId']>>().resolves(),
+        getDocumentTargets: stub<Parameters<AppBridgeBlock['getDocumentTargets']>>().resolves(),
+        getDocumentPageTargets: stub<Parameters<AppBridgeBlock['getDocumentPageTargets']>>().resolves(),
     };
 };


### PR DESCRIPTION
Adds AppBridgeBase interface to provide shared functionalities between `AppBridgeBlock` and `AppBridgeTheme`.
Implementation: https://github.com/Frontify/clarify/pull/14394/files