### PR TITLE
refactor!: rename `document` to `documentPage` and add different methods

### DIFF
--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -41,11 +41,11 @@ export interface AppBridgeTheme extends AppBridgeBase {
 
     getDocumentPageTemplateSettings<Settings>(documentPageId: number): Promise<Settings>;
 
-    updateDocumentPageTemplateSettings(settings: Record<string, unknown>): Promise<void>;
+    updateDocumentPageTemplateSettings(documentPageId: number, settings: Record<string, unknown>): Promise<void>;
 
-    getLibraryTemplateSettings<Settings>(documentId: number): Promise<Settings>;
+    getLibraryPageTemplateSettings<Settings>(documentId: number): Promise<Settings>;
 
-    updateLibraryTemplateSettings(settings: Record<string, unknown>): Promise<void>;
+    updateLibraryPageTemplateSettings(documentId: number, settings: Record<string, unknown>): Promise<void>;
 
     createLink(link: DocumentLinkCreate): Promise<Document>;
 

--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -35,11 +35,17 @@ export interface AppBridgeTheme extends AppBridgeBase {
 
     openNavigationManager(): void;
 
-    getCoverPageSettings<Settings>(): Promise<Settings>;
+    getCoverPageTemplateSettings<Settings>(): Promise<Settings>;
 
-    updateCoverPageSettings(settings: Record<string, unknown>): Promise<void>;
+    updateCoverPageTemplateSettings(settings: Record<string, unknown>): Promise<void>;
 
-    getDocumentSettings<Settings>(documentId: number): Promise<Settings>;
+    getDocumentPageTemplateSettings<Settings>(documentPageId: number): Promise<Settings>;
+
+    updateDocumentPageTemplateSettings(settings: Record<string, unknown>): Promise<void>;
+
+    getLibraryTemplateSettings<Settings>(documentId: number): Promise<Settings>;
+
+    updateLibraryTemplateSettings(settings: Record<string, unknown>): Promise<void>;
 
     createLink(link: DocumentLinkCreate): Promise<Document>;
 

--- a/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
@@ -21,7 +21,7 @@ describe('usePageTemplateSettings', () => {
         documentId?: Parameters<typeof usePageTemplateSettings>[2],
     ) => {
         const appBridgeStub = getAppBridgeThemeStub({
-            templateSettings,
+            pageTemplateSettings: templateSettings,
         });
 
         const { result } = renderHook(() => usePageTemplateSettings(appBridgeStub, template, documentId));

--- a/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
@@ -16,12 +16,12 @@ describe('usePageTemplateSettings', () => {
     });
 
     const loadUsePageTemplateSettings = async (
-        templateSettings: Record<string, unknown>,
+        pageTemplateSettings: Record<string, unknown>,
         template: Parameters<typeof usePageTemplateSettings>[1],
         documentId?: Parameters<typeof usePageTemplateSettings>[2],
     ) => {
         const appBridgeStub = getAppBridgeThemeStub({
-            pageTemplateSettings: templateSettings,
+            pageTemplateSettings,
         });
 
         const { result } = renderHook(() => usePageTemplateSettings(appBridgeStub, template, documentId));

--- a/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
@@ -16,12 +16,12 @@ describe('usePageTemplateSettings', () => {
     });
 
     const loadUsePageTemplateSettings = async (
-        pageSettings: Record<string, unknown>,
+        templateSettings: Record<string, unknown>,
         template: Parameters<typeof usePageTemplateSettings>[1],
         documentId?: Parameters<typeof usePageTemplateSettings>[2],
     ) => {
         const appBridgeStub = getAppBridgeThemeStub({
-            pageSettings,
+            templateSettings,
         });
 
         const { result } = renderHook(() => usePageTemplateSettings(appBridgeStub, template, documentId));

--- a/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
@@ -59,7 +59,7 @@ describe('usePageTemplateSettings', () => {
     });
 
     it('returns the page settings for document page', async () => {
-        const { result } = await loadUsePageTemplateSettings(PAGE_SETTINGS, 'document', DOCUMENT_ID);
+        const { result } = await loadUsePageTemplateSettings(PAGE_SETTINGS, 'documentPage', DOCUMENT_ID);
 
         expect(result.current.isLoading).toEqual(true);
 
@@ -70,7 +70,7 @@ describe('usePageTemplateSettings', () => {
     });
 
     it('returns `null` for document page if no document id passed', async () => {
-        const { result } = await loadUsePageTemplateSettings(PAGE_SETTINGS, 'document');
+        const { result } = await loadUsePageTemplateSettings(PAGE_SETTINGS, 'documentPage');
 
         expect(result.current.isLoading).toEqual(false);
 

--- a/packages/app-bridge/src/react/usePageTemplateSettings.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.ts
@@ -7,7 +7,7 @@ import type { EmitterEvents } from '../types';
 
 export const usePageTemplateSettings = <T = Record<string, unknown>>(
     appBridge: AppBridgeTheme,
-    template: 'cover' | 'document' | 'library',
+    template: 'cover' | 'documentPage' | 'library',
     documentId?: number,
 ) => {
     const [pageTemplateSettings, setPageTemplateSettings] = useState<Nullable<T>>(null);
@@ -22,20 +22,20 @@ export const usePageTemplateSettings = <T = Record<string, unknown>>(
             setIsLoading(true);
 
             if (template === 'cover') {
-                const coverPageSettings = await appBridge.getCoverPageSettings<T>();
+                const coverPageSettings = await appBridge.getCoverPageTemplateSettings<T>();
                 setPageTemplateSettings(coverPageSettings);
-            } else if (template === 'document') {
+            } else if (template === 'documentPage') {
                 if (documentId === undefined) {
                     console.error('Document ID is required for document page template settings');
                 } else {
-                    const documentSettings = await appBridge.getDocumentSettings<T>(documentId);
+                    const documentSettings = await appBridge.getDocumentPageTemplateSettings<T>(documentId);
                     setPageTemplateSettings(documentSettings);
                 }
             } else if (template === 'library') {
                 if (documentId === undefined) {
                     console.error('Document ID is required for library template settings');
                 } else {
-                    const librarySettings = await appBridge.getDocumentSettings<T>(documentId);
+                    const librarySettings = await appBridge.getLibraryTemplateSettings<T>(documentId);
                     setPageTemplateSettings(librarySettings);
                 }
             }
@@ -55,17 +55,21 @@ export const usePageTemplateSettings = <T = Record<string, unknown>>(
     const updatePageTemplateSettings = async (pageTemplateSettingsUpdate: Partial<T>) => {
         try {
             if (template === 'cover') {
-                await appBridge.updateCoverPageSettings(pageTemplateSettingsUpdate);
-            } else if (template === 'document') {
+                await appBridge.updateCoverPageTemplateSettings(pageTemplateSettingsUpdate);
+            } else if (template === 'documentPage') {
                 if (documentId === undefined) {
                     console.error('Document ID is required for document page template settings');
                     return;
                 }
+
+                await appBridge.updateDocumentPageTemplateSettings(pageTemplateSettingsUpdate);
             } else if (template === 'library') {
                 if (documentId === undefined) {
                     console.error('Document ID is required for library template settings');
                     return;
                 }
+
+                await appBridge.updateLibraryTemplateSettings(pageTemplateSettingsUpdate);
             }
 
             window.emitter.emit('AppBridge:PageTemplateSettingsUpdated', {

--- a/packages/app-bridge/src/react/usePageTemplateSettings.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.ts
@@ -35,7 +35,7 @@ export const usePageTemplateSettings = <T = Record<string, unknown>>(
                 if (documentId === undefined) {
                     console.error('Document ID is required for library template settings');
                 } else {
-                    const librarySettings = await appBridge.getLibraryTemplateSettings<T>(documentId);
+                    const librarySettings = await appBridge.getLibraryPageTemplateSettings<T>(documentId);
                     setPageTemplateSettings(librarySettings);
                 }
             }
@@ -62,14 +62,14 @@ export const usePageTemplateSettings = <T = Record<string, unknown>>(
                     return;
                 }
 
-                await appBridge.updateDocumentPageTemplateSettings(pageTemplateSettingsUpdate);
+                await appBridge.updateDocumentPageTemplateSettings(documentId, pageTemplateSettingsUpdate);
             } else if (template === 'library') {
                 if (documentId === undefined) {
                     console.error('Document ID is required for library template settings');
                     return;
                 }
 
-                await appBridge.updateLibraryTemplateSettings(pageTemplateSettingsUpdate);
+                await appBridge.updateLibraryPageTemplateSettings(documentId, pageTemplateSettingsUpdate);
             }
 
             window.emitter.emit('AppBridge:PageTemplateSettingsUpdated', {

--- a/packages/app-bridge/src/react/usePageTemplateSettings.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.ts
@@ -8,7 +8,7 @@ import type { EmitterEvents } from '../types';
 export const usePageTemplateSettings = <T = Record<string, unknown>>(
     appBridge: AppBridgeTheme,
     template: 'cover' | 'documentPage' | 'library',
-    documentId?: number,
+    documentOrDocumentPageId?: number,
 ) => {
     const [pageTemplateSettings, setPageTemplateSettings] = useState<Nullable<T>>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -25,17 +25,19 @@ export const usePageTemplateSettings = <T = Record<string, unknown>>(
                 const coverPageSettings = await appBridge.getCoverPageTemplateSettings<T>();
                 setPageTemplateSettings(coverPageSettings);
             } else if (template === 'documentPage') {
-                if (documentId === undefined) {
+                if (documentOrDocumentPageId === undefined) {
                     console.error('Document ID is required for document page template settings');
                 } else {
-                    const documentSettings = await appBridge.getDocumentPageTemplateSettings<T>(documentId);
+                    const documentSettings = await appBridge.getDocumentPageTemplateSettings<T>(
+                        documentOrDocumentPageId,
+                    );
                     setPageTemplateSettings(documentSettings);
                 }
             } else if (template === 'library') {
-                if (documentId === undefined) {
+                if (documentOrDocumentPageId === undefined) {
                     console.error('Document ID is required for library template settings');
                 } else {
-                    const librarySettings = await appBridge.getLibraryPageTemplateSettings<T>(documentId);
+                    const librarySettings = await appBridge.getLibraryPageTemplateSettings<T>(documentOrDocumentPageId);
                     setPageTemplateSettings(librarySettings);
                 }
             }
@@ -50,26 +52,29 @@ export const usePageTemplateSettings = <T = Record<string, unknown>>(
         return () => {
             window.emitter.off('AppBridge:PageTemplateSettingsUpdated', updateBlockSettingsFromEvent);
         };
-    }, [appBridge, documentId, template]);
+    }, [appBridge, documentOrDocumentPageId, template]);
 
     const updatePageTemplateSettings = async (pageTemplateSettingsUpdate: Partial<T>) => {
         try {
             if (template === 'cover') {
                 await appBridge.updateCoverPageTemplateSettings(pageTemplateSettingsUpdate);
             } else if (template === 'documentPage') {
-                if (documentId === undefined) {
+                if (documentOrDocumentPageId === undefined) {
                     console.error('Document ID is required for document page template settings');
                     return;
                 }
 
-                await appBridge.updateDocumentPageTemplateSettings(documentId, pageTemplateSettingsUpdate);
+                await appBridge.updateDocumentPageTemplateSettings(
+                    documentOrDocumentPageId,
+                    pageTemplateSettingsUpdate,
+                );
             } else if (template === 'library') {
-                if (documentId === undefined) {
+                if (documentOrDocumentPageId === undefined) {
                     console.error('Document ID is required for library template settings');
                     return;
                 }
 
-                await appBridge.updateLibraryPageTemplateSettings(documentId, pageTemplateSettingsUpdate);
+                await appBridge.updateLibraryPageTemplateSettings(documentOrDocumentPageId, pageTemplateSettingsUpdate);
             }
 
             window.emitter.emit('AppBridge:PageTemplateSettingsUpdated', {

--- a/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
@@ -62,7 +62,7 @@ export type getAppBridgeThemeStubProps = {
     brandId?: number;
     portalId?: number;
     projectId?: number;
-    templateSettings?: Record<string, unknown>;
+    pageTemplateSettings?: Record<string, unknown>;
     language?: string;
 };
 
@@ -71,12 +71,12 @@ export const getAppBridgeThemeStub = ({
     brandId = BRAND_ID,
     portalId = PORTAL_ID,
     projectId = PROJECT_ID,
-    templateSettings = {},
+    pageTemplateSettings = {},
     language = 'en',
 }: getAppBridgeThemeStubProps = {}): SinonStubbedInstance<AppBridgeTheme> => {
     window.emitter = spy(mitt()) as unknown as Emitter<EmitterEvents>;
 
-    let localTemplateSettings = templateSettings;
+    let localPageTemplateSettings = pageTemplateSettings;
 
     return {
         getPortalId: stub<Parameters<AppBridgeTheme['getPortalId']>>().returns(portalId),
@@ -156,11 +156,11 @@ export const getAppBridgeThemeStub = ({
             DocumentPageTargetsDummy.with(DOCUMENT_PAGE_ID_1),
         ),
         getCoverPageTemplateSettings:
-            stub<Parameters<AppBridgeTheme['getCoverPageTemplateSettings']>>().resolves(localTemplateSettings),
+            stub<Parameters<AppBridgeTheme['getCoverPageTemplateSettings']>>().resolves(localPageTemplateSettings),
         getDocumentPageTemplateSettings:
-            stub<Parameters<AppBridgeTheme['getDocumentPageTemplateSettings']>>().resolves(localTemplateSettings),
-        getLibraryTemplateSettings:
-            stub<Parameters<AppBridgeTheme['getLibraryTemplateSettings']>>().resolves(localTemplateSettings),
+            stub<Parameters<AppBridgeTheme['getDocumentPageTemplateSettings']>>().resolves(localPageTemplateSettings),
+        getLibraryPageTemplateSettings:
+            stub<Parameters<AppBridgeTheme['getLibraryPageTemplateSettings']>>().resolves(localPageTemplateSettings),
         createLink: stub<Parameters<AppBridgeTheme['createLink']>>().resolves(DocumentDummy.with(1)),
         createLibrary: stub<Parameters<AppBridgeTheme['createLibrary']>>().resolves(DocumentDummy.with(1)),
         createStandardDocument: stub<Parameters<AppBridgeTheme['createStandardDocument']>>().resolves(
@@ -199,19 +199,19 @@ export const getAppBridgeThemeStub = ({
         ),
         updateCoverPageTemplateSettings: stub<
             Parameters<AppBridgeTheme['updateCoverPageTemplateSettings']>
-        >().callsFake(async (templateSettingsUpdate) => {
-            localTemplateSettings = mergeDeep(localTemplateSettings, templateSettingsUpdate);
+        >().callsFake(async (pageTemplateSettingsUpdate) => {
+            localPageTemplateSettings = mergeDeep(localPageTemplateSettings, pageTemplateSettingsUpdate);
         }),
         updateDocumentPageTemplateSettings: stub<
             Parameters<AppBridgeTheme['updateDocumentPageTemplateSettings']>
-        >().callsFake(async (templateSettingsUpdate) => {
-            localTemplateSettings = mergeDeep(localTemplateSettings, templateSettingsUpdate);
+        >().callsFake(async (pageTemplateSettingsUpdate) => {
+            localPageTemplateSettings = mergeDeep(localPageTemplateSettings, pageTemplateSettingsUpdate);
         }),
-        updateLibraryTemplateSettings: stub<Parameters<AppBridgeTheme['updateLibraryTemplateSettings']>>().callsFake(
-            async (templateSettingsUpdate) => {
-                localTemplateSettings = mergeDeep(localTemplateSettings, templateSettingsUpdate);
-            },
-        ),
+        updateLibraryPageTemplateSettings: stub<
+            Parameters<AppBridgeTheme['updateLibraryPageTemplateSettings']>
+        >().callsFake(async (pageTemplateSettingsUpdate) => {
+            localPageTemplateSettings = mergeDeep(localPageTemplateSettings, pageTemplateSettingsUpdate);
+        }),
         deleteCoverPage: stub<Parameters<AppBridgeTheme['deleteCoverPage']>>().resolves(),
         deleteDocumentCategory: stub<Parameters<AppBridgeTheme['deleteDocumentCategory']>>().resolves(),
         deleteDocumentGroup: stub<Parameters<AppBridgeTheme['deleteDocumentGroup']>>().resolves(),

--- a/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
@@ -62,7 +62,7 @@ export type getAppBridgeThemeStubProps = {
     brandId?: number;
     portalId?: number;
     projectId?: number;
-    pageSettings?: Record<string, unknown>;
+    templateSettings?: Record<string, unknown>;
     language?: string;
 };
 
@@ -71,12 +71,12 @@ export const getAppBridgeThemeStub = ({
     brandId = BRAND_ID,
     portalId = PORTAL_ID,
     projectId = PROJECT_ID,
-    pageSettings = {},
+    templateSettings = {},
     language = 'en',
 }: getAppBridgeThemeStubProps = {}): SinonStubbedInstance<AppBridgeTheme> => {
     window.emitter = spy(mitt()) as unknown as Emitter<EmitterEvents>;
 
-    let localPageSettings = pageSettings;
+    let localTemplateSettings = templateSettings;
 
     return {
         getPortalId: stub<Parameters<AppBridgeTheme['getPortalId']>>().returns(portalId),
@@ -156,11 +156,11 @@ export const getAppBridgeThemeStub = ({
             DocumentPageTargetsDummy.with(DOCUMENT_PAGE_ID_1),
         ),
         getCoverPageTemplateSettings:
-            stub<Parameters<AppBridgeTheme['getCoverPageTemplateSettings']>>().resolves(localPageSettings),
+            stub<Parameters<AppBridgeTheme['getCoverPageTemplateSettings']>>().resolves(localTemplateSettings),
         getDocumentPageTemplateSettings:
-            stub<Parameters<AppBridgeTheme['getDocumentPageTemplateSettings']>>().resolves(localPageSettings),
+            stub<Parameters<AppBridgeTheme['getDocumentPageTemplateSettings']>>().resolves(localTemplateSettings),
         getLibraryTemplateSettings:
-            stub<Parameters<AppBridgeTheme['getLibraryTemplateSettings']>>().resolves(localPageSettings),
+            stub<Parameters<AppBridgeTheme['getLibraryTemplateSettings']>>().resolves(localTemplateSettings),
         createLink: stub<Parameters<AppBridgeTheme['createLink']>>().resolves(DocumentDummy.with(1)),
         createLibrary: stub<Parameters<AppBridgeTheme['createLibrary']>>().resolves(DocumentDummy.with(1)),
         createStandardDocument: stub<Parameters<AppBridgeTheme['createStandardDocument']>>().resolves(
@@ -199,17 +199,17 @@ export const getAppBridgeThemeStub = ({
         ),
         updateCoverPageTemplateSettings: stub<
             Parameters<AppBridgeTheme['updateCoverPageTemplateSettings']>
-        >().callsFake(async (pageSettingsUpdate) => {
-            localPageSettings = mergeDeep(localPageSettings, pageSettingsUpdate);
+        >().callsFake(async (templateSettingsUpdate) => {
+            localTemplateSettings = mergeDeep(localTemplateSettings, templateSettingsUpdate);
         }),
         updateDocumentPageTemplateSettings: stub<
             Parameters<AppBridgeTheme['updateDocumentPageTemplateSettings']>
-        >().callsFake(async (pageSettingsUpdate) => {
-            localPageSettings = mergeDeep(localPageSettings, pageSettingsUpdate);
+        >().callsFake(async (templateSettingsUpdate) => {
+            localTemplateSettings = mergeDeep(localTemplateSettings, templateSettingsUpdate);
         }),
         updateLibraryTemplateSettings: stub<Parameters<AppBridgeTheme['updateLibraryTemplateSettings']>>().callsFake(
-            async (pageSettingsUpdate) => {
-                localPageSettings = mergeDeep(localPageSettings, pageSettingsUpdate);
+            async (templateSettingsUpdate) => {
+                localTemplateSettings = mergeDeep(localTemplateSettings, templateSettingsUpdate);
             },
         ),
         deleteCoverPage: stub<Parameters<AppBridgeTheme['deleteCoverPage']>>().resolves(),

--- a/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
@@ -155,8 +155,12 @@ export const getAppBridgeThemeStub = ({
         getDocumentPageTargets: stub<Parameters<AppBridgeTheme['getDocumentPageTargets']>>().resolves(
             DocumentPageTargetsDummy.with(DOCUMENT_PAGE_ID_1),
         ),
-        getCoverPageSettings: stub<Parameters<AppBridgeTheme['getCoverPageSettings']>>().resolves(localPageSettings),
-        getDocumentSettings: stub<Parameters<AppBridgeTheme['getDocumentSettings']>>().resolves(localPageSettings),
+        getCoverPageTemplateSettings:
+            stub<Parameters<AppBridgeTheme['getCoverPageTemplateSettings']>>().resolves(localPageSettings),
+        getDocumentPageTemplateSettings:
+            stub<Parameters<AppBridgeTheme['getDocumentPageTemplateSettings']>>().resolves(localPageSettings),
+        getLibraryTemplateSettings:
+            stub<Parameters<AppBridgeTheme['getLibraryTemplateSettings']>>().resolves(localPageSettings),
         createLink: stub<Parameters<AppBridgeTheme['createLink']>>().resolves(DocumentDummy.with(1)),
         createLibrary: stub<Parameters<AppBridgeTheme['createLibrary']>>().resolves(DocumentDummy.with(1)),
         createStandardDocument: stub<Parameters<AppBridgeTheme['createStandardDocument']>>().resolves(
@@ -193,7 +197,17 @@ export const getAppBridgeThemeStub = ({
         updateBrandportalLink: stub<Parameters<AppBridgeTheme['updateBrandportalLink']>>().resolves(
             BrandportalLinkDummy.with(),
         ),
-        updateCoverPageSettings: stub<Parameters<AppBridgeTheme['updateCoverPageSettings']>>().callsFake(
+        updateCoverPageTemplateSettings: stub<
+            Parameters<AppBridgeTheme['updateCoverPageTemplateSettings']>
+        >().callsFake(async (pageSettingsUpdate) => {
+            localPageSettings = mergeDeep(localPageSettings, pageSettingsUpdate);
+        }),
+        updateDocumentPageTemplateSettings: stub<
+            Parameters<AppBridgeTheme['updateDocumentPageTemplateSettings']>
+        >().callsFake(async (pageSettingsUpdate) => {
+            localPageSettings = mergeDeep(localPageSettings, pageSettingsUpdate);
+        }),
+        updateLibraryTemplateSettings: stub<Parameters<AppBridgeTheme['updateLibraryTemplateSettings']>>().callsFake(
             async (pageSettingsUpdate) => {
                 localPageSettings = mergeDeep(localPageSettings, pageSettingsUpdate);
             },


### PR DESCRIPTION
Renamed template `document` to `documentPage` (we moved the template settings on document page level)

Added:
- `updateDocumentPageTemplateSettings`
- `getLibraryPageTemplateSettings`
- `updateLibraryPageTemplateSettings`

Renamed:
- `getCoverPageSettings` to `getCoverPageTemplateSettings`
- `updateCoverPageSettings` to `updateCoverPageTemplateSettings`
- `getDocumentSettings` to `getDocumentPageTemplateSettings`

Make usage of the methods in the `usePageTemplateSettings` hook