### PR TITLE
feat: add custom icon support in segmented controls/dropdown/input

### DIFF
--- a/.changeset/empty-rockets-sin.md
+++ b/.changeset/empty-rockets-sin.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": minor
+---
+
+Add support of custom icon in the settings sidebar

--- a/.changeset/mighty-waves-impress.md
+++ b/.changeset/mighty-waves-impress.md
@@ -1,0 +1,6 @@
+---
+"@frontify/guideline-blocks-settings": patch
+"@frontify/sidebar-settings": patch
+---
+
+Unpin dev dependencies

--- a/packages/guideline-blocks-settings/package.json
+++ b/packages/guideline-blocks-settings/package.json
@@ -23,17 +23,17 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@frontify/eslint-config-typescript": "0.15.7",
-        "@types/react": "18.0.35",
-        "@types/react-dom": "18.0.11",
-        "eslint": "8.38.0",
-        "eslint-plugin-notice": "0.9.10",
-        "prettier": "2.8.7",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "typescript": "5.0.4",
-        "vite": "4.2.1",
-        "vite-plugin-dts": "2.2.0"
+        "@frontify/eslint-config-typescript": "^0.15.7",
+        "@types/react": "^18.0.35",
+        "@types/react-dom": "^18.0.11",
+        "eslint": "^8.38.0",
+        "eslint-plugin-notice": "^0.9.10",
+        "prettier": "^2.8.7",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^5.0.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.2.0"
     },
     "dependencies": {
         "@frontify/app-bridge": "^3 || ^3.0.0-beta.61",

--- a/packages/sidebar-settings/package.json
+++ b/packages/sidebar-settings/package.json
@@ -25,16 +25,18 @@
         "test:watch": "vitest"
     },
     "devDependencies": {
-        "@frontify/eslint-config-typescript": "0.15.7",
-        "eslint": "8.38.0",
-        "eslint-plugin-notice": "0.9.10",
-        "prettier": "2.8.7",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "typescript": "5.0.4",
-        "vite": "4.2.1",
-        "vite-plugin-dts": "2.2.0",
-        "vitest": "0.30.1"
+        "@frontify/eslint-config-typescript": "^0.15.7",
+        "@types/react": "^18.0.35",
+        "@types/react-dom": "^18.0.11",
+        "eslint": "^8.38.0",
+        "eslint-plugin-notice": "^0.9.10",
+        "prettier": "^2.8.7",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^5.0.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.2.0",
+        "vitest": "^0.30.1"
     },
     "dependencies": {
         "@frontify/app-bridge": "^3 || ^3.0.0-beta.61",

--- a/packages/sidebar-settings/src/blocks/choices.ts
+++ b/packages/sidebar-settings/src/blocks/choices.ts
@@ -1,5 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ReactElement } from 'react';
+
 import type { IconEnum } from '.';
 import type { BaseBlock, ValueOrPromisedValue } from './base';
 
@@ -14,7 +16,7 @@ export type Choice = {
      *
      * The full list of icons can be found here {@link https://github.com/Frontify/fondue/blob/beta/src/foundation/Icon/IconEnum.ts}
      */
-    icon?: IconEnum | keyof typeof IconEnum;
+    icon?: IconEnum | keyof typeof IconEnum | ReactElement;
 
     /**
      * The value of the item.

--- a/packages/sidebar-settings/src/blocks/input.ts
+++ b/packages/sidebar-settings/src/blocks/input.ts
@@ -1,5 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ReactElement } from 'react';
+
 import type { Rule } from '../helpers';
 import type { BaseBlock } from './base';
 import type { IconEnum, TextInputType } from '.';
@@ -15,7 +17,7 @@ export type InputBlock<AppBridge> = {
      *
      * The full list of icons can be found here {@link https://github.com/Frontify/fondue/blob/beta/src/foundation/Icon/IconEnum.ts}
      */
-    icon?: IconEnum | keyof typeof IconEnum;
+    icon?: IconEnum | keyof typeof IconEnum | ReactElement;
 
     /**
      * The type of input (text, number, etc.).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,34 +243,40 @@ importers:
         version: 12.0.0-beta-16(@types/react@18.0.35)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@frontify/eslint-config-typescript':
-        specifier: 0.15.7
+        specifier: ^0.15.7
         version: 0.15.7(eslint@8.38.0)(prettier@2.8.7)(typescript@5.0.4)
+      '@types/react':
+        specifier: ^18.0.35
+        version: 18.0.35
+      '@types/react-dom':
+        specifier: ^18.0.11
+        version: 18.0.11
       eslint:
-        specifier: 8.38.0
+        specifier: ^8.38.0
         version: 8.38.0
       eslint-plugin-notice:
-        specifier: 0.9.10
+        specifier: ^0.9.10
         version: 0.9.10(eslint@8.38.0)
       prettier:
-        specifier: 2.8.7
+        specifier: ^2.8.7
         version: 2.8.7
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: 5.0.4
+        specifier: ^5.0.4
         version: 5.0.4
       vite:
-        specifier: 4.2.1
+        specifier: ^4.2.1
         version: 4.2.1(@types/node@18.15.11)
       vite-plugin-dts:
-        specifier: 2.2.0
+        specifier: ^2.2.0
         version: 2.2.0(vite@4.2.1)
       vitest:
-        specifier: 0.30.1
+        specifier: ^0.30.1
         version: 0.30.1(@vitest/ui@0.30.1)(happy-dom@9.3.0)
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,37 +200,37 @@ importers:
         version: link:../sidebar-settings
     devDependencies:
       '@frontify/eslint-config-typescript':
-        specifier: 0.15.7
+        specifier: ^0.15.7
         version: 0.15.7(eslint@8.38.0)(prettier@2.8.7)(typescript@5.0.4)
       '@types/react':
-        specifier: 18.0.35
+        specifier: ^18.0.35
         version: 18.0.35
       '@types/react-dom':
-        specifier: 18.0.11
+        specifier: ^18.0.11
         version: 18.0.11
       eslint:
-        specifier: 8.38.0
+        specifier: ^8.38.0
         version: 8.38.0
       eslint-plugin-notice:
-        specifier: 0.9.10
+        specifier: ^0.9.10
         version: 0.9.10(eslint@8.38.0)
       prettier:
-        specifier: 2.8.7
+        specifier: ^2.8.7
         version: 2.8.7
       react:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: 5.0.4
+        specifier: ^5.0.4
         version: 5.0.4
       vite:
-        specifier: 4.2.1
+        specifier: ^4.2.1
         version: 4.2.1(@types/node@18.15.11)
       vite-plugin-dts:
-        specifier: 2.2.0
+        specifier: ^2.2.0
         version: 2.2.0(vite@4.2.1)
 
   packages/sidebar-settings:


### PR DESCRIPTION
Designers uses custom icons in the sidebar for themes... so we now need to support it 😬 
Remove the `devDependencies` strict version as it is only used in dev and pnpm will optimize the installation