### PR TITLE
Chore/remove depreacted document group property

### DIFF
--- a/packages/app-bridge/src/types/DocumentGroup.ts
+++ b/packages/app-bridge/src/types/DocumentGroup.ts
@@ -15,7 +15,7 @@ export type DocumentGroupApi = {
     valid_to: Nullable<string>;
     project_id: number;
     portal_id: number;
-    number_of_documents: Nullable<DocumentApi[]>;
+    number_of_documents: Nullable<number>;
 };
 
 export type DocumentGroup = Merge<CamelCasedPropertiesDeep<DocumentGroupApi>, { documents: number[] }>;

--- a/packages/app-bridge/src/types/DocumentGroup.ts
+++ b/packages/app-bridge/src/types/DocumentGroup.ts
@@ -15,7 +15,7 @@ export type DocumentGroupApi = {
     valid_to: Nullable<string>;
     project_id: number;
     portal_id: number;
-    documents: Nullable<DocumentApi[]>;
+    number_of_documents: Nullable<DocumentApi[]>;
 };
 
 export type DocumentGroup = Merge<CamelCasedPropertiesDeep<DocumentGroupApi>, { documents: number[] }>;


### PR DESCRIPTION
This PR changes the following types:

DocumentGroupApi:

- removed `documents` because it should not be used anymore
- added `number_of_documents`