### PR TITLE
feat: add `enabled` to hooks

### DIFF
--- a/packages/app-bridge/src/react/useBrandportalLink.spec.ts
+++ b/packages/app-bridge/src/react/useBrandportalLink.spec.ts
@@ -1,36 +1,23 @@
+// @vitest-environment happy-dom
+
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import mitt, { Emitter } from 'mitt';
 import { act, renderHook } from '@testing-library/react';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import type { EmitterEvents } from '../types';
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useBrandportalLink } from './useBrandportalLink';
-import { BrandportalLinkDummy } from '../tests';
+import { BrandportalLinkDummy, getAppBridgeThemeStub } from '../tests';
 
 describe('useBrandportalLink', () => {
-    const appBridge: AppBridgeTheme = {} as AppBridgeTheme;
-    let emitter: Emitter<EmitterEvents>;
-
-    beforeAll(() => {
-        window.emitter = mitt();
-    });
-
-    beforeEach(() => {
-        emitter = mitt();
-        vi.spyOn(window, 'emitter', 'get').mockReturnValue(emitter);
-    });
-
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
     it('should return the brandportal link from appBridge', async () => {
-        const brandportalLink = BrandportalLinkDummy.with();
+        const appBridge = getAppBridgeThemeStub();
 
-        appBridge.getBrandportalLink = vi.fn().mockResolvedValue(brandportalLink);
+        const brandportalLink = BrandportalLinkDummy.with();
+        appBridge.getBrandportalLink.resolves(brandportalLink);
 
         const { result } = renderHook(() => useBrandportalLink(appBridge));
 
@@ -44,6 +31,7 @@ describe('useBrandportalLink', () => {
     });
 
     it('should update the brandportal link when an event is emitted', () => {
+        const appBridge = getAppBridgeThemeStub();
         const { result } = renderHook(() => useBrandportalLink(appBridge));
 
         const updatedBrandportalLink = BrandportalLinkDummy.with({
@@ -61,6 +49,7 @@ describe('useBrandportalLink', () => {
     });
 
     it('should not update the brandportal link when an event with an invalid action is emitted', () => {
+        const appBridge = getAppBridgeThemeStub();
         const { result } = renderHook(() => useBrandportalLink(appBridge));
 
         result.current.brandportalLink = BrandportalLinkDummy.with();
@@ -74,5 +63,21 @@ describe('useBrandportalLink', () => {
         });
 
         expect(result.current.brandportalLink).toEqual(BrandportalLinkDummy.with());
+    });
+
+    it('should start fetching only when it is enabled', () => {
+        const appBridge = getAppBridgeThemeStub();
+        const spy = vi.spyOn(appBridge, 'getBrandportalLink');
+
+        let enabled = false;
+
+        const { rerender } = renderHook(() => useBrandportalLink(appBridge, { enabled }));
+
+        expect(spy).not.toBeCalled();
+
+        enabled = true;
+        rerender();
+
+        expect(spy).toBeCalled();
     });
 });

--- a/packages/app-bridge/src/react/useBrandportalLink.spec.ts
+++ b/packages/app-bridge/src/react/useBrandportalLink.spec.ts
@@ -80,4 +80,15 @@ describe('useBrandportalLink', () => {
 
         expect(spy).toBeCalled();
     });
+
+    it('should unregister when unmounted', () => {
+        const appBridge = getAppBridgeThemeStub();
+        const spy = vi.spyOn(window.emitter, 'off');
+
+        const { unmount } = renderHook(() => useBrandportalLink(appBridge));
+
+        unmount();
+
+        expect(spy).toBeCalledWith('AppBridge:GuidelineBrandportalLinkAction', expect.any(Function));
+    });
 });

--- a/packages/app-bridge/src/react/useBrandportalLink.ts
+++ b/packages/app-bridge/src/react/useBrandportalLink.ts
@@ -13,18 +13,32 @@ const defaultState: BrandportalLink = {
 
 export type UseBrandportalLinkReturnType = {
     brandportalLink: Nullable<BrandportalLink>;
+    isLoading: boolean;
 };
 
-export const useBrandportalLink = (appBridge: AppBridgeTheme): UseBrandportalLinkReturnType => {
+type Options = {
+    /**
+     * Whether it should fetch on mount.
+     */
+    enabled?: boolean;
+};
+
+export const useBrandportalLink = (
+    appBridge: AppBridgeTheme,
+    options: Options = { enabled: true },
+): UseBrandportalLinkReturnType => {
     const [brandportalLink, setBrandportalLink] = useState<Nullable<BrandportalLink>>(null);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         const fetchBrandportalLink = async () => {
+            setIsLoading(true);
             setBrandportalLink(await appBridge.getBrandportalLink());
+            setIsLoading(false);
         };
 
-        fetchBrandportalLink();
-    }, [appBridge]);
+        options.enabled && fetchBrandportalLink();
+    }, [appBridge, options.enabled]);
 
     useEffect(() => {
         const updateBrandportalLinkFromEvent = (event: {
@@ -47,5 +61,5 @@ export const useBrandportalLink = (appBridge: AppBridgeTheme): UseBrandportalLin
         };
     }, [appBridge]);
 
-    return { brandportalLink };
+    return { brandportalLink, isLoading };
 };

--- a/packages/app-bridge/src/react/useBrandportalLink.ts
+++ b/packages/app-bridge/src/react/useBrandportalLink.ts
@@ -37,7 +37,13 @@ export const useBrandportalLink = (
             setIsLoading(false);
         };
 
-        options.enabled && fetchBrandportalLink();
+        if (options.enabled) {
+            try {
+                fetchBrandportalLink();
+            } catch (error) {
+                console.error(error);
+            }
+        }
     }, [appBridge, options.enabled]);
 
     useEffect(() => {

--- a/packages/app-bridge/src/react/useBrandportalLink.ts
+++ b/packages/app-bridge/src/react/useBrandportalLink.ts
@@ -38,11 +38,7 @@ export const useBrandportalLink = (
         };
 
         if (options.enabled) {
-            try {
-                fetchBrandportalLink();
-            } catch (error) {
-                console.error(error);
-            }
+            fetchBrandportalLink().catch(console.error);
         }
     }, [appBridge, options.enabled]);
 

--- a/packages/app-bridge/src/react/useCoverPage.spec.ts
+++ b/packages/app-bridge/src/react/useCoverPage.spec.ts
@@ -1,36 +1,25 @@
+// @vitest-environment happy-dom
+
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import mitt, { Emitter } from 'mitt';
 import { act, renderHook } from '@testing-library/react';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { CoverPage, CoverPageUpdate, EmitterEvents } from '../types';
-import type { AppBridgeTheme } from '../AppBridgeTheme';
+import type { CoverPage, CoverPageUpdate } from '../types';
 
 import { useCoverPage } from './useCoverPage';
-import { CoverPageDummy } from '../tests';
+import { CoverPageDummy, getAppBridgeThemeStub } from '../tests';
 
 describe('useCoverPage', () => {
-    const appBridge: AppBridgeTheme = {} as AppBridgeTheme;
-    let emitter: Emitter<EmitterEvents>;
-
-    beforeAll(() => {
-        window.emitter = mitt();
-    });
-
-    beforeEach(() => {
-        emitter = mitt();
-        vi.spyOn(window, 'emitter', 'get').mockReturnValue(emitter);
-    });
-
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
     it('should return the cover page from appBridge', async () => {
-        const coverPage = CoverPageDummy.with(1);
+        const appBridge = getAppBridgeThemeStub();
 
-        appBridge.getCoverPage = vi.fn().mockResolvedValue(coverPage);
+        const coverPage = CoverPageDummy.with(1);
+        appBridge.getCoverPage.resolves(coverPage);
 
         const { result } = renderHook(() => useCoverPage(appBridge));
 
@@ -44,6 +33,8 @@ describe('useCoverPage', () => {
     });
 
     it('should update the cover page when an event is emitted', () => {
+        const appBridge = getAppBridgeThemeStub();
+
         const { result } = renderHook(() => useCoverPage(appBridge));
 
         const updatedCoverPage: CoverPageUpdate = { id: 1, title: 'Updated Cover Page' };
@@ -59,6 +50,8 @@ describe('useCoverPage', () => {
     });
 
     it('should set the cover page to null when an event to delete it is emitted', () => {
+        const appBridge = getAppBridgeThemeStub();
+
         const { result } = renderHook(() => useCoverPage(appBridge));
 
         result.current.coverPage = null;
@@ -71,6 +64,8 @@ describe('useCoverPage', () => {
     });
 
     it('should not update the cover page when an event with an invalid action is emitted', () => {
+        const appBridge = getAppBridgeThemeStub();
+
         const { result } = renderHook(() => useCoverPage(appBridge));
 
         result.current.coverPage = CoverPageDummy.with(1);
@@ -81,5 +76,21 @@ describe('useCoverPage', () => {
         });
 
         expect(result.current.coverPage).toEqual(CoverPageDummy.with(1));
+    });
+
+    it('should start fetching only when it is enabled', () => {
+        const appBridge = getAppBridgeThemeStub();
+        const spy = vi.spyOn(appBridge, 'getCoverPage');
+
+        let enabled = false;
+
+        const { rerender } = renderHook(() => useCoverPage(appBridge, { enabled }));
+
+        expect(spy).not.toBeCalled();
+
+        enabled = true;
+        rerender();
+
+        expect(spy).toBeCalled();
     });
 });

--- a/packages/app-bridge/src/react/useCoverPage.spec.ts
+++ b/packages/app-bridge/src/react/useCoverPage.spec.ts
@@ -2,7 +2,7 @@
 
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { CoverPage, CoverPageUpdate } from '../types';
@@ -30,6 +30,24 @@ describe('useCoverPage', () => {
         });
 
         expect(result.current.coverPage).toEqual(coverPage);
+    });
+
+    it('should create the cover page when an event is emitted', async () => {
+        const appBridge = getAppBridgeThemeStub();
+
+        const coverPage = CoverPageDummy.with(243);
+        appBridge.getCoverPage.resolves(coverPage);
+
+        const { result } = renderHook(() => useCoverPage(appBridge));
+
+        act(() => {
+            window.emitter.emit('AppBridge:GuidelineCoverPageAction', {
+                action: 'add',
+                coverPage,
+            });
+        });
+
+        await waitFor(() => expect(result.current.coverPage).toEqual(coverPage));
     });
 
     it('should update the cover page when an event is emitted', () => {

--- a/packages/app-bridge/src/react/useCoverPage.spec.ts
+++ b/packages/app-bridge/src/react/useCoverPage.spec.ts
@@ -93,4 +93,15 @@ describe('useCoverPage', () => {
 
         expect(spy).toBeCalled();
     });
+
+    it('should unregister when unmounted', () => {
+        const appBridge = getAppBridgeThemeStub();
+        const spy = vi.spyOn(window.emitter, 'off');
+
+        const { unmount } = renderHook(() => useCoverPage(appBridge));
+
+        unmount();
+
+        expect(spy).toBeCalledWith('AppBridge:GuidelineCoverPageAction', expect.any(Function));
+    });
 });

--- a/packages/app-bridge/src/react/useCoverPage.ts
+++ b/packages/app-bridge/src/react/useCoverPage.ts
@@ -10,20 +10,31 @@ export type UseCoverPageReturnType = {
     isLoading: boolean;
 };
 
-export const useCoverPage = (appBridge: AppBridgeTheme): UseCoverPageReturnType => {
+type Options = {
+    /**
+     * Whether it should fetch on mount.
+     */
+    enabled?: boolean;
+};
+
+export const useCoverPage = (
+    appBridge: AppBridgeTheme,
+    options: Options = { enabled: true },
+): UseCoverPageReturnType => {
     const [coverPage, setCoverPage] = useState<Nullable<CoverPage>>(null);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         const fetchCoverPage = async () => {
+            setIsLoading(true);
             setCoverPage(await appBridge.getCoverPage());
+            setIsLoading(false);
         };
 
-        if (isLoading) {
+        if (options.enabled) {
             fetchCoverPage();
-            setIsLoading(false);
         }
-    }, [appBridge, isLoading]);
+    }, [appBridge, options.enabled]);
 
     useEffect(() => {
         const updateCoverPageFromEvent = (event: { action: EmitterAction; coverPage?: CoverPage }) => {

--- a/packages/app-bridge/src/react/useCoverPage.ts
+++ b/packages/app-bridge/src/react/useCoverPage.ts
@@ -32,11 +32,7 @@ export const useCoverPage = (
         };
 
         if (options.enabled) {
-            try {
-                fetchCoverPage();
-            } catch (error) {
-                console.error(error);
-            }
+            fetchCoverPage().catch(console.error);
         }
     }, [appBridge, options.enabled]);
 

--- a/packages/app-bridge/src/react/useCoverPage.ts
+++ b/packages/app-bridge/src/react/useCoverPage.ts
@@ -32,7 +32,11 @@ export const useCoverPage = (
         };
 
         if (options.enabled) {
-            fetchCoverPage();
+            try {
+                fetchCoverPage();
+            } catch (error) {
+                console.error(error);
+            }
         }
     }, [appBridge, options.enabled]);
 

--- a/packages/app-bridge/src/react/useDocumentCategories.ts
+++ b/packages/app-bridge/src/react/useDocumentCategories.ts
@@ -11,9 +11,20 @@ type DocumentPageEvent = {
     documentPage: { id: number; categoryId?: number | null };
 };
 
+type Options = {
+    /**
+     * Whether it should fetch on mount.
+     */
+    enabled?: boolean;
+};
+
 const sortDocumentCategories = (a: DocumentCategory, b: DocumentCategory) => (a.sort && b.sort ? a.sort - b.sort : 0);
 
-export const useDocumentCategories = (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {
+export const useDocumentCategories = (
+    appBridge: AppBridgeBlock | AppBridgeTheme,
+    documentId: number,
+    options: Options = { enabled: true },
+) => {
     const [documentCategories, setDocumentCategories] = useState<Map<number, DocumentCategory>>(new Map([]));
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -26,13 +37,15 @@ export const useDocumentCategories = (appBridge: AppBridgeBlock | AppBridgeTheme
     }, [appBridge, documentId]);
 
     useEffect(() => {
-        refetch();
-    }, [refetch]);
+        if (options.enabled) {
+            refetch();
+        }
+    }, [refetch, options.enabled]);
 
     useEffect(() => {
         const handlePageEventUpdates = (event: DocumentPageEvent) => {
             setDocumentCategories((previousState) => {
-                const action: 'add-page' | 'delete-page' | 'update-page' = `${event.action}-page`;
+                const action = `${event.action}-page` as const;
 
                 const handler = actionHandlers[action] || actionHandlers.default;
 
@@ -126,11 +139,8 @@ const deletePage = (categories: Map<number, DocumentCategory>, pageToDelete: Doc
 
 const actionHandlers = {
     'add-page': addPage,
-
     'update-page': updatePage,
-
     'delete-page': deletePage,
-
     default: (categories: Map<number, DocumentCategory>) => categories,
 };
 

--- a/packages/app-bridge/src/react/useGuidelineActions.ts
+++ b/packages/app-bridge/src/react/useGuidelineActions.ts
@@ -64,16 +64,16 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const deleteLink = useCallback(
-        async (id: number) => {
-            await appBridge.deleteLink(id);
+        async (documentId: number) => {
+            await appBridge.deleteLink(documentId);
 
             window.emitter.emit('AppBridge:GuidelineDocumentAction', {
-                document: { id },
+                document: { id: documentId },
                 action: 'delete',
             });
 
             window.emitter.emit('AppBridge:GuidelineDocumentGroupDocumentAction', {
-                document: { id },
+                document: { id: documentId },
                 action: 'delete',
             });
         },
@@ -122,16 +122,16 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const deleteLibrary = useCallback(
-        async (id: number) => {
-            await appBridge.deleteLibrary(id);
+        async (documentId: number) => {
+            await appBridge.deleteLibrary(documentId);
 
             window.emitter.emit('AppBridge:GuidelineDocumentAction', {
-                document: { id },
+                document: { id: documentId },
                 action: 'delete',
             });
 
             window.emitter.emit('AppBridge:GuidelineDocumentGroupDocumentAction', {
-                document: { id },
+                document: { id: documentId },
                 action: 'delete',
             });
         },
@@ -180,16 +180,16 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const deleteStandardDocument = useCallback(
-        async (id: number) => {
-            await appBridge.deleteStandardDocument(id);
+        async (documentId: number) => {
+            await appBridge.deleteStandardDocument(documentId);
 
             window.emitter.emit('AppBridge:GuidelineDocumentAction', {
-                document: { id },
+                document: { id: documentId },
                 action: 'delete',
             });
 
             window.emitter.emit('AppBridge:GuidelineDocumentGroupDocumentAction', {
-                document: { id },
+                document: { id: documentId },
                 action: 'delete',
             });
         },
@@ -225,11 +225,11 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const deleteDocumentGroup = useCallback(
-        async (id: number) => {
-            await appBridge.deleteDocumentGroup(id);
+        async (documentGroupId: number) => {
+            await appBridge.deleteDocumentGroup(documentGroupId);
 
             window.emitter.emit('AppBridge:GuidelineDocumentGroupAction', {
-                documentGroup: { id },
+                documentGroup: { id: documentGroupId },
                 action: 'delete',
             });
         },
@@ -440,12 +440,12 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const moveDocument = useCallback(
-        async (id: number, position: number, newGroupId?: number, oldGroupId?: number) => {
-            await appBridge.moveDocument(id, position, newGroupId, oldGroupId);
+        async (documentId: number, position: number, newGroupId?: number) => {
+            await appBridge.moveDocument(documentId, position, newGroupId);
 
             window.emitter.emit('AppBridge:GuidelineDocumentAction', {
                 document: {
-                    id,
+                    id: documentId,
                     sort: position,
                     documentGroupId: newGroupId,
                 } as Document,
@@ -453,7 +453,7 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
             });
 
             window.emitter.emit('AppBridge:GuidelineDocumentGroupDocumentAction', {
-                document: { id, documentGroupId: newGroupId as number },
+                document: { id: documentId, documentGroupId: newGroupId as number },
                 action: 'update',
             });
         },
@@ -473,11 +473,11 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const moveDocumentCategory = useCallback(
-        async (id: number, documentId: number, position: number) => {
-            await appBridge.moveDocumentCategory(id, documentId, position);
+        async (documentCategoryId: number, documentId: number, position: number) => {
+            await appBridge.moveDocumentCategory(documentCategoryId, documentId, position);
 
             window.emitter.emit(`AppBridge:GuidelineDocumentCategoryAction:${documentId}`, {
-                documentCategory: { id, documentId, sort: position } as DocumentCategory,
+                documentCategory: { id: documentCategoryId, documentId, sort: position } as DocumentCategory,
                 action: 'update',
             });
         },
@@ -485,17 +485,17 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const moveDocumentPage = useCallback(
-        async (id: number, documentId: number, position: number, categoryId?: number) => {
-            await appBridge.moveDocumentPage(id, documentId, position, categoryId);
+        async (documentPageId: number, documentId: number, position: number, categoryId?: number) => {
+            await appBridge.moveDocumentPage(documentPageId, documentId, position, categoryId);
 
             window.emitter.emit(`AppBridge:GuidelineDocumentPageAction:${documentId}`, {
-                documentPage: { id, documentId, sort: position, categoryId } as DocumentPage,
+                documentPage: { id: documentPageId, documentId, sort: position, categoryId } as DocumentPage,
                 action: 'update',
             });
 
             if (categoryId) {
                 window.emitter.emit(`AppBridge:GuidelineDocumentCategoryPageAction:${documentId}`, {
-                    documentPage: { id, categoryId },
+                    documentPage: { id: documentPageId, categoryId },
                     action: 'update',
                 });
             }
@@ -504,16 +504,16 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const moveDocumentPageBetweenDocuments = useCallback(
-        async (id: number, sourceDocumentId: number, targetDocumentId: number) => {
-            await appBridge.moveDocumentPageBetweenDocuments(id, targetDocumentId);
+        async (documentPageId: number, sourceDocumentId: number, targetDocumentId: number) => {
+            await appBridge.moveDocumentPageBetweenDocuments(documentPageId, targetDocumentId);
 
             window.emitter.emit(`AppBridge:GuidelineDocumentPageAction:${sourceDocumentId}`, {
-                documentPage: { id, documentId: sourceDocumentId } as DocumentPage,
+                documentPage: { id: documentPageId, documentId: sourceDocumentId } as DocumentPage,
                 action: 'update',
             });
 
             window.emitter.emit(`AppBridge:GuidelineDocumentPageAction:${targetDocumentId}`, {
-                documentPage: { id, documentId: targetDocumentId } as DocumentPage,
+                documentPage: { id: documentPageId, documentId: targetDocumentId } as DocumentPage,
                 action: 'update',
             });
         },
@@ -521,11 +521,11 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
     );
 
     const updateDocumentPageTargets = useCallback(
-        async (targets: number[], pageIds: number[]) => {
-            const result = await appBridge.updateDocumentPageTargets(targets, pageIds);
+        async (targets: number[], documentPageIds: number[]) => {
+            const result = await appBridge.updateDocumentPageTargets(targets, documentPageIds);
 
             window.emitter.emit('AppBridge:GuidelineDocumentPageTargetsAction', {
-                payload: { targets, pageIds },
+                payload: { targets, pageIds: documentPageIds },
                 action: 'update',
             });
 

--- a/packages/app-bridge/src/tests/DocumentApiDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentApiDummy.ts
@@ -44,7 +44,7 @@ export class DocumentApiDummy {
             targets: [],
             token: 'a-dummy-token',
             permanent_link: `/r/document-${id}`,
-            number_of_document_categories: 0,
+            number_of_document_page_categories: 0,
             number_of_uncategorized_document_pages: 0,
         };
     }

--- a/packages/app-bridge/src/tests/DocumentApiDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentApiDummy.ts
@@ -21,7 +21,6 @@ export class DocumentApiDummy {
             subheading: 'Document Dummy subHeading',
             description: null,
             logo: null,
-            layout: null,
             sort: 5,
             lazy: true,
             link_type: LinkType.Internal,
@@ -45,6 +44,8 @@ export class DocumentApiDummy {
             targets: [],
             token: 'a-dummy-token',
             permanent_link: `/r/document-${id}`,
+            number_of_document_categories: 0,
+            number_of_uncategorized_document_pages: 0,
         };
     }
 }

--- a/packages/app-bridge/src/tests/DocumentCategoryApiDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentCategoryApiDummy.ts
@@ -19,6 +19,7 @@ export class DocumentCategoryApiDummy {
             slug: `document-category-dummy-${id}`,
             sort: 1,
             document_pages: document_pages.map((page) => DocumentPageApiDummy.with(page)),
+            number_of_document_pages: document_pages.length,
         };
     }
 }

--- a/packages/app-bridge/src/tests/DocumentGroupApiDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentGroupApiDummy.ts
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import type { DocumentGroupApi } from '../types';
+
 import { DocumentApiDummy } from './DocumentApiDummy';
 
 export class DocumentGroupApiDummy {
-    static with(id: number, documents: number[] = []) {
+    static with(id: number, documents: number[] = []): DocumentGroupApi {
         return {
             id,
             creator: 9,
@@ -16,6 +18,7 @@ export class DocumentGroupApiDummy {
             name: `Document Group Dummy ${id}`,
             sort: 1,
             documents: documents.map((document) => DocumentApiDummy.with(document)),
+            number_of_documents: documents.length,
         };
     }
 }

--- a/packages/app-bridge/src/types/Document.ts
+++ b/packages/app-bridge/src/types/Document.ts
@@ -91,7 +91,7 @@ export type DocumentApi = Simplify<
         permanent_link: string;
 
         // Enriched fields
-        number_of_document_categories: number;
+        number_of_document_page_categories: number;
         number_of_uncategorized_document_pages: number;
     } & (DocumentApiAsLink | DocumentApiAsNoneLink)
 >;

--- a/packages/app-bridge/src/types/Document.ts
+++ b/packages/app-bridge/src/types/Document.ts
@@ -5,20 +5,6 @@
 import type { CamelCasedPropertiesDeep, RequireAtLeastOne, SetOptional, Simplify } from 'type-fest';
 import { SingleTargetApi } from './Targets';
 
-/**
- * @deprecated fields that are not used anymore
- */
-type DocumentApiDeprecatedFields = {
-    layout: Nullable<string>;
-};
-
-/**
- * virtual fields of Document that wont be returned by API
- */
-type DocumentApiVirtualFields = {
-    document_group_id?: Nullable<number>;
-};
-
 export type DocumentLibraryMode =
     | 'MEDIALIBRARY'
     | 'ICONLIBRARY'
@@ -60,50 +46,54 @@ type DocumentAsLink = CamelCasedPropertiesDeep<DocumentApiAsLink>;
 type DocumentAsNoneLink = CamelCasedPropertiesDeep<DocumentApiAsNoneLink>;
 
 export type DocumentApi = Simplify<
-    DocumentApiDeprecatedFields &
-        DocumentApiVirtualFields & {
-            id: number;
-            creator: number;
-            created: string;
-            modifier: Nullable<number>;
-            modified: Nullable<string>;
-            project_id: number;
-            valid_from: string;
-            valid_to: Nullable<string>;
-            visibility: Nullable<string>;
-            portal_id: Nullable<number>;
-            title: string;
-            slug: Nullable<string>;
-            heading: Nullable<string>;
-            subheading: Nullable<string>;
-            description: Nullable<string>;
-            logo: Nullable<string>;
-            sort: Nullable<number>;
-            lazy: Nullable<boolean>;
-            link_settings: Nullable<DocumentLinkSettingsApi>;
-            view_count: Nullable<number>;
-            mode: DocumentMode;
-            settings: {
-                project?: number;
-                project_slug?: string;
-                facettes?: any[];
-            };
-            appearance: Nullable<Record<string, any>>;
-            logo_file_id: Nullable<string>;
-            logo_settings: Nullable<any>;
-            background_file_id: Nullable<string>;
-            background_settings: Nullable<any>;
-            change_processed: Nullable<string>;
-            change_processed_by: Nullable<string>;
-            change_skipped: Nullable<string>;
-            change_skipped_by: Nullable<string>;
-            change_comment: Nullable<string>;
-            change_comment_by: Nullable<string>;
-            change_title: Nullable<string>;
-            targets: Nullable<SingleTargetApi['target'][]>;
-            token: Nullable<string>;
-            permanent_link: string;
-        } & (DocumentApiAsLink | DocumentApiAsNoneLink)
+    {
+        id: number;
+        creator: number;
+        created: string;
+        modifier: Nullable<number>;
+        modified: Nullable<string>;
+        project_id: number;
+        document_group_id?: Nullable<number>;
+        valid_from: string;
+        valid_to: Nullable<string>;
+        visibility: Nullable<string>;
+        portal_id: Nullable<number>;
+        title: string;
+        slug: Nullable<string>;
+        heading: Nullable<string>;
+        subheading: Nullable<string>;
+        description: Nullable<string>;
+        logo: Nullable<string>;
+        sort: Nullable<number>;
+        lazy: Nullable<boolean>;
+        link_settings: Nullable<DocumentLinkSettingsApi>;
+        view_count: Nullable<number>;
+        mode: DocumentMode;
+        settings: {
+            project?: number;
+            project_slug?: string;
+            facettes?: any[];
+        };
+        appearance: Nullable<Record<string, any>>;
+        logo_file_id: Nullable<string>;
+        logo_settings: Nullable<any>;
+        background_file_id: Nullable<string>;
+        background_settings: Nullable<any>;
+        change_processed: Nullable<string>;
+        change_processed_by: Nullable<string>;
+        change_skipped: Nullable<string>;
+        change_skipped_by: Nullable<string>;
+        change_comment: Nullable<string>;
+        change_comment_by: Nullable<string>;
+        change_title: Nullable<string>;
+        targets: Nullable<SingleTargetApi['target'][]>;
+        token: Nullable<string>;
+        permanent_link: string;
+
+        // Enriched fields
+        number_of_document_categories: number;
+        number_of_uncategorized_document_pages: number;
+    } & (DocumentApiAsLink | DocumentApiAsNoneLink)
 >;
 
 export type Document = CamelCasedPropertiesDeep<DocumentApi>;

--- a/packages/app-bridge/src/types/DocumentCategory.ts
+++ b/packages/app-bridge/src/types/DocumentCategory.ts
@@ -17,6 +17,7 @@ export type DocumentCategoryApi = {
     valid_from: string;
     valid_to: Nullable<string>;
     document_pages: Nullable<DocumentPageApi[]>;
+    number_of_document_pages: number;
 };
 
 type DocumentPageRequestFields = 'title' | 'documentId' | 'id';

--- a/packages/app-bridge/src/types/DocumentGroup.ts
+++ b/packages/app-bridge/src/types/DocumentGroup.ts
@@ -16,6 +16,7 @@ export type DocumentGroupApi = {
     project_id: number;
     portal_id: number;
     documents: Nullable<DocumentApi[]>;
+    number_of_documents: number;
 };
 
 export type DocumentGroup = Merge<CamelCasedPropertiesDeep<DocumentGroupApi>, { documents: number[] }>;


### PR DESCRIPTION
- Added `enabled` to guideline hooks
- Added enriched fields `number_of_[...]` on `DocumentGroup`, `DocumentCategory` and `Document`
- Replaced `document_group_ids` on `Document` with the singular form
- Removed extra API call on `fetchDocuments`