### PR TITLE
fix: incorrect document and document page targets type

### DIFF
--- a/packages/app-bridge/src/types/Document.ts
+++ b/packages/app-bridge/src/types/Document.ts
@@ -100,7 +100,7 @@ export type DocumentApi = Simplify<
             change_comment: Nullable<string>;
             change_comment_by: Nullable<string>;
             change_title: Nullable<string>;
-            targets: Nullable<SingleTargetApi[]>;
+            targets: Nullable<SingleTargetApi['target'][]>;
             token: Nullable<string>;
             permanent_link: string;
         } & (DocumentApiAsLink | DocumentApiAsNoneLink)

--- a/packages/app-bridge/src/types/DocumentPage.ts
+++ b/packages/app-bridge/src/types/DocumentPage.ts
@@ -43,7 +43,7 @@ export type DocumentPageApi = {
     change_comment: Nullable<string>;
     change_comment_by: Nullable<number>;
     change_title: Nullable<string>;
-    targets: Nullable<SingleTargetApi[]>;
+    targets: Nullable<SingleTargetApi['target'][]>;
     category?: Nullable<Record<string, unknown>>;
     parent_document?: Nullable<Record<string, unknown>>;
     parent_portal?: Nullable<Record<string, unknown>>;


### PR DESCRIPTION
Document and DocumentPage targets come like: 
```
targets: [{
        account_id: number;
        asset_ids: unknown[];
        created: string;
        creator: number;
        description: string;
        group_ids: unknown[];
        id: number;
        modified: Nullable<unknown>;
        modifier: Nullable<unknown>;
        name: string;
        sort: number;
        total_groups: Nullable<unknown>;
        total_links: Nullable<unknown>;
        total_users: Nullable<unknown>;
        user_ids: unknown[];
    }]
```
and not like:
```
targets:[{
    checked: boolean;
    disabled: boolean;
    indeterminate: boolean;
    label: string;
    target: {
        account_id: number;
        asset_ids: unknown[];
        created: string;
        creator: number;
        description: string;
        group_ids: unknown[];
        id: number;
        modified: Nullable<unknown>;
        modifier: Nullable<unknown>;
        name: string;
        sort: number;
        total_groups: Nullable<unknown>;
        total_links: Nullable<unknown>;
        total_users: Nullable<unknown>;
        user_ids: unknown[];
    };
    value: number;
}]
```