### PR TITLE
Refactor: Moving event emitters/observers out of hooks

### DIFF
--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -65,7 +65,12 @@ export interface AppBridgeTheme extends AppBridgeBase {
 
     deleteStandardDocument(id: number): Promise<void>;
 
-    moveDocument(documentId: number, position: number, newDocumentGroupId?: number): Promise<Document>;
+    moveDocument(
+        documentId: number,
+        position: number,
+        newDocumentGroupId?: number,
+        oldGroupId?: number,
+    ): Promise<Document>;
 
     createDocumentGroup(documentGroup: DocumentGroupCreate): Promise<DocumentGroup>;
 

--- a/packages/app-bridge/src/events/blockSettings.ts
+++ b/packages/app-bridge/src/events/blockSettings.ts
@@ -1,0 +1,20 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { BlockSettingsEvents, BlockSettingsUpdateCallback } from '../types';
+
+const APP_BRIDGE_BLOCK_SETTINGS_UPDATED_EVENT = BlockSettingsEvents.BlockSettingsUpdated;
+
+export const onBlockSettingsUpdated = (callback: BlockSettingsUpdateCallback) => {
+    window.emitter.on(APP_BRIDGE_BLOCK_SETTINGS_UPDATED_EVENT, callback);
+};
+
+export const offBlockSettingsUpdated = (callback: BlockSettingsUpdateCallback) => {
+    window.emitter.off(APP_BRIDGE_BLOCK_SETTINGS_UPDATED_EVENT, callback);
+};
+
+export const notifyBlockSettingsUpdated = (blockSettings: {
+    blockId: number;
+    blockSettings: Record<string, unknown>;
+}) => {
+    window.emitter.emit(APP_BRIDGE_BLOCK_SETTINGS_UPDATED_EVENT, blockSettings);
+};

--- a/packages/app-bridge/src/events/index.ts
+++ b/packages/app-bridge/src/events/index.ts
@@ -1,0 +1,3 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './blockSettings';

--- a/packages/app-bridge/src/react/useBlockSettings.ts
+++ b/packages/app-bridge/src/react/useBlockSettings.ts
@@ -1,14 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useEffect, useState } from 'react';
-
-import { mergeDeep } from '../utilities/object';
 import type { AppBridgeBlock } from '../AppBridgeBlock';
+import { notifyBlockSettingsUpdated, offBlockSettingsUpdated, onBlockSettingsUpdated } from '../events';
+import { BlockSettingsUpdateEvent } from '../types';
 
-export type BlockSettingsUpdateEvent<T = Record<string, unknown>> = {
-    blockId: number;
-    blockSettings: T;
-};
+import { mergeDeep } from '../utilities';
 
 export const useBlockSettings = <T = Record<string, unknown>>(
     appBridge: AppBridgeBlock,
@@ -24,17 +21,17 @@ export const useBlockSettings = <T = Record<string, unknown>>(
             }
         };
 
-        window.emitter.on('AppBridge:BlockSettingsUpdated', updateBlockSettingsFromEvent);
+        onBlockSettingsUpdated(updateBlockSettingsFromEvent);
 
         return () => {
-            window.emitter.off('AppBridge:BlockSettingsUpdated', updateBlockSettingsFromEvent);
+            offBlockSettingsUpdated(updateBlockSettingsFromEvent);
         };
     }, [blockId]);
 
     const updateBlockSettings = async (blockSettingsUpdate: Partial<T>) => {
         try {
             await appBridge.updateBlockSettings(blockSettingsUpdate);
-            window.emitter.emit('AppBridge:BlockSettingsUpdated', {
+            notifyBlockSettingsUpdated({
                 blockId,
                 blockSettings: mergeDeep(blockSettings, blockSettingsUpdate),
             });

--- a/packages/app-bridge/src/types/BlockSettings.ts
+++ b/packages/app-bridge/src/types/BlockSettings.ts
@@ -1,0 +1,12 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export type BlockSettingsUpdateEvent<T = Record<string, unknown>> = {
+    blockId: number;
+    blockSettings: T;
+};
+
+export type BlockSettingsUpdateCallback<T = Record<string, unknown>> = (event: BlockSettingsUpdateEvent<T>) => void;
+
+export enum BlockSettingsEvents {
+    BlockSettingsUpdated = 'AppBridge:BlockSettingsUpdated',
+}

--- a/packages/app-bridge/src/types/Emitter.ts
+++ b/packages/app-bridge/src/types/Emitter.ts
@@ -1,16 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import type { BlockSettingsUpdateEvent } from '../react/useBlockSettings';
-
 import type { Asset } from './Asset';
+import { BlockSettingsUpdateEvent } from './BlockSettings';
+import type { BrandportalLink } from './BrandportalLink';
 import type { Color } from './Color';
-import type { Document } from './Document';
-import type { DocumentPage } from './DocumentPage';
 import type { ColorPalette } from './ColorPalette';
 import type { CoverPage } from './CoverPage';
-import type { DocumentGroup } from './DocumentGroup';
+import type { Document } from './Document';
 import type { DocumentCategory } from './DocumentCategory';
-import type { BrandportalLink } from './BrandportalLink';
+import type { DocumentGroup } from './DocumentGroup';
+import type { DocumentPage } from './DocumentPage';
 import type { PrivacySettings } from './PrivacySettings';
 
 export type EmitterAction = 'add' | 'update' | 'delete';

--- a/packages/app-bridge/src/types/index.ts
+++ b/packages/app-bridge/src/types/index.ts
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export * from './Asset';
+export * from './BlockSettings';
 export * from './BrandportalLink';
 export * from './BulkDownload';
 export * from './Color';


### PR DESCRIPTION
### Purpose
- The aim is to have a  _separation of concern_ for event observers + emitters (plus their type definitions), thus moving them outside the React hooks.
- This allows usage/refactoring of these event methods without modifying the hooks
- Suggestion: The `events` can be renamed as `commands`, which is currently a requirement, to have a standard set of APIs to communicate with the main Frontify app.
- We can further group these events into the following:
  1. Asset Management
  2. Block and Page Settings
  3. Brand and Guideline Management
  4. File Management
  5. Navigation Management
  6. Printing Management
  7. Privacy Settings
  8. Template Management
  9. Editor State
  10. Bulk Download
- ClickUp Ticket: [#8677xch6z](https://app.clickup.com/t/8677xch6z)