### PR TITLE
chore(sidebar-settings): update fondue to support react 18

### DIFF
--- a/.changeset/mean-dodos-return.md
+++ b/.changeset/mean-dodos-return.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": patch
+---
+
+Update fondue version to support React 18

--- a/packages/sidebar-settings/package.json
+++ b/packages/sidebar-settings/package.json
@@ -40,7 +40,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.66",
-        "@frontify/fondue": "^12.0.0-beta.190"
+        "@frontify/fondue": "^12.0.0-beta.213"
     },
     "peerDependencies": {
         "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: ^3.0.0-beta.66
         version: link:../app-bridge
       '@frontify/fondue':
-        specifier: ^12.0.0-beta.190
-        version: 12.0.0-beta.190(@types/react@18.2.0)(@udecode/plate@19.7.0)(framer-motion@10.12.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.1)
+        specifier: ^12.0.0-beta.213
+        version: 12.0.0-beta-15(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@frontify/eslint-config-typescript':
         specifier: ^0.15.7
@@ -742,65 +742,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dnd-kit/accessibility@3.0.1(react@18.2.0):
-    resolution: {integrity: sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==}
-    peerDependencies:
-      react: '>=16.8.0'
-    dependencies:
-      react: 18.2.0
-      tslib: 2.5.0
-    dev: false
-
-  /@dnd-kit/core@6.0.8(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-    dependencies:
-      '@dnd-kit/accessibility': 3.0.1(react@18.2.0)
-      '@dnd-kit/utilities': 3.2.1(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.5.0
-    dev: false
-
-  /@dnd-kit/modifiers@6.0.1(@dnd-kit/core@6.0.8)(react@18.2.0):
-    resolution: {integrity: sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.0.6
-      react: '>=16.8.0'
-    dependencies:
-      '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
-      '@dnd-kit/utilities': 3.2.1(react@18.2.0)
-      react: 18.2.0
-      tslib: 2.5.0
-    dev: false
-
-  /@dnd-kit/sortable@7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0):
-    resolution: {integrity: sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.0.7
-      react: '>=16.8.0'
-    dependencies:
-      '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
-      '@dnd-kit/utilities': 3.2.1(react@18.2.0)
-      react: 18.2.0
-      tslib: 2.5.0
-    dev: false
-
-  /@dnd-kit/utilities@3.2.1(react@18.2.0):
-    resolution: {integrity: sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==}
-    peerDependencies:
-      react: '>=16.8.0'
-    dependencies:
-      react: 18.2.0
-      tslib: 2.5.0
-    dev: false
-
-  /@emoji-mart/data@1.1.2:
-    resolution: {integrity: sha512-1HP8BxD2azjqWJvxIaWAMyTySeZY0Osr83ukYjltPVkNXeJvTz7yDrPLBtnrD5uqJ3tg4CcLuuBW09wahqL/fg==}
-    dev: false
-
   /@emotion/is-prop-valid@0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
     requiresBuild: true
@@ -1207,8 +1148,8 @@ packages:
       - supports-color
     dev: true
 
-  /@frontify/fondue-tokens@3.1.0-next.5:
-    resolution: {integrity: sha512-snjEROg5Ak6ra051EMF86+TgxRPgkpxoi4JmJUp71S4cjhdC8DUwMI/Zg81zacrZDb4XOkamttFmVNPsn0BMUg==}
+  /@frontify/fondue-tokens@3.2.1:
+    resolution: {integrity: sha512-EAXgbiy1+Yg2panx4XVOUvJ97wyOe0HeRiqGujDdxa2c4nACkK2Q+dQmSAe/aEiZupRGIjkmpiMFcKHbNFlnew==}
     dependencies:
       postcss: 8.4.21
       tailwindcss: 3.3.1(postcss@8.4.21)
@@ -1216,90 +1157,88 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.190(@types/react@18.2.0)(@udecode/plate@19.7.0)(framer-motion@10.12.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.1):
-    resolution: {integrity: sha512-cPzQEM9bT1o17uWjcejaC0SgWBMAalnBbcT4V+d8IfDQJA6J8jdPyNKyreHaWY2O0hjewkUC6JLRxFK5FmKpBw==}
-    engines: {node: '>=16', npm: <=0, pnpm: '>=8'}
+  /@frontify/fondue@12.0.0-beta-15(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-zgJBN2yHFmAv7PLeXauaByVgyAiLesASZeqRJpoM72abEjnKcOhrJ1NP9iKRUpWvan08m6bEVSbyoIQTFCLhgA==}
     peerDependencies:
-      '@udecode/plate': ^19
-      framer-motion: ^10
-      react: ^17 || ^18
-      react-dom: ^17 || ^18
+      react: ^17.0.2
+      react-dom: ^17.0.2
     dependencies:
-      '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
-      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.0.8)(react@18.2.0)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
-      '@dnd-kit/utilities': 3.2.1(react@18.2.0)
-      '@frontify/fondue-tokens': 3.1.0-next.5
+      '@frontify/fondue-tokens': 3.2.1
       '@popperjs/core': 2.11.6
-      '@react-aria/accordion': 3.0.0-alpha.13(react@18.2.0)
+      '@react-aria/accordion': 3.0.0-alpha.9(react@18.2.0)
       '@react-aria/aria-modal-polyfill': 3.6.1(react@18.2.0)
       '@react-aria/breadcrumbs': 3.4.0(react@18.2.0)
-      '@react-aria/button': 3.6.3(react@18.2.0)
+      '@react-aria/button': 3.6.4(react@18.2.0)
       '@react-aria/checkbox': 3.7.0(react@18.2.0)
       '@react-aria/combobox': 3.4.3(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/dialog': 3.4.1(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/focus': 3.12.0(react@18.2.0)
-      '@react-aria/interactions': 3.13.0(react@18.2.0)
-      '@react-aria/link': 3.3.5(react@18.2.0)
-      '@react-aria/listbox': 3.7.1(react@18.2.0)
-      '@react-aria/menu': 3.7.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/interactions': 3.15.0(react@18.2.0)
+      '@react-aria/link': 3.3.6(react@18.2.0)
+      '@react-aria/listbox': 3.7.2(react@18.2.0)
+      '@react-aria/menu': 3.7.1(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/overlays': 3.12.1(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/radio': 3.4.1(react@18.2.0)
       '@react-aria/select': 3.8.3(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/selection': 3.12.0(react@18.2.0)
+      '@react-aria/selection': 3.14.0(react@18.2.0)
       '@react-aria/table': 3.6.0(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/tooltip': 3.3.3(react@18.2.0)
-      '@react-aria/utils': 3.14.1(react@18.2.0)
-      '@react-aria/visually-hidden': 3.6.0(react@18.2.0)
+      '@react-aria/utils': 3.16.0(react@18.2.0)
+      '@react-aria/visually-hidden': 3.6.1(react@18.2.0)
       '@react-stately/checkbox': 3.3.2(react@18.2.0)
-      '@react-stately/collections': 3.4.4(react@18.2.0)
-      '@react-stately/combobox': 3.2.2(react@18.2.0)
-      '@react-stately/list': 3.5.4(react@18.2.0)
-      '@react-stately/menu': 3.4.4(react@18.2.0)
-      '@react-stately/overlays': 3.4.2(react@18.2.0)
-      '@react-stately/radio': 3.6.0(react@18.2.0)
-      '@react-stately/select': 3.3.2(react@18.2.0)
-      '@react-stately/table': 3.5.0(react@18.2.0)
-      '@react-stately/toggle': 3.4.2(react@18.2.0)
-      '@react-stately/tooltip': 3.2.2(react@18.2.0)
-      '@react-stately/tree': 3.3.4(react@18.2.0)
-      '@react-types/dialog': 3.4.5(react@18.2.0)
-      '@react-types/shared': 3.16.0(react@18.2.0)
-      '@tailwindcss/forms': 0.5.3(tailwindcss@3.3.1)
-      '@udecode/plate': 19.7.0(@types/react@18.2.0)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@xstate/immer': 0.3.1(immer@9.0.12)(xstate@4.28.1)
+      '@react-stately/collections': 3.7.0(react@18.2.0)
+      '@react-stately/combobox': 3.5.0(react@18.2.0)
+      '@react-stately/list': 3.8.0(react@18.2.0)
+      '@react-stately/menu': 3.5.1(react@18.2.0)
+      '@react-stately/overlays': 3.5.1(react@18.2.0)
+      '@react-stately/radio': 3.8.0(react@18.2.0)
+      '@react-stately/select': 3.5.0(react@18.2.0)
+      '@react-stately/table': 3.9.0(react@18.2.0)
+      '@react-stately/toggle': 3.5.1(react@18.2.0)
+      '@react-stately/tooltip': 3.4.0(react@18.2.0)
+      '@react-stately/tree': 3.6.0(react@18.2.0)
+      '@storybook/addon-a11y': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@udecode/plate': 16.9.1(@types/react@18.2.0)(react-dnd-html5-backend@15.1.2)(react-dnd@15.1.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@xstate/immer': 0.3.1(immer@9.0.21)(xstate@4.28.1)
       '@xstate/react': 1.6.3(@types/react@18.2.0)(react@18.2.0)(xstate@4.28.1)
       date-fns: 2.29.3
-      escape-html: 1.0.3
-      framer-motion: 10.12.4(react-dom@18.2.0)(react@18.2.0)
-      immer: 9.0.12
-      is-hotkey: 0.2.0
+      framer-motion: 6.5.1(react-dom@18.2.0)(react@18.2.0)
+      immer: 9.0.21
       react: 18.2.0
       react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
       react-datepicker: 4.8.0(react-dom@18.2.0)(react@18.2.0)
-      react-dnd: 16.0.1(@types/react@18.2.0)(react@18.2.0)
+      react-dnd: 15.1.2(@types/react@18.2.0)(react@18.2.0)
       react-dnd-html5-backend: 15.1.2
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.2.0
       react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0)
-      react-textarea-autosize: 8.4.0(@types/react@18.2.0)(react@18.2.0)
-      remark-gfm: 3.0.1
-      remark-parse: 10.0.1
+      react-textarea-autosize: 8.4.1(@types/react@18.2.0)(react@18.2.0)
       scheduler: 0.23.0
-      slate: 0.87.0
-      slate-react: 0.88.0(react-dom@18.2.0)(react@18.2.0)(slate@0.87.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-hyperscript: 0.77.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       tinycolor2: 1.4.2
-      unified: 10.1.2
-      unist-util-visit: 4.1.2
       xstate: 4.28.1
     transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
       - '@xstate/fsm'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
       - supports-color
-      - tailwindcss
       - ts-node
     dev: false
 
@@ -1406,10 +1345,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@juggle/resize-observer@3.4.0:
-    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
-    dev: false
-
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
@@ -1473,6 +1408,53 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
+  /@motionone/animation@10.15.1:
+    resolution: {integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==}
+    dependencies:
+      '@motionone/easing': 10.15.1
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/dom@10.12.0:
+    resolution: {integrity: sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==}
+    dependencies:
+      '@motionone/animation': 10.15.1
+      '@motionone/generators': 10.15.1
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/easing@10.15.1:
+    resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
+    dependencies:
+      '@motionone/utils': 10.15.1
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/generators@10.15.1:
+    resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
+    dependencies:
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/types@10.15.1:
+    resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
+    dev: false
+
+  /@motionone/utils@10.15.1:
+    resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
+    dependencies:
+      '@motionone/types': 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.5.0
+    dev: false
+
   /@mswjs/cookies@0.2.2:
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
     engines: {node: '>=14'}
@@ -1527,27 +1509,27 @@ packages:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
 
-  /@radix-ui/react-compose-refs@1.0.0(react@18.2.0):
-    resolution: {integrity: sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==}
+  /@radix-ui/react-compose-refs@0.1.0(react@18.2.0):
+    resolution: {integrity: sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==}
     peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0
+      react: ^16.8 || ^17.0
     dependencies:
       '@babel/runtime': 7.21.0
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-slot@1.0.1(react@18.2.0):
-    resolution: {integrity: sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==}
+  /@radix-ui/react-slot@0.1.2(react@18.2.0):
+    resolution: {integrity: sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==}
     peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0
+      react: ^16.8 || ^17.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 0.1.0(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-aria/accordion@3.0.0-alpha.13(react@18.2.0):
-    resolution: {integrity: sha512-xq9R6Op9UeKRG/dUcA64SXPJ71+sS3GTtaccsl0BYpMn1wEwmpEazMMOFJw2piPdWEllMDa51Twked77CEYMnA==}
+  /@react-aria/accordion@3.0.0-alpha.9(react@18.2.0):
+    resolution: {integrity: sha512-3n55HzOKu9/JWdbASSdNE0KI4vKH1zsWVeoLgE9M5MXfgHYsOb/c7KkHIrBkC1oD03KdKioDlNENEXzBoOiI4w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -1557,7 +1539,7 @@ packages:
       '@react-aria/selection': 3.14.0(react@18.2.0)
       '@react-aria/utils': 3.16.0(react@18.2.0)
       '@react-stately/tree': 3.6.0(react@18.2.0)
-      '@react-types/accordion': 3.0.0-alpha.11(react@18.2.0)
+      '@react-types/accordion': 3.0.0-alpha.7(react@18.2.0)
       '@react-types/button': 3.7.2(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
@@ -1585,21 +1567,6 @@ packages:
       '@react-aria/link': 3.3.6(react@18.2.0)
       '@react-aria/utils': 3.16.0(react@18.2.0)
       '@react-types/breadcrumbs': 3.5.1(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
-  /@react-aria/button@3.6.3(react@18.2.0):
-    resolution: {integrity: sha512-t6UHFPFMlAQW0yefjhqwyQya6RYlUtMRtMKZjnRANbK6JskazkkLvu//qULs+vsiM21PLhspKVLcGdS+t2khsA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/focus': 3.12.0(react@18.2.0)
-      '@react-aria/interactions': 3.15.0(react@18.2.0)
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-stately/toggle': 3.5.1(react@18.2.0)
-      '@react-types/button': 3.7.2(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -1731,17 +1698,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-aria/interactions@3.13.0(react@18.2.0):
-    resolution: {integrity: sha512-gbZL+qs+6FPitR/abAramth4lqz/drEzXwzIDF6p6WyajF805mjyAgZin1/3mQygSE5BwJNDU7jMUSGRvgFyTw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-aria/interactions@3.15.0(react@18.2.0):
     resolution: {integrity: sha512-8br5uatPDISEWMINKGs7RhNPtqLhRsgwQsooaH7Jgxjs0LBlylODa8l7D3NA1uzVzlvfnZm/t2YN/y8ieRSDcQ==}
     peerDependencies:
@@ -1766,20 +1722,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-aria/link@3.3.5(react@18.2.0):
-    resolution: {integrity: sha512-BbyoJ73IAQcQMYWFxhV/zJWYFlx4Edprm6xfBZKMEBrEpUcvBwe/X3QsCQmRXZ8fJodMjQ9SdQPyue1yi8Ksrw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/focus': 3.12.0(react@18.2.0)
-      '@react-aria/interactions': 3.15.0(react@18.2.0)
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-types/link': 3.4.1(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-aria/link@3.3.6(react@18.2.0):
     resolution: {integrity: sha512-UjbdBJ8EB+jCC3mPZD6cYykHqZKTy6/VvI5RGJoKtF8cg9639tRy6g102pd4ncFTdD4DfU5PPWtthC24nQRCyQ==}
     peerDependencies:
@@ -1791,24 +1733,6 @@ packages:
       '@react-types/link': 3.4.1(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-aria/listbox@3.7.1(react@18.2.0):
-    resolution: {integrity: sha512-vKovd+u8F7jdcogZeDPtm89gn390cR0xpMbOoyPzbACOdST43SYexDXWV4Ww/M2YWkdJxT3jZ576NeifcfO2MA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/focus': 3.12.0(react@18.2.0)
-      '@react-aria/interactions': 3.15.0(react@18.2.0)
-      '@react-aria/label': 3.5.1(react@18.2.0)
-      '@react-aria/selection': 3.14.0(react@18.2.0)
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/list': 3.8.0(react@18.2.0)
-      '@react-types/listbox': 3.4.1(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -1836,28 +1760,6 @@ packages:
       '@swc/helpers': 0.4.14
     dev: false
 
-  /@react-aria/menu@3.7.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-dCSg67G3vEXOovZyaojZXvcq19MLqual6oTSJC9WhNS/SR0AuNPbwMbD34a/b1Je73ro5bzjIbmQPyt/i3XaCA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/i18n': 3.7.1(react@18.2.0)
-      '@react-aria/interactions': 3.15.0(react@18.2.0)
-      '@react-aria/overlays': 3.12.1(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/selection': 3.14.0(react@18.2.0)
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/menu': 3.5.1(react@18.2.0)
-      '@react-stately/tree': 3.6.0(react@18.2.0)
-      '@react-types/button': 3.7.2(react@18.2.0)
-      '@react-types/menu': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
   /@react-aria/menu@3.7.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5KIUTs3xYSmERB8qzofFghznMVLcG3RWDnJcQjpRtrrYjm6Oc39TJeodDH874fiEr6o3i5WwMrEYVp7NSxz/TQ==}
     peerDependencies:
@@ -1876,27 +1778,6 @@ packages:
       '@react-types/menu': 3.9.0(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       '@swc/helpers': 0.4.14
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
-  /@react-aria/overlays@3.12.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-jsGeLTB3W3S5Cf2zDTxh1ODTNkE69miFDOGMB0VLwS1GWDwDvytcTRpBKY9JBrxad+4u0x6evnah7IbJ61qNBA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/focus': 3.12.0(react@18.2.0)
-      '@react-aria/i18n': 3.7.1(react@18.2.0)
-      '@react-aria/interactions': 3.15.0(react@18.2.0)
-      '@react-aria/ssr': 3.6.0(react@18.2.0)
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-aria/visually-hidden': 3.6.1(react@18.2.0)
-      '@react-stately/overlays': 3.5.1(react@18.2.0)
-      '@react-types/button': 3.7.2(react@18.2.0)
-      '@react-types/overlays': 3.7.1(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -1960,22 +1841,6 @@ packages:
       '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
-  /@react-aria/selection@3.12.0(react@18.2.0):
-    resolution: {integrity: sha512-Akzx5Faxw+sOZFXLCOw6OddDNFbP5Kho3EP6bYJfd2pzMkBc8/JemC/YDrtIuy8e9x6Je9HHSZqtKjwiEaXWog==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/focus': 3.12.0(react@18.2.0)
-      '@react-aria/i18n': 3.7.1(react@18.2.0)
-      '@react-aria/interactions': 3.15.0(react@18.2.0)
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/selection': 3.13.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
     dev: false
 
   /@react-aria/selection@3.14.0(react@18.2.0):
@@ -2072,19 +1937,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-aria/utils@3.14.1(react@18.2.0):
-    resolution: {integrity: sha512-+ynP0YlxN02MHVEBaeuTrIhBsfBYpfJn36pZm2t7ZEFbafH8DPaMGZ70ffYZXAESkWzRULXL3e79DheWOFI1qA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/ssr': 3.6.0(react@18.2.0)
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      clsx: 1.2.1
-      react: 18.2.0
-    dev: false
-
   /@react-aria/utils@3.16.0(react@18.2.0):
     resolution: {integrity: sha512-BumpgENDlXuoRPQm1OfVUYRcxY9vwuXw1AmUpwF61v55gAZT3LvJWsfF8jgfQNzLJr5jtr7xvUx7pXuEyFpJMA==}
     peerDependencies:
@@ -2094,19 +1946,6 @@ packages:
       '@react-stately/utils': 3.6.0(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       '@swc/helpers': 0.4.14
-      clsx: 1.2.1
-      react: 18.2.0
-    dev: false
-
-  /@react-aria/visually-hidden@3.6.0(react@18.2.0):
-    resolution: {integrity: sha512-W3Ix5wdlVzh2GY7dytqOAyLCXiHzk3S4jLKSaoiCwPJX9fHE5zMlZwahhDy27V0LXfjmdjBltbwyEZOq4G/Q0w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/interactions': 3.15.0(react@18.2.0)
-      '@react-aria/utils': 3.16.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
       clsx: 1.2.1
       react: 18.2.0
     dev: false
@@ -2128,20 +1967,28 @@ packages:
     resolution: {integrity: sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==}
     dev: false
 
-  /@react-dnd/asap@5.0.2:
-    resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
+  /@react-dnd/asap@4.0.1:
+    resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
     dev: false
 
   /@react-dnd/invariant@3.0.0:
     resolution: {integrity: sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==}
     dev: false
 
-  /@react-dnd/invariant@4.0.2:
-    resolution: {integrity: sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==}
+  /@react-dnd/invariant@3.0.1:
+    resolution: {integrity: sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g==}
     dev: false
 
-  /@react-dnd/shallowequal@4.0.2:
-    resolution: {integrity: sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==}
+  /@react-dnd/shallowequal@3.0.1:
+    resolution: {integrity: sha512-XjDVbs3ZU16CO1h5Q3Ew2RPJqmZBDE/EVf1LYp6ePEffs3V/MX9ZbL5bJr8qiK5SbGmUMuDoaFgyKacYz8prRA==}
+    dev: false
+
+  /@react-hook/merged-ref@1.3.2(react@18.2.0):
+    resolution: {integrity: sha512-cQ9Y8m4zlrw/qotReo33E+3Sy9FVqMZb5JwUlb3wj3IJJ1cNJtxcgfWF6rS2NZQrfBJ2nAnckUdPJjMyIJTNZg==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /@react-stately/checkbox@3.3.2(react@18.2.0):
@@ -2157,16 +2004,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-stately/collections@3.4.4(react@18.2.0):
-    resolution: {integrity: sha512-gryUYCe6uzqE0ea5frTwOxOPpx/6Z42PRk7KetOh3ddN3Ts0j8XQP08jP1IB/7BC1QidrkHWvDCqGHxRiEjiIg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-stately/collections@3.7.0(react@18.2.0):
     resolution: {integrity: sha512-xZHJxjGXFe3LUbuNgR1yATBVSIQnm+ItLq2DJZo3JzTtRu3gEwLoRRoapPsBQnC5VsjcaimgoqvT05P0AlvCTQ==}
     peerDependencies:
@@ -2174,21 +2011,6 @@ packages:
     dependencies:
       '@react-types/shared': 3.18.0(react@18.2.0)
       '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-stately/combobox@3.2.2(react@18.2.0):
-    resolution: {integrity: sha512-kUMxgXskrtwdeEExZkJ9CjF4EJANetj+7970cOevCpy6ePCdrvdgO6+0cMrVvSgZeMaMDZXDIbbF7fqA6w0uXQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/list': 3.8.0(react@18.2.0)
-      '@react-stately/menu': 3.5.1(react@18.2.0)
-      '@react-stately/select': 3.5.0(react@18.2.0)
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/combobox': 3.6.1(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -2236,19 +2058,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-stately/list@3.5.4(react@18.2.0):
-    resolution: {integrity: sha512-AB0r2RevKVAP2AOQM1JRuCVjS2UUxMJFshA53t8pV+OSVWeyirYccsMR49mWwU60ZnxYqBWVMN+Pl7NTPTnT8w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/selection': 3.13.0(react@18.2.0)
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-stately/list@3.8.0(react@18.2.0):
     resolution: {integrity: sha512-eJ1iUFnXPZi5MGW2h/RdNTrKtq4HLoAlFAQbC4eSPlET6VDeFsX9NkKhE/A111ia24DnWCqJB5zH20EvNbOxxA==}
     peerDependencies:
@@ -2257,19 +2066,6 @@ packages:
       '@react-stately/collections': 3.7.0(react@18.2.0)
       '@react-stately/selection': 3.13.0(react@18.2.0)
       '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-stately/menu@3.4.4(react@18.2.0):
-    resolution: {integrity: sha512-WKak1NSV9yDY0tDB4mzsbj0FboTtR06gekio0VmKb1+FmnrC07mef8eGKUn974F0WhTNUy5A1iI5eM0W2YNynA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-stately/overlays': 3.5.1(react@18.2.0)
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/menu': 3.9.0(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -2288,17 +2084,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-stately/overlays@3.4.2(react@18.2.0):
-    resolution: {integrity: sha512-UTCnn0aT+JL4ZhYPQYUWHwhmuR2T3vKTFUEZeZN9sTuDCctg08VfGoASJx8qofqkLwYJXeb8D5PMhhTDPiUQPw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/overlays': 3.7.1(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-stately/overlays@3.5.1(react@18.2.0):
     resolution: {integrity: sha512-lDKqqpdaIQdJb8DS4+tT7p0TLyCeaUaFpEtWZNjyv1/nguoqYtSeRwnyPR4p/YM4AW7SJspNiTJSLQxkTMIa8w==}
     peerDependencies:
@@ -2307,18 +2092,6 @@ packages:
       '@react-stately/utils': 3.6.0(react@18.2.0)
       '@react-types/overlays': 3.7.1(react@18.2.0)
       '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-stately/radio@3.6.0(react@18.2.0):
-    resolution: {integrity: sha512-hzNwIapDSnbk5mCim/AgHQTtHRgy2QiW95okfVnGflzO7nnws8WH/s2Va4f7UupWObPv8XTqHADUEng86mVBJA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/radio': 3.4.1(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -2331,22 +2104,6 @@ packages:
       '@react-types/radio': 3.4.1(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-stately/select@3.3.2(react@18.2.0):
-    resolution: {integrity: sha512-/C9fW7HT+V9XnmSTiZZqH5cn+ifY9vdXvIKDbUyna98lFHtDgn7i/UvD5edunOGY0qqSMIO3kJ6/BiNg+gpn6Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/list': 3.8.0(react@18.2.0)
-      '@react-stately/menu': 3.5.1(react@18.2.0)
-      '@react-stately/selection': 3.13.0(react@18.2.0)
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/select': 3.8.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -2378,21 +2135,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-stately/table@3.5.0(react@18.2.0):
-    resolution: {integrity: sha512-C0HFfKMCOomqPtRCPs85AtoJGPnGu9mzFfwksFxAssdIatw3t66h5SJS0vSSql7Ku9h70scmvJR+nIOckx0IeA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/grid': 3.6.0(react@18.2.0)
-      '@react-stately/selection': 3.13.0(react@18.2.0)
-      '@react-types/grid': 3.1.7(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      '@react-types/table': 3.6.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-stately/table@3.9.0(react@18.2.0):
     resolution: {integrity: sha512-Cl0jmC5eCEhWBAhCjhGklsgYluziNZHF34lHnc99T/DPP+OxwrgwS9rJKTW7L6UOvHU/ADKjEwkE/fZuqVBohg==}
     peerDependencies:
@@ -2408,18 +2150,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-stately/toggle@3.4.2(react@18.2.0):
-    resolution: {integrity: sha512-+pO13Ap/tj4optu6VjQrEAaAoZvJAEwarMUaZvrkc0kdvMTNPdiT/2vhN32yvsSW0ssuFqToa3jMrTylCbpo8w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/checkbox': 3.4.3(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-stately/toggle@3.5.1(react@18.2.0):
     resolution: {integrity: sha512-PF4ZaATpXWu7DkneGSZ2/PA6LJ1MrhKNiaENTZlbojXMRr5kK33wPzaDW7I8O25IUm0+rvQicv7A6QkEOxgOPg==}
     peerDependencies:
@@ -2432,18 +2162,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-stately/tooltip@3.2.2(react@18.2.0):
-    resolution: {integrity: sha512-Y9itW2PDRWi/FdMYhpAC/kmXx22mRElADbM1AqKkMkWiJHhTbn2Cr5ie1uZcm+SMb5Dq2ypMV5rUzuiCVVB8/g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/overlays': 3.5.1(react@18.2.0)
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/tooltip': 3.4.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-stately/tooltip@3.4.0(react@18.2.0):
     resolution: {integrity: sha512-TQyDIcugRah4eGmbK6UsyrtJrKJKte+xKv8X7kgdiGVMWiENiMG5h+3pGa8OT07FJzg7FvQHkMH+hrIuAqXT2g==}
     peerDependencies:
@@ -2453,19 +2171,6 @@ packages:
       '@react-stately/utils': 3.6.0(react@18.2.0)
       '@react-types/tooltip': 3.4.0(react@18.2.0)
       '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-stately/tree@3.3.4(react@18.2.0):
-    resolution: {integrity: sha512-CBgXvwa9qYBsJuxrAiVgGnm48eSxLe/6OjPMwH1pWf4s383Mx73MbbN4fS0oWDeXBVgdqz5/Xg/p8nvPIvl3WQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/selection': 3.13.0(react@18.2.0)
-      '@react-stately/utils': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -2502,8 +2207,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-types/accordion@3.0.0-alpha.11(react@18.2.0):
-    resolution: {integrity: sha512-7TAvvMnfSWtX4gkmRg3pE31y/E/oTWfUAIi9WT4hPJBbE/8zItjD2P5cQ5tLizXT87fnm+4s8jvci7gZcN2/pw==}
+  /@react-types/accordion@3.0.0-alpha.7(react@18.2.0):
+    resolution: {integrity: sha512-h5Nvf/+O+Cl/Vw6m3RNGD3hv7VwKX0ilJe1a473iJgjruzMQybSgpcCdWES31QZdEE+rkjpqTGoG22MusEOE+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2544,16 +2249,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
-  /@react-types/dialog@3.4.5(react@18.2.0):
-    resolution: {integrity: sha512-FkxZAYNRWkZVH5rjlw6qyQ/SpoGcYtNI/JQvn1H/xtZy/OJh2b2ERxGWv5x0RItGSeyATdSwFO1Qnf1Kl2K02A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/overlays': 3.7.1(react@18.2.0)
       '@react-types/shared': 3.18.0(react@18.2.0)
       react: 18.2.0
     dev: false
@@ -2639,14 +2334,6 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.18.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
-  /@react-types/shared@3.16.0(react@18.2.0):
-    resolution: {integrity: sha512-IQgU4oAEvMwylEvaTsr2XB1G/mAoMe1JFYLD6G78v++oAR9l8o9MQxZ0YSeANDkqTamb2gKezGoT1RxvSKjVxw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
       react: 18.2.0
     dev: false
 
@@ -2774,19 +2461,172 @@ packages:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
 
+  /@storybook/addon-a11y@6.5.16(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-/e9s34o+TmEhy+Q3/YzbRJ5AJ/Sy0gjZXlvsCrcRpiQLdt5JRbN8s+Lbn/FWxy8U1Tb1wlLYlqjJ+fYi5RrS3A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/api': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/channels': 6.5.16
+      '@storybook/client-logger': 6.5.16
+      '@storybook/components': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      axe-core: 4.7.0
+      core-js: 3.30.2
+      global: 4.4.0
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-sizeme: 3.0.2
+      regenerator-runtime: 0.13.11
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/addons@6.5.16(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-p3DqQi+8QRL5k7jXhXmJZLsE/GqHqyY6PcoA1oNTJr0try48uhTGUOYkgzmqtDaa/qPFO5LP+xCPzZXckGtquQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/api': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/channels': 6.5.16
+      '@storybook/client-logger': 6.5.16
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@types/webpack-env': 1.18.0
+      core-js: 3.30.2
+      global: 4.4.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+    dev: false
+
+  /@storybook/api@6.5.16(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-HOsuT8iomqeTMQJrRx5U8nsC7lJTwRr1DhdD0SzlqL4c80S/7uuCy4IZvOt4sYQjOzW5fOo/kamcoBXyLproTA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/channels': 6.5.16
+      '@storybook/client-logger': 6.5.16
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/semver': 7.3.2
+      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      core-js: 3.30.2
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      store2: 2.14.2
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/channels@6.5.16:
+    resolution: {integrity: sha512-VylzaWQZaMozEwZPJdyJoz+0jpDa8GRyaqu9TGG6QGv+KU5POoZaGLDkRE7TzWkyyP0KQLo80K99MssZCpgSeg==}
+    dependencies:
+      core-js: 3.30.2
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/client-logger@6.5.16:
+    resolution: {integrity: sha512-pxcNaCj3ItDdicPTXTtmYJE3YC1SjxFrBmHcyrN+nffeNyiMuViJdOOZzzzucTUG0wcOOX8jaSyak+nnHg5H1Q==}
+    dependencies:
+      core-js: 3.30.2
+      global: 4.4.0
+    dev: false
+
+  /@storybook/components@6.5.16(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-LzBOFJKITLtDcbW9jXl0/PaG+4xAz25PK8JxPZpIALbmOpYWOAPcO6V9C2heX6e6NgWFMUxjplkULEk9RCQMNA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
+      core-js: 3.30.2
+      memoizerific: 1.11.3
+      qs: 6.11.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/core-events@6.5.16:
+    resolution: {integrity: sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==}
+    dependencies:
+      core-js: 3.30.2
+    dev: false
+
+  /@storybook/csf@0.0.2--canary.4566f4d.1:
+    resolution: {integrity: sha512-9OVvMVh3t9znYZwb0Svf/YQoxX2gVOeQTGe2bses2yj+a3+OJnCrUF3/hGv6Em7KujtOdL2LL+JnG49oMVGFgQ==}
+    dependencies:
+      lodash: 4.17.21
+    dev: false
+
+  /@storybook/router@6.5.16(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ZgeP8a5YV/iuKbv31V8DjPxlV4AzorRiR8OuSt/KqaiYXNXlOoQDz/qMmiNcrshrfLpmkzoq7fSo4T8lWo2UwQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.16
+      core-js: 3.30.2
+      memoizerific: 1.11.3
+      qs: 6.11.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+    dev: false
+
+  /@storybook/semver@7.3.2:
+    resolution: {integrity: sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      core-js: 3.30.2
+      find-up: 4.1.0
+    dev: false
+
+  /@storybook/theming@6.5.16(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-hNLctkjaYLRdk1+xYTkC1mg4dYz2wSv6SqbLpcKMbkPHTE0ElhddGPHQqB362md/w9emYXNkt1LSMD8Xk9JzVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.16
+      core-js: 3.30.2
+      memoizerific: 1.11.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+    dev: false
+
   /@swc/helpers@0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.5.0
-    dev: false
-
-  /@tailwindcss/forms@0.5.3(tailwindcss@3.3.1):
-    resolution: {integrity: sha512-y5mb86JUoiUgBjY/o6FJSFZSEttfb3Q5gllE4xoKjAAD+vBrnIhE4dViwUuow3va8mpH4s9jyUbUbrRGoRdc2Q==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
-    dependencies:
-      mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.3.1(postcss@8.4.21)
     dev: false
 
   /@testing-library/dom@9.0.0:
@@ -2879,6 +2719,11 @@ packages:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
       '@types/ms': 0.7.31
+    dev: true
+
+  /@types/escape-html@1.0.2:
+    resolution: {integrity: sha512-gaBLT8pdcexFztLSPRtriHeXY/Kn4907uOCZ4Q3lncFBkheAWOuNt53ypsF8szgxbEJ513UeBzcf4utN0EzEwA==}
+    dev: false
 
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
@@ -2893,6 +2738,10 @@ packages:
     dependencies:
       ci-info: 3.8.0
     dev: true
+
+  /@types/is-function@1.0.1:
+    resolution: {integrity: sha512-A79HEEiwXTFtfY+Bcbo58M2GRYzCr9itHWzbzHVFNEYCcoU/MMGwYYf721gBrnhpj1s6RGVVha/IgNFnR0Iw/Q==}
+    dev: false
 
   /@types/is-hotkey@0.1.7:
     resolution: {integrity: sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ==}
@@ -2933,12 +2782,6 @@ packages:
     dependencies:
       '@types/unist': 2.0.6
 
-  /@types/mdast@3.0.11:
-    resolution: {integrity: sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==}
-    dependencies:
-      '@types/unist': 2.0.6
-    dev: false
-
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
@@ -2951,6 +2794,7 @@ packages:
 
   /@types/ms@0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
+    dev: true
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -3019,6 +2863,10 @@ packages:
 
   /@types/unist@2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+
+  /@types/webpack-env@1.18.0:
+    resolution: {integrity: sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==}
+    dev: false
 
   /@types/ws@8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
@@ -3156,21 +3004,21 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
-  /@udecode/plate-alignment@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-0yZUdLLTQ30HzNotm5yOoFZI3CA2SGPXhSwoi5OcbW0LP5bWr6kEw5ZdOT1KunhfJrN5s2g2jXEglu8MQu3lqQ==}
+  /@udecode/plate-alignment@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-d/Fv88lQ6lkl007CSQoQaTaz8H38g2nYF88iA3imoPkWdfEphjWlNx5xR/4VU+DVNTH/tvUuNm/pSH0UWG+ZBg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3187,21 +3035,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-autoformat@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-maGl/ST9ps818X9+4vcdaMVi4vTfPGUf0FqdfQyyGGJOWhPrZI5JfgUr543nrgeXrNKOxADm1Mto/gkv/X53tA==}
+  /@udecode/plate-autoformat@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-DIrQV/A5yRiwlgjygxGWOiceIkmtDyvsXJ6K+lwyumOFu0XpLw1l67s6+s2TEnJYPitMcMOdhIxqCNE0pVedVw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3218,25 +3066,25 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-basic-elements@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-JFGX34IijE5k/U1NsPhlpPFjgsI58NM2IgxkkIIbbvglDnH856Adj9tntTODoK+JXRxV6XTDC9RE7QnWx4Fwfg==}
+  /@udecode/plate-basic-elements@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-qMzRL5N9RsoUjj+FcgSf5IEAyeR0ysfDaf7tQOL5lEqYhqk1vnJh8JZqQqxnRo1yugvFlE0WvszXU8Nq2ZFO1A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-block-quote': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-code-block': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-heading': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-paragraph': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-block-quote': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-code-block': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-heading': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-paragraph': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3253,21 +3101,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-basic-marks@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-ysAEuCM1PUo/B11Slu3n0JRV9WP8OVL3Gqycgv5EeYu52sX+nA74Kad9mueP7G1H5FhXY0xXx/kem4E3Vqcv+g==}
+  /@udecode/plate-basic-marks@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-yqRVR+zowfjzOK9AxDZ//hiq6+tNUFY2gGJck8ClGMr5y9pbQfCDOyL7nkgbS7mUO4vzZmDIOjl+spGvOUVuSg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3284,21 +3132,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-block-quote@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-JaC3jJXIGn74Qi/AwFnGmLabamoZaaof+h/O4a0g8+czqddfjGt8O+bHo5FgCoOACMvNXrpOhUP1sGZTIkH4zg==}
+  /@udecode/plate-block-quote@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-lVGotr93cMD4+3wJNV/LvF2aLRhnp3qOEMbFRKbFqt9sjuI98gviqizAtHo5yw34NoYiz4YDTa2wOyXNKg/FJg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3315,21 +3163,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-break@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-CYDgr66rmBwkxQ9qmHa0pAssDUkj6PFibtIbjZoMSHnoBuRQd+qbB/O7BfNCRkwy/aVj5of2lQtxDwcAqkXilw==}
+  /@udecode/plate-break@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-48WpW9/SqngeTP6ZNRi90j89iOii7mhI6ImYd6uA4QbhrE9rtDLm+HRHmy1uNaOlJLECZ2jp4+2yWTN6rbObdg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3346,21 +3194,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-button@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-cXr21b8Lu0rJHcAXiN4Ss86wn6K2W1a9shMgGpycMEMhrgY8VDqnhuIME7/dA8r5wNkqOyWOfvoHsXiS/+2PUw==}
+  /@udecode/plate-button@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-1FPMGTAYddSO08YoOJWf97wbrOLACUIxN2YI0QhOLl8k60bKKHlhhO5Bt/JV6uFElrpZiCjn6aBhE+wKxEs1gw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3377,22 +3225,22 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-code-block@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-Z/FkK1Z2a9Oy2qseqbTp2ooAkqKVyka0l1DMRk5dGpXNKVmew62ANzLuvrsmliAVm6c4788tLV9i8RfTtWzumQ==}
+  /@udecode/plate-code-block@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-mtFy2IPuPF62qzMnqol6qk6Ag7dPco547Blcwf7UI/RFcRuCuX8/O/4phokz3ji35dZ06/oTrWWf0kGOpR/8Lw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       prismjs: 1.29.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3409,23 +3257,23 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-combobox@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-CJPmmtwKvZw9LKqehrmqkynNndsdPbMKdL4EbAbNxsCBsiyrNzDgNbce3PMjL+6of6REz3KJJHBCIpEA3Vn+rw==}
+  /@udecode/plate-combobox@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-wyLavjSk58xsxp1vBwanRubx47CobjKEYOZY2zU2IHc/uSiPI4ut2Y6reXzEdG7NZYGHVJ2dNWLutFAcUc+NPg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-floating': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-floating': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       downshift: 6.1.12(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3443,59 +3291,26 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-comments@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-Hzc0lF+8LEOebLGkG5JjZt87xP1KKmzxYcDw+3YjiDha66sEEphTcz2hzCiFkMz2WY0ScuFpj+BfshXpXjB92A==}
+  /@udecode/plate-core@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-zd6ZxwDOuazKWGT4DFiQxQ8z3t2xAoBzg3JC5lY+4Xj/By5zjZD/ZmQAAogRWErC4ZNL6SqA2EbHDZij6hNrWg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-button': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-core@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-D5l9EHzg5Lse5FLkpBADjDoQu1uuNqaHSFCKWRfVbKn1aQd2USPfGvQv2jgb21qALVz24NOjm4Kkl7TlLWVf7w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-    dependencies:
-      '@radix-ui/react-slot': 1.0.1(react@18.2.0)
+      '@radix-ui/react-slot': 0.1.2(react@18.2.0)
       '@udecode/zustood': 1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@3.7.2)
       clsx: 1.2.1
       jotai: 1.13.1(react@18.2.0)
       lodash: 4.17.21
-      nanoid: 3.3.6
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-hotkeys-hook: 4.3.8(react-dom@18.2.0)(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      react-hotkeys-hook: 3.4.7(react-dom@18.2.0)(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       use-deep-compare: 1.1.0(react@18.2.0)
       zustand: 3.7.2(react@18.2.0)
     transitivePeerDependencies:
@@ -3514,55 +3329,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-emoji@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-zQaqFO/9m7bo8el6lkO/JszhFhpMwhozndQRy4SnuyFiLX9S3WTIx0l91up+uat/WIaGRarpcHO68E5Wt5x59g==}
+  /@udecode/plate-find-replace@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-VWtXbGdvP1mLu3MA9A7WrZl3rmIxzxOgnezpUCzZiGLsIuCsp87UCaS+e5FTpmxz1Ca7suer0ir2sJ//BErAIQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@emoji-mart/data': 1.1.2
-      '@udecode/plate-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-find-replace@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-jT6OCT19J634BKy4Zl3YXUyjYzs5zWpOYD1oS8yCIQiiY1DPsG2bxBC5VcF9mwyd6Y48kO2EnFtVDhJleJRE/A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3579,22 +3360,22 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-floating@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-XkmNbZJsJsEon3xIn901lhOrdc3dI3LIj2O8htSbfGSTiI/AZMLEh/xqzANF9exITKQ4IoQtAvhCcSdjfiHf8A==}
+  /@udecode/plate-floating@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-i9yHOGsHCaiFEFcqIj7k/8DQufTCqPmCV4seG2xyRqrzMULRgIsLCgogEosRF4mYvYXb04UhTkZ82aN6AfYdSw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
       '@floating-ui/react-dom-interactions': 0.6.6(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3612,21 +3393,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-font@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-5i/5BOnUcAOL5p0dF79+nSn7HFSvof+XQowb++6GKgW5gKdpcaa3gr9WamZs2mJD3bvVWOKUrdOvNWuh0eE4Hg==}
+  /@udecode/plate-font@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-jKAY0nUtwBPGBe1jdPhc2AZvPj1RwZicbG3v9nHQgQpcR/49MAmnR3fF8XV53CBu9LDPypAKvF2CI4V8bnXAJw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3643,21 +3424,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-heading@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-QGGY4gSLh0vTVdBKy/4DtyuYZk3E6O08iqIrLqvJFgEMjGb2yGFaCk2+MknzVjwrPacVodi6IzYpO2H+E8munQ==}
+  /@udecode/plate-heading@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-L6JUgeRFkDL6lrf/CpvOMHrBBDZScJPYrmXhGzdv11MU4f34sllf5C/WLCygMRERKaDZ/CO3wt6/B18nTDTOHA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3674,60 +3455,58 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-headless@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-UhF7fkSv+PGAvnGwBPL0oIKfv0uRwsNYkQ3hD7bs1QgDCrPvTmNYelhiMdm1RLmuX5SJdC5EF3mQDb3W3na7zA==}
+  /@udecode/plate-headless@16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-wR0V4IwjnPXe+yWYDmIDTP7yVI1bXh6kr9iVKp6C2DCXX6+fn/n52KN6DWIth85ze+9KAa6IK1+T87dEifpqDA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.88.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-alignment': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-autoformat': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-basic-elements': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-basic-marks': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-block-quote': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-break': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-button': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-code-block': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-comments': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-emoji': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-find-replace': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-floating': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-font': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-heading': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-highlight': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-horizontal-rule': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-indent': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-indent-list': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-kbd': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-line-height': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-link': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-list': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-media': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-mention': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-node-id': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-normalizers': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-paragraph': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-reset-node': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-select': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-serializer-csv': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-serializer-docx': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-serializer-html': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-serializer-md': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-tabbable': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-table': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-trailing-block': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-alignment': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-autoformat': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-basic-elements': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-basic-marks': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-block-quote': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-break': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-button': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-code-block': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-combobox': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-find-replace': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-floating': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-font': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-heading': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-highlight': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-horizontal-rule': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-indent': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-indent-list': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-kbd': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-line-height': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-link': 16.9.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-list': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-media': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-mention': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-node-id': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-normalizers': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-paragraph': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-reset-node': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-select': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-selection': 16.8.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-serializer-csv': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-serializer-docx': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-serializer-html': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-serializer-md': 16.9.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-table': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-trailing-block': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-hyperscript: 0.77.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-hyperscript: 0.77.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3746,21 +3525,21 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-highlight@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-FyfshKCYfYqQPUy/fk6d0mSu5Yh27aA5+UtBrBN09HiNfHB9Ap0JrEWcY+fOFGN3a2eypMMC9H6QtPZWtepl4g==}
+  /@udecode/plate-highlight@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-Rd7ufUlgDfQPy0AwALpWiQBPS9PLLUZvRdPutE0tJjGAq2YOF71DRVr2nk2CQduhAcg0mmhD4z0guy6ZeJManw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3777,21 +3556,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-horizontal-rule@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-cA3mXakFBmrJCqDqM+RJzlgami1ozkG1CmUFNacVc5IW5oQNFfqLSCrj+xEbq537DZwCZAw2+zyVJvnZ/sgNoQ==}
+  /@udecode/plate-horizontal-rule@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-Gr8wfkIXabdMnNILPdgJzvOcXJF/VTvnky8NbH1JNrmim1n6bZLiSxY+Txo7KhVF0zbGX5UykAujPDzsjPz9ug==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3808,23 +3587,23 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-indent-list@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-qXZYeuo7slq3aVksRW631I7tk3MMhQ03EtvbzIk2YjxpIT4Hcb8DDFzJreyGm0ZUMyQirFiNnCXNWMkC6fbBPw==}
+  /@udecode/plate-indent-list@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-sfRaYiEAqO1hsGHxfDidk1DXkIJOoTiAV5SARSSVdOmLu1m4YYT2Z/tmxMRxwI6ttV+rUjbKtnF1XbliQmWdlA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-indent': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-list': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-indent': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-list': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3841,21 +3620,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-indent@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-uBUvkL37HwSGHFF16HRg/pxyRRgqaKvf22clc2jgNgbMiMsdcuqvGR97KKAmZ4zIRt+mQqZvs3qeG6Ep1q5Ppg==}
+  /@udecode/plate-indent@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-bvhWAUCS539AK4wDBXeYv1gnE6tGukiNOz+laV5urV/9hbHEgMYa5AeA9F9NY1erZtNjy6G+hwZNPh3yrkycWw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3872,21 +3651,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-kbd@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-xvjQuT7uBXZAFST9cDkA85xlAH8kN+nzW76FQDjmcARf+cQd+zbNlaUBNRNggMzR1CVFSK/RrJEfc+LfnLu87A==}
+  /@udecode/plate-kbd@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-V6hYWFBf2LQVAU7Ewf4GmcJElsMrBzNa0fkPwzy8hDmRxG7z2dRJ0HEBK2SUX0UKP8iJv6r6VNklJu96S7U2kg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3903,21 +3682,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-line-height@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-1QqM/NONvaJRh3Kxw3t+oHS+kOxC8JKm+RIRoG9ELAfvBjcwbuz3iI+uTCHqiX54/d4tfk/MLOcClVsrNmkQ5w==}
+  /@udecode/plate-line-height@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-eD4FOcTh3hmh54H0OK2sknc7XQeyQQOij5dAfsEqA88Ycb5d9Ku0o+6dDXcBneh/GVlrUba96bTKZkYWd1zqSA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3934,23 +3713,23 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-link@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-SpJj3ufa/rCM0GHWT+1xZbpwaSw4thCSaZmtCHEfhxOJHqUxFeTrBLgQGV4bS0HRKWoaZauKEyvWdPGxMNvcng==}
+  /@udecode/plate-link@16.9.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-pf2CkH2FP8JDl6ad9yZalYin6VtYmwMgCpFVVbjTMgWrpUUqMkyUtiVboha+B0jL3CS9xuDDhfds9/zYlEWYYg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-button': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-normalizers': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-button': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-normalizers': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3967,22 +3746,22 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-list@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-Y6wk1U7wC9D1dw9GXP252nMeFcEFkQ13v7NZP3JlZJdvLvZJEHEOZW5IDFnxFdul9xx3VJ/qFIbVjZ/ajFxQ5Q==}
+  /@udecode/plate-list@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-TNEzHS0NfYAClV3rNVa7sOD0XGBK7ykwA/uEb/tLom2L0HSyITMJQuTyStLELQ15Yn8Bz4BBfo68h/dPYXKjHg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-reset-node': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-reset-node': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3999,25 +3778,25 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-media@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-khOnujZTqlSxWOHE8mX6O0KjEe3Wgzx/Qe8ODlBNapqhzmtux3zojVTH95TLK81zkIfU9wMIQLbZFVq6teBH8Q==}
+  /@udecode/plate-media@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-EpYA/my8d0z2cBYxlPBtBTC134AOMYV60AH8n3TjnLpFdE69WcS2FjHlueDkt0QvteRlPILlMQ0o2zd7BMPe3Q==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       js-video-url-parser: 0.5.1
       re-resizable: 6.9.9(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-textarea-autosize: 8.4.1(@types/react@18.2.0)(react@18.2.0)
       scriptjs: 2.5.9
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4035,22 +3814,22 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-mention@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-q27yxRJKUmN/NKXHvlOF3gK8DIXOi0hcgmLtLkqQRYBAzruK/Y1HEM9kqq0Gh5Dl65Vh2TTxLwrDxEHOToZAqw==}
+  /@udecode/plate-mention@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-w9+6O1mjd8T/abJyD9XcfFR6nbRTY98nVQ7UYCosp+mr5DQGtRf54KaNv0vWtpdXmy5q2MolKRyu8J7Ot1ZqOA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-combobox': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4068,21 +3847,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-node-id@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-YU52nSjBNZqjNJW/jHW9pGcj89Ann7vQssMoSQOYzKhfatsZHcMoOcp/j5b/RmIXGs1Rhft3FC1a8S6zI+PZPg==}
+  /@udecode/plate-node-id@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-QVEm+mZKqv9zfeFcx1IuW1F+qupR8P7evldoPxmx+nWKYk46mzoN0Zar2+mkiVtzyLS9VMTuNTbsIE975trQPg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4099,21 +3878,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-normalizers@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-dIRIG3wEtrpytlg1AlB1QR0N5f+/I0HoTDD7gnGvDv/llzFluCbkCsUMsjmMDJhBrx4Lc7bbCKbdaouBVw3aSA==}
+  /@udecode/plate-normalizers@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-51o+2ir9yumTjbcMsvLu78PW/e9nXqkiHtM/eIw4QGUXjKDOJf2gAJk447OXLGPBnAn29ucfrSRAwVmAGzlpeg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4130,21 +3909,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-paragraph@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-JJFW53lwIF1r7f8b+RcyJdrl7jRVKBuaQUHXg5OY8loK8fadHsQHjw/+P6HGButgST4JEcmsvm7OhZm5TKRbYQ==}
+  /@udecode/plate-paragraph@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-p44WrWqIrtfJZpjslSjnqh6g9AcajlRs1BiJf6CGU9U5ITNTltUtl9+NL0Miabibgk0Hz1SguFZ7RCVOLWtL1w==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4161,21 +3940,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-reset-node@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-LwCZ9bKj1+oXyimRJB54gTAbjfAYTjskvyWjr2hXFUltBSaHI/JADc9+6tg8v+YtDfj26JLsh7ryurHGJGPPpA==}
+  /@udecode/plate-reset-node@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-ex6WEAAlgMAC4iEFxP3pxmbRPA7lCfMJJQDrJlZBT9VwOdBTSZDLWcjosPI4nYg+7r01frYH75pVwfkGlW/NUA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4192,21 +3971,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-select@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-aR77BIqUK/DZlT/6tMcUzZ9mEbFxyHiiz9vHsRIWypYR1i2GaDqvg0sDH09MZlkEVQef2hhQC1go0M1Br7a9hg==}
+  /@udecode/plate-select@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-W08xMr1UcXU9Kz9rU1CELTXzV9Sw5uBOj8efm7Bfg1jreAwEnGKZUQ9Ctx9JyQ2GgRHTzi69VF2LglSkTFeVwA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4223,23 +4002,55 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-csv@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-dLcfCR5LaQ1qdxrHGhcNLKsnerVb0BqCljmxoHvtDoYjITMX3bcGM+eXaiCO+I+iiJ7VI1ZImbf9vxAr0a7T0w==}
+  /@udecode/plate-selection@16.8.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-0PLuMU8A7ow5qmCio7s4G8WKarXVWO7a2fdt2DWIocdTo99JSCHGaZCzL8XTlyXxoNOCKrfoC297B8gVi3r72A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@viselect/vanilla': 3.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-serializer-csv@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-I+13F+1GcdoTTuC6HAb02nby8W3ATyBsI8eVZzmRccWgEbC5sAQ+pyx/SUZL5asxE6kg4hx7G+TOI0qjIZeeMw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.88.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-table': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-table': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       papaparse: 5.4.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-hyperscript: 0.77.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-hyperscript: 0.77.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4257,29 +4068,29 @@ packages:
       - slate-history
     dev: false
 
-  /@udecode/plate-serializer-docx@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-55QB6lLPZaKzjv1rjkBn2HNaUf58/HtgmTj3CwNryVZkTG41FUG5ZiBEdryYSVrgU9cRGwR+6GOD0sfmTaBGlA==}
+  /@udecode/plate-serializer-docx@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-ZGXMIBT6HQIaDcSCHEatiUW4ekJMAy64wbtCpoByDIKwAliNzIcs2btMFVZkcjN+X1j5PrAfT4WfZ/bPt3NH3Q==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.88.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-heading': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-indent': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-indent-list': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-media': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-paragraph': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-table': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-heading': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-indent': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-indent-list': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-media': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-paragraph': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-table': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-hyperscript: 0.77.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-hyperscript: 0.77.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       validator: 13.9.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -4298,24 +4109,24 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-html@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-JsqQh1mtdh46ks1hDgYZNCyAITxd5l5dA0SvAWYbvY/05i4FZVAGBJS48zMQNWFq+7/FtQDCsEWOedulFOYPIw==}
+  /@udecode/plate-serializer-html@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-AY2OvWLiLbuiubgV9LzagBBdwu9mEvgBH3MLIK19pw6yB01/yPqL0cbVT0HE8YKWG9KutzRcxinoFuNG/5FNAw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.88.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       html-entities: 2.3.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-hyperscript: 0.77.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-hyperscript: 0.77.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4332,28 +4143,29 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-md@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-xQdv1U4dlJpYJJ9LUfgSwjFdSK90rgywlLUEYv1JzEVLddg4slWmemnt2AunjPDMVlu4dhG9XQpOOp3c5R9CWQ==}
+  /@udecode/plate-serializer-md@16.9.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-ceK1KKoRzZbUqptRMEumu+nDUyzi2Riu67QbXKtJAb1FkQ/cyxfyudvMdR+vSHwOsZAoByKnWHts/q0zoXuGew==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-block-quote': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-code-block': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-heading': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-link': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-list': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-paragraph': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-block-quote': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-code-block': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-heading': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-link': 16.9.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-list': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-paragraph': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       remark-parse: 9.0.0
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      remark-slate: 1.8.6
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       unified: 9.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -4372,25 +4184,25 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-styled-components@19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-fDtN8W4iavmicp/Dq5UZVukGkmT35fO4YmK3YBEc0eTupTEjDNfVDLo2CYv4R1O+n6F/Yc24sTByW8KWVCiiNw==}
+  /@udecode/plate-styled-components@16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-wOHvK1wcUjUJRKNIzU2IAskBUycgJ3owlmh5b+1qwgByECjvvzjxISZiDZhnIHJFpx+CfmTreext0HicBAz58g==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
       react-is: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       clsx: 1.2.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.2.0
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4408,22 +4220,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-tabbable@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-SjdH+UpKtmxzrc2yjaULQwp0u3k3l0XxqtOTC8n2gebPw0EAzA3llukxOhwb1oyix8RLFYFBK0t8AweTm8G5NA==}
+  /@udecode/plate-table@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-6GBRw0mpiYwMMnS1XyjOJ2jK7v0C+MlIsExs3P9JjHuIxy4BZKCHF9tBs2RMBJ7vK1hR9wxcwSVI1f9wG+C2nw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      tabbable: 6.1.1
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4440,21 +4251,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-table@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-1tmsQD+l95Y3R+YLaUHXVJunPG0yVM3US/U9dHgNMNfm0UQtB+XKNhYzlBzR46pJoO6OyuXd7pWcIVTRGo9kQg==}
+  /@udecode/plate-trailing-block@16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0):
+    resolution: {integrity: sha512-eaawcb5oCyKfvPBrXmD6J+dXv7+7wypCXqAvDQwbdS/0pckc8SZKT6j6Un2vsticCTZkmtRyEc8+x2RdZLFikg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4471,56 +4282,25 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-trailing-block@19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0):
-    resolution: {integrity: sha512-BNDOAwJ6SvK97V8/nB+APEhPkuIBualS8ZCEN9vZl3LPp9DW0TdRKLueNftj1Fp4X0IjGMyCol9HVndn8Tms4g==}
+  /@udecode/plate-ui-alignment@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-c+thv0uZKmhHN7LDJkVuQJSCg1C4DTrYexYirHT7zu85G9r8G/Brov9vpTnPLDM9P823lo/SkBMaY0qv1Bs2WQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-alignment@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-U7ZeeyTlr8Y7OOfyCVajUiFHKJXg07n2yMtr0YMGiilTMNG1Wp/OnBI32GZ3iMoIIVQWtAdpUzF3MX9jOeGg2A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-alignment': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@udecode/plate-alignment': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4540,24 +4320,24 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-block-quote@19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-mbiClcn3K41sOBD2dAy+Oh1GbIH0bVX5j13AUTFt9khm3pjuF2P8ZVvRX77wEmhygreLHxnLhp1sD1LkUN/5Gg==}
+  /@udecode/plate-ui-block-quote@16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-OgF7cDU/gBiadNCX7J2jqY8P96/RxrJX2JWsv0dEfVfmfArjas4J2vCOXEAVYpz79s77HBkhp3+3kImRQsUyIQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-block-quote': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@udecode/plate-block-quote': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4576,24 +4356,24 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-button@19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-VdTFtxwJ0TXohLPWqn930TkKlk0lBmm/0Unm8wNsJ+7toZpo3B0dTsawQ3tBlDI1PA/dT/IZrgaVZAB1d7jrqQ==}
+  /@udecode/plate-ui-button@16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-19qS5BXtXRm7pnXxVKHbIacSSc9ml/931gU6ll9qim6gJ6wgqGyUXKK03ivpzS0Gk7+5cWbSV1ib5NyGqW8gyA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-button': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@udecode/plate-button': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4612,63 +4392,25 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-code-block@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-bxQlkD7COtVcAH/5vdRS6U8Soc1BgcWELVAiUq2FdpvT7IClk1mPLm7sWe+Qj5eHkQiFI4CS3G4U9XEs6qWzmQ==}
+  /@udecode/plate-ui-code-block@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-MT85/G/m9NGBATLEMImdY7F18V1wCe7CgBlhD7vuwom0diQjbwPEMQ9t7Q5yexiHbzFl+6WOSbjSYPWsLartsQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-code-block': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@udecode/plate-code-block': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-combobox@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-H9DoRkYrU0GkRwdq0QJGoLzY8xYIGNjzuirbc6GFEn9PUOYr4AGX7meePvvK2jHG7q4qWRxRqyRqpcb/IYOSsg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-floating': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4688,26 +4430,25 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-comments@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-1VujbYbRHJ02Z37LssLuR9WweMCQpiU2iNsSIdfs4grOyHTRVQEdD0LJOKiOpHh3VDKflO0thKzIMr4kAxrczg==}
+  /@udecode/plate-ui-combobox@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-NLxW4jG89Xk2Qn01iyKMU8Ae9nXPhbPBeK76Ts5RgxlaqOsfIQDgNysv4yfMm1hYwsmc4cWhT4TYl+OkBqGe7A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-comments': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-button': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@udecode/plate-combobox': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-floating': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4727,23 +4468,23 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-cursor@19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-pq5f990QBpKew7fzgjyZq0KTaCDCgkFvt6a9eixfGCMejoUgKWUe+VxL2P0trJPKtnK1pxVYE0QkSBNuFLPSYQ==}
+  /@udecode/plate-ui-cursor@16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-n4ry53exgKcz1P0NG9kGtfcZo7D5QbrURoRyOG6JYfNKUQ7HTXi5Du1+s9+3lSrs3ILv1BzsmNRSkDLDSvOpQA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4762,478 +4503,477 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-emoji@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-Y4xTNqITiLzcHkBPLhC+OePI4w044VaZvQYEZthEVKgrssfQJhH00AxtR14W0OvvpIzSXGMuFfTDNQgPNwCjQw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-emoji': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-find-replace@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-GEheksQAqEV3vve4pcquohs9ZTTB8lFFvjYA8gjxlrekQZHGNMfIigMaWqb8ZhRwCstTNVAZJ+/K5bKItyoxxw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-find-replace': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-font@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-d2nCllU1uTzfzv0/XjubyVdQOLMLsxNZbkAEA7EJsNjxrnXEBaYY3xxWKSNoRYg6e1/1oYE1oAGa6tiOmqULBQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-font': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-button': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-line-height@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-89Tsmczx4hpSM5xh8iYz/+ELiI5DocDO2mReP1rWYBBu4ToHc2YmF64oK51Swkn71t8/OUDqX0NqSzeTpC6VRQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-line-height': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-link@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-1cDQ2xHOLaK6Rmn72dRL3192Sj2uVoMJhmrw2wQ3toN+tu4o1Avl2U0yDoDTy61ci/DzmgwF3pmr95u802Rmjg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-link': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-button': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-list@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-h+etpvzq523vD0qPpAAgZa0gee0FoVNxTUXFpjgaPEZK9255w4FcaZbNWDaE5ARcGRV3JGpD6bglXpqkFMY6MA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-list': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-media@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-CaKjK1aXHtWyaKqacnpNxlpYsExQg0v6nMgN80OyqBXtwhMHPspEHp4nDYCIp8Eq5BFUiJHN6OSnpgOq+SHLug==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-floating': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-link': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-media': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-link': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      js-video-url-parser: 0.5.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-mention@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-iN2/9gwCjv0igIQaPBNRP0wCUV/RRSsvBFHf482sWmiIJwvvSSXFcRobf0SgVtmonTnHhePHXf9W2qsGitl6Fw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-mention': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-placeholder@19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-n2U1eeWcF71PYt7XxfgctoS+vFn1GMv2fWg9IGWEgfaWzW9hsDQ6kVoz5fwq/Lgb+DUfy3EkPvMMkzbaODRoAg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-table@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-pR3xm9veA3RrJE8LTkTaMoOcCbcFBaGlDr6Uux7qz8l+gwvj9pvfALibqfa+yB2fT+kIkKHAGtuCILfA4g5rJQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-floating': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-table': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-ui-button': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      re-resizable: 6.9.9(react-dom@18.2.0)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-toolbar@19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-owc5eQGDQbWpAq6veJTNTGZr37Y3rr0eM6HTQU0/8vxJdWYvlFXr0VOU8h4V/0hyoJXbavjC5QFxw8IgBmC0mQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-react: '>=0.88.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-core': 19.7.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-floating': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-button': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-use: 17.4.0(react-dom@18.2.0)(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
-      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui@19.7.0(@types/react@18.2.0)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-gfqhxGcZOTMgW10LBJ3R/vF7IiWfIX79kIecbHWV5XtUrKjRlpT9vB9hTX2kFHtHnKXslA6C5mACPq9H98hUvg==}
+  /@udecode/plate-ui-dnd@16.8.0(react-dnd-html5-backend@15.1.2)(react-dnd@15.1.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-0OyDs/CbsWdz7WgrjVqNrrIxKLUDBxT478+HPDytcbJIYaKoexaOwN0IhUmFzy/XZSp8XnfoJMxuVLV43TSFKA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dnd: '>=14.0.0'
       react-dnd-html5-backend: '>=14.0.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.88.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-styled-components': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-alignment': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-block-quote': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-button': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-code-block': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-combobox': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-comments': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-cursor': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-emoji': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-find-replace': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-font': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-line-height': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-link': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-list': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-media': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-mention': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-placeholder': 19.7.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-table': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
-      '@udecode/plate-ui-toolbar': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@react-hook/merged-ref': 1.3.2(react@18.2.0)
+      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
-      react-dnd: 16.0.1(@types/react@18.2.0)(react@18.2.0)
-      react-dnd-html5-backend: 16.0.1
+      react-dnd: 15.1.2(@types/react@18.2.0)(react@18.2.0)
+      react-dnd-html5-backend: 15.1.2
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-hyperscript: 0.77.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      use-context-selector: 1.4.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-find-replace@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-oM+RjCQkzakFdXHJhkXSGtAPIldLkxoUSUAsSqYAa1jg6O0nMNHeD53di++0VhlGwlmqYikk+NAj4uysdZiy9A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-find-replace': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-font@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-9hWHNnBxZLgWYsOaWsu7bqS/a8v5r1jgCnNqqoxfYLZVKTQtheS9/fuOIgfi5koiHklfii+fZ8punaNE/yElSg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-font': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-button': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-line-height@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-mjdaM8eG289hxwA6U2b92BCVSI9LtpGYBndX9GzXLYRqPXvEkBTDOlMAXalOwZj/tUulxdni5P+4GmM2RKSu1A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-line-height': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-link@16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-iHzT3CeHGd9xE2zYmeTBaTRIw7UQbihaV+nnXHWwF/TumCtWfvungGySB55n9P0zJUy71Ye2U++N2M1AYQJBwg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-link': 16.9.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-button': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-list@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-hTXIiNkGhFgcbobJG/gai4kuKXIQAmtkDnACilmq0BKHQ2lzWs6y6qjei+KH3Ku5SSYbYxzX74SyyPv71wrYEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-list': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-media@16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-nuclGmLFJ2wV4nJJ9njhH9zHOGLVU+6Ce96NbjJ2yXF3vw5i4kADsFXXQymvnkbtZ/FPQa4aTi54PMJJ6QTc7Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-floating': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-link': 16.9.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-media': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-link': 16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      js-video-url-parser: 0.5.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-mention@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-wtAt8OHsygQlt1zN7cTJZExeeKbuDXU2PR0stnmUbHw7hpqozvL29MAH3I1ZkcFv7RA5507fKsDawwzbOO2rQA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-combobox': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-mention': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-combobox': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-placeholder@16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-9zM5PE1BtHMLlcRc174YZeMxfvyevQ0VO+PQan29D35gCfiK5BajztznGirhYsJ7Bd/ruHdHeCXq5BnZ6d1KxQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-table@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-VH1Cu+txBQxbhhSoVsf6BC+fw6SKd3IzrT1tPgCVhJsaHnxqzJWoqX/9HZXd+a3vSdH7bQCo7A4VLBRIYVdGqQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-floating': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-table': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-ui-button': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      re-resizable: 6.9.9(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-toolbar@16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-KbUwxVUeFYJGmbVBBoLRv9VJxoveWZS7x6u9+RO7e8F0Yim5Szlg+A1yeF8kHcHNeBbv+4LyAPJOoL94EUkiOg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
+      '@udecode/plate-core': 16.8.0(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-floating': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-button': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-use: 17.4.0(react-dom@18.2.0)(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui@16.9.1(@types/react@18.2.0)(react-dnd-html5-backend@15.1.2)(react-dnd@15.1.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-lxZw1EtfRd4vmcPm9bJgWCisIce4TJ4pPYKydM2r0XvQBpTw7epO2hjuMRaaeg30xf3JUmaTls5GhWjZ4q82nQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dnd: '>=14.0.0'
+      react-dnd-html5-backend: '>=14.0.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.79.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-styled-components': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-alignment': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-block-quote': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-button': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-code-block': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-combobox': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-cursor': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-dnd': 16.8.0(react-dnd-html5-backend@15.1.2)(react-dnd@15.1.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-find-replace': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-font': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-line-height': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-link': 16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-list': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-media': 16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-mention': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-placeholder': 16.8.0(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-table': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      '@udecode/plate-ui-toolbar': 16.8.0(@types/react@18.2.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
+      react: 18.2.0
+      react-dnd: 15.1.2(@types/react@18.2.0)(react@18.2.0)
+      react-dnd-html5-backend: 15.1.2
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-hyperscript: 0.77.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
+      styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -5253,25 +4993,25 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate@19.7.0(@types/react@18.2.0)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9):
-    resolution: {integrity: sha512-0kRTQy4D7zBfoQiVCMyGc9bh/WkzVmhGBQNJJQmsMmm37SPPxumqzaogLkgsWxlqCCl83B4inCcnHP/7gSjR6A==}
+  /@udecode/plate@16.9.1(@types/react@18.2.0)(react-dnd-html5-backend@15.1.2)(react-dnd@15.1.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9):
+    resolution: {integrity: sha512-Gs4atVprE+Y3xaY17fTkeN1SSjHAfowmoDbVR+jLLA8DpdG67/qNUVdIJNO81dLBsi9DMKffqi/eMwAuFf6GsQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.87.0'
-      slate-history: '>=0.86.0'
+      slate: '>=0.78.0'
+      slate-history: '>=0.66.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.88.0'
+      slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 19.7.0(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)
-      '@udecode/plate-ui': 19.7.0(@types/react@18.2.0)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.93.0)(slate@0.93.0)(styled-components@5.3.9)
+      '@udecode/plate-headless': 16.9.1(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)
+      '@udecode/plate-ui': 16.9.1(@types/react@18.2.0)(react-dnd-html5-backend@15.1.2)(react-dnd@15.1.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      slate: 0.93.0
-      slate-history: 0.93.0(slate@0.93.0)
-      slate-hyperscript: 0.77.0(slate@0.93.0)
-      slate-react: 0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0)
+      slate: 0.78.0
+      slate-history: 0.66.0(slate@0.78.0)
+      slate-hyperscript: 0.77.0(slate@0.78.0)
+      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
       styled-components: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -5307,6 +5047,10 @@ packages:
       - react-dom
       - react-native
       - scheduler
+    dev: false
+
+  /@viselect/vanilla@3.2.7:
+    resolution: {integrity: sha512-wzdtrbCrdgBOaS0yqNspbSHg1k8FjEA/coPmFRthDwaE4o+ApK5zVN7lbjZVVNon2O5ZYpaYYVIEctrDJ/Azag==}
     dev: false
 
   /@vitejs/plugin-react@4.0.0(vite@4.3.2):
@@ -5395,13 +5139,13 @@ packages:
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
     dev: false
 
-  /@xstate/immer@0.3.1(immer@9.0.12)(xstate@4.28.1):
+  /@xstate/immer@0.3.1(immer@9.0.21)(xstate@4.28.1):
     resolution: {integrity: sha512-YE+KY08IjEEmXo6XKKpeSGW4j9LfcXw+5JVixLLUO3fWQ3M95joWJ40VtGzx0w0zQSzoCNk8NgfvwWBGSbIaTA==}
     peerDependencies:
       immer: ^9.0.6
       xstate: ^4.29.0
     dependencies:
-      immer: 9.0.12
+      immer: 9.0.21
       xstate: 4.28.1
     dev: false
 
@@ -5698,17 +5442,9 @@ packages:
       - supports-color
     dev: false
 
-  /babel-plugin-styled-components@2.1.1(styled-components@5.3.6):
-    resolution: {integrity: sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==}
-    peerDependencies:
-      styled-components: '>= 2'
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.21.4
-      babel-plugin-syntax-jsx: 6.18.0
-      lodash: 4.17.21
-      picomatch: 2.3.1
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+  /axe-core@4.7.0:
+    resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
+    engines: {node: '>=4'}
     dev: false
 
   /babel-plugin-styled-components@2.1.1(styled-components@5.3.9):
@@ -5732,15 +5468,15 @@ packages:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
     dev: false
 
-  /bail@2.0.2:
-    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
-    dev: false
-
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  /batch-processor@1.0.0:
+    resolution: {integrity: sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==}
+    dev: false
 
   /better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -5867,7 +5603,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.3
-    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -5899,10 +5634,6 @@ packages:
 
   /caniuse-lite@1.0.30001447:
     resolution: {integrity: sha512-bdKU1BQDPeEXe9A39xJnGtY0uRq/z5osrnXUw0TcK+EYno45Y+U7QU9HhHEyzvMDffpYadFXi3idnSNkcwLkTw==}
-    dev: false
-
-  /ccount@2.0.1:
-    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: false
 
   /chai@4.3.7:
@@ -5947,10 +5678,6 @@ packages:
 
   /character-entities@1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
-
-  /character-entities@2.0.2:
-    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
-    dev: false
 
   /character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
@@ -6147,6 +5874,11 @@ packages:
       toggle-selection: 1.0.6
     dev: false
 
+  /core-js@3.30.2:
+    resolution: {integrity: sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==}
+    requiresBuild: true
+    dev: false
+
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: false
@@ -6300,12 +6032,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /decode-named-character-reference@1.0.2:
-    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
-    dependencies:
-      character-entities: 2.0.2
-    dev: false
-
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
@@ -6389,11 +6115,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-    dev: false
-
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -6411,6 +6132,7 @@ packages:
   /diff@5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
+    dev: true
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -6436,11 +6158,11 @@ packages:
       redux: 4.2.1
     dev: false
 
-  /dnd-core@16.0.1:
-    resolution: {integrity: sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==}
+  /dnd-core@15.1.2:
+    resolution: {integrity: sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==}
     dependencies:
-      '@react-dnd/asap': 5.0.2
-      '@react-dnd/invariant': 4.0.2
+      '@react-dnd/asap': 4.0.1
+      '@react-dnd/invariant': 3.0.1
       redux: 4.2.1
     dev: false
 
@@ -6469,6 +6191,10 @@ packages:
       domhandler: 5.0.3
       entities: 4.4.0
     dev: true
+
+  /dom-walk@0.1.2:
+    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+    dev: false
 
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
@@ -6516,6 +6242,12 @@ packages:
 
   /electron-to-chromium@1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+    dev: false
+
+  /element-resize-detector@1.2.4:
+    resolution: {integrity: sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==}
+    dependencies:
+      batch-processor: 1.0.0
     dev: false
 
   /emoji-regex@8.0.0:
@@ -6723,11 +6455,6 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
     dev: true
-
-  /escape-string-regexp@5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
-    dev: false
 
   /eslint-config-prettier@8.8.0(eslint@8.39.0):
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
@@ -7259,7 +6986,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: true
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -7314,22 +7040,28 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /framer-motion@10.12.4(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-9gLtv8T6dui0tujHROR+VM3kdJyKiFCFiD94IQE+0OuX6LaIyXtdVpviokVdrHSb1giWhmmX4yzoucALMx6mtw==}
+  /framer-motion@6.5.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
     peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
+      react: '>=16.8 || ^17.0.0 || ^18.0.0'
+      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
     dependencies:
+      '@motionone/dom': 10.12.0
+      framesync: 6.0.1
+      hey-listen: 1.0.8
+      popmotion: 11.0.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      style-value-types: 5.0.0
       tslib: 2.5.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
+    dev: false
+
+  /framesync@6.0.1:
+    resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
+    dependencies:
+      tslib: 2.5.0
     dev: false
 
   /fs-constants@1.0.0:
@@ -7418,7 +7150,6 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
-    dev: true
 
   /get-intrinsic@1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
@@ -7477,6 +7208,13 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  /global@4.4.0:
+    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
+    dependencies:
+      min-document: 2.19.0
+      process: 0.11.10
+    dev: false
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -7570,14 +7308,12 @@ packages:
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -7594,6 +7330,10 @@ packages:
     resolution: {integrity: sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==}
     dev: true
 
+  /hey-listen@1.0.8:
+    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+    dev: false
+
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -7603,6 +7343,10 @@ packages:
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
+
+  /hotkeys-js@3.9.4:
+    resolution: {integrity: sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q==}
+    dev: false
 
   /html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
@@ -7666,10 +7410,6 @@ packages:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
     engines: {node: '>= 4'}
     dev: true
-
-  /immer@9.0.12:
-    resolution: {integrity: sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==}
-    dev: false
 
   /immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
@@ -7760,6 +7500,12 @@ packages:
       '@formatjs/fast-memoize': 2.0.1
       '@formatjs/icu-messageformat-parser': 2.3.0
       tslib: 2.5.0
+    dev: false
+
+  /invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+    dependencies:
+      loose-envify: 1.4.0
     dev: false
 
   /ipaddr.js@1.9.1:
@@ -7890,6 +7636,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-function@1.0.2:
+    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
+    dev: false
+
   /is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
@@ -7908,10 +7658,6 @@ packages:
 
   /is-hotkey@0.1.8:
     resolution: {integrity: sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ==}
-    dev: false
-
-  /is-hotkey@0.2.0:
-    resolution: {integrity: sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==}
     dev: false
 
   /is-inside-container@1.0.0:
@@ -7966,11 +7712,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
-    dev: false
-
   /is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
@@ -7982,7 +7723,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-set@2.0.2:
     resolution: {integrity: sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==}
@@ -8023,7 +7763,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /is-typed-array@1.1.10:
     resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
@@ -8084,6 +7823,11 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  /isobject@4.0.0:
+    resolution: {integrity: sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -8297,6 +8041,7 @@ packages:
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -8353,7 +8098,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
-    dev: true
 
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -8412,10 +8156,6 @@ packages:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
     dev: true
-
-  /longest-streak@3.1.0:
-    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-    dev: false
 
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -8494,8 +8234,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /markdown-table@3.0.3:
-    resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
+  /map-or-similar@1.5.0:
+    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
     dev: false
 
   /md5-hex@3.0.1:
@@ -8504,15 +8244,6 @@ packages:
     dependencies:
       blueimp-md5: 2.19.0
     dev: true
-
-  /mdast-util-find-and-replace@2.2.2:
-    resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      escape-string-regexp: 5.0.0
-      unist-util-is: 5.2.1
-      unist-util-visit-parents: 5.1.3
-    dev: false
 
   /mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
@@ -8525,112 +8256,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /mdast-util-from-markdown@1.3.0:
-    resolution: {integrity: sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      '@types/unist': 2.0.6
-      decode-named-character-reference: 1.0.2
-      mdast-util-to-string: 3.2.0
-      micromark: 3.1.0
-      micromark-util-decode-numeric-character-reference: 1.0.0
-      micromark-util-decode-string: 1.0.2
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      unist-util-stringify-position: 3.0.3
-      uvu: 0.5.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /mdast-util-gfm-autolink-literal@1.0.3:
-    resolution: {integrity: sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      ccount: 2.0.1
-      mdast-util-find-and-replace: 2.2.2
-      micromark-util-character: 1.1.0
-    dev: false
-
-  /mdast-util-gfm-footnote@1.0.2:
-    resolution: {integrity: sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      mdast-util-to-markdown: 1.5.0
-      micromark-util-normalize-identifier: 1.0.0
-    dev: false
-
-  /mdast-util-gfm-strikethrough@1.0.3:
-    resolution: {integrity: sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      mdast-util-to-markdown: 1.5.0
-    dev: false
-
-  /mdast-util-gfm-table@1.0.7:
-    resolution: {integrity: sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      markdown-table: 3.0.3
-      mdast-util-from-markdown: 1.3.0
-      mdast-util-to-markdown: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /mdast-util-gfm-task-list-item@1.0.2:
-    resolution: {integrity: sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      mdast-util-to-markdown: 1.5.0
-    dev: false
-
-  /mdast-util-gfm@2.0.2:
-    resolution: {integrity: sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==}
-    dependencies:
-      mdast-util-from-markdown: 1.3.0
-      mdast-util-gfm-autolink-literal: 1.0.3
-      mdast-util-gfm-footnote: 1.0.2
-      mdast-util-gfm-strikethrough: 1.0.3
-      mdast-util-gfm-table: 1.0.7
-      mdast-util-gfm-task-list-item: 1.0.2
-      mdast-util-to-markdown: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /mdast-util-phrasing@3.0.1:
-    resolution: {integrity: sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      unist-util-is: 5.2.1
-    dev: false
-
-  /mdast-util-to-markdown@1.5.0:
-    resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      '@types/unist': 2.0.6
-      longest-streak: 3.1.0
-      mdast-util-phrasing: 3.0.1
-      mdast-util-to-string: 3.2.0
-      micromark-util-decode-string: 1.0.2
-      unist-util-visit: 4.1.2
-      zwitch: 2.0.4
-    dev: false
-
   /mdast-util-to-string@2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
 
-  /mdast-util-to-string@3.2.0:
-    resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
-    dependencies:
-      '@types/mdast': 3.0.11
-    dev: false
-
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    dev: false
+
+  /memoizerific@1.11.3:
+    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
+    dependencies:
+      map-or-similar: 1.5.0
     dev: false
 
   /meow@6.1.1:
@@ -8662,231 +8298,6 @@ packages:
     resolution: {integrity: sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==}
     dev: true
 
-  /micromark-core-commonmark@1.0.6:
-    resolution: {integrity: sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==}
-    dependencies:
-      decode-named-character-reference: 1.0.2
-      micromark-factory-destination: 1.0.0
-      micromark-factory-label: 1.0.2
-      micromark-factory-space: 1.0.0
-      micromark-factory-title: 1.0.2
-      micromark-factory-whitespace: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-chunked: 1.0.0
-      micromark-util-classify-character: 1.0.0
-      micromark-util-html-tag-name: 1.1.0
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-resolve-all: 1.0.0
-      micromark-util-subtokenize: 1.0.2
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-extension-gfm-autolink-literal@1.0.3:
-    resolution: {integrity: sha512-i3dmvU0htawfWED8aHMMAzAVp/F0Z+0bPh3YrbTPPL1v4YAlCZpy5rBO5p0LPYiZo0zFVkoYh7vDU7yQSiCMjg==}
-    dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-sanitize-uri: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-extension-gfm-footnote@1.1.0:
-    resolution: {integrity: sha512-RWYce7j8+c0n7Djzv5NzGEGitNNYO3uj+h/XYMdS/JinH1Go+/Qkomg/rfxExFzYTiydaV6GLeffGO5qcJbMPA==}
-    dependencies:
-      micromark-core-commonmark: 1.0.6
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-sanitize-uri: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-extension-gfm-strikethrough@1.0.5:
-    resolution: {integrity: sha512-X0oI5eYYQVARhiNfbETy7BfLSmSilzN1eOuoRnrf9oUNsPRrWOAe9UqSizgw1vNxQBfOwL+n2610S3bYjVNi7w==}
-    dependencies:
-      micromark-util-chunked: 1.0.0
-      micromark-util-classify-character: 1.0.0
-      micromark-util-resolve-all: 1.0.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-extension-gfm-table@1.0.5:
-    resolution: {integrity: sha512-xAZ8J1X9W9K3JTJTUL7G6wSKhp2ZYHrFk5qJgY/4B33scJzE2kpfRL6oiw/veJTbt7jiM/1rngLlOKPWr1G+vg==}
-    dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-extension-gfm-tagfilter@1.0.2:
-    resolution: {integrity: sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==}
-    dependencies:
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-extension-gfm-task-list-item@1.0.4:
-    resolution: {integrity: sha512-9XlIUUVnYXHsFF2HZ9jby4h3npfX10S1coXTnV035QGPgrtNYQq3J6IfIvcCIUAJrrqBVi5BqA/LmaOMJqPwMQ==}
-    dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-extension-gfm@2.0.1:
-    resolution: {integrity: sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==}
-    dependencies:
-      micromark-extension-gfm-autolink-literal: 1.0.3
-      micromark-extension-gfm-footnote: 1.1.0
-      micromark-extension-gfm-strikethrough: 1.0.5
-      micromark-extension-gfm-table: 1.0.5
-      micromark-extension-gfm-tagfilter: 1.0.2
-      micromark-extension-gfm-task-list-item: 1.0.4
-      micromark-util-combine-extensions: 1.0.0
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-factory-destination@1.0.0:
-    resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
-    dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-factory-label@1.0.2:
-    resolution: {integrity: sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==}
-    dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-factory-space@1.0.0:
-    resolution: {integrity: sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==}
-    dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-factory-title@1.0.2:
-    resolution: {integrity: sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==}
-    dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-factory-whitespace@1.0.0:
-    resolution: {integrity: sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==}
-    dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-util-character@1.1.0:
-    resolution: {integrity: sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==}
-    dependencies:
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-util-chunked@1.0.0:
-    resolution: {integrity: sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==}
-    dependencies:
-      micromark-util-symbol: 1.0.1
-    dev: false
-
-  /micromark-util-classify-character@1.0.0:
-    resolution: {integrity: sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==}
-    dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-util-combine-extensions@1.0.0:
-    resolution: {integrity: sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==}
-    dependencies:
-      micromark-util-chunked: 1.0.0
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-util-decode-numeric-character-reference@1.0.0:
-    resolution: {integrity: sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==}
-    dependencies:
-      micromark-util-symbol: 1.0.1
-    dev: false
-
-  /micromark-util-decode-string@1.0.2:
-    resolution: {integrity: sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==}
-    dependencies:
-      decode-named-character-reference: 1.0.2
-      micromark-util-character: 1.1.0
-      micromark-util-decode-numeric-character-reference: 1.0.0
-      micromark-util-symbol: 1.0.1
-    dev: false
-
-  /micromark-util-encode@1.0.1:
-    resolution: {integrity: sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==}
-    dev: false
-
-  /micromark-util-html-tag-name@1.1.0:
-    resolution: {integrity: sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==}
-    dev: false
-
-  /micromark-util-normalize-identifier@1.0.0:
-    resolution: {integrity: sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==}
-    dependencies:
-      micromark-util-symbol: 1.0.1
-    dev: false
-
-  /micromark-util-resolve-all@1.0.0:
-    resolution: {integrity: sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==}
-    dependencies:
-      micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-util-sanitize-uri@1.1.0:
-    resolution: {integrity: sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==}
-    dependencies:
-      micromark-util-character: 1.1.0
-      micromark-util-encode: 1.0.1
-      micromark-util-symbol: 1.0.1
-    dev: false
-
-  /micromark-util-subtokenize@1.0.2:
-    resolution: {integrity: sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==}
-    dependencies:
-      micromark-util-chunked: 1.0.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    dev: false
-
-  /micromark-util-symbol@1.0.1:
-    resolution: {integrity: sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==}
-    dev: false
-
-  /micromark-util-types@1.0.2:
-    resolution: {integrity: sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==}
-    dev: false
-
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
@@ -8894,30 +8305,6 @@ packages:
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
-
-  /micromark@3.1.0:
-    resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}
-    dependencies:
-      '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@5.5.0)
-      decode-named-character-reference: 1.0.2
-      micromark-core-commonmark: 1.0.6
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-chunked: 1.0.0
-      micromark-util-combine-extensions: 1.0.0
-      micromark-util-decode-numeric-character-reference: 1.0.0
-      micromark-util-encode: 1.0.1
-      micromark-util-normalize-identifier: 1.0.0
-      micromark-util-resolve-all: 1.0.0
-      micromark-util-sanitize-uri: 1.1.0
-      micromark-util-subtokenize: 1.0.2
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -8935,15 +8322,16 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /min-document@2.19.0:
+    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
+    dependencies:
+      dom-walk: 0.1.2
+    dev: false
+
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
     dev: true
-
-  /mini-svg-data-uri@1.4.4:
-    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
-    hasBin: true
-    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -9007,11 +8395,6 @@ packages:
     resolution: {integrity: sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==}
     engines: {node: '>=12.0.0'}
     dev: true
-
-  /mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-    dev: false
 
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
@@ -9202,7 +8585,6 @@ packages:
 
   /object-inspect@1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
-    dev: true
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -9353,7 +8735,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
-    dev: true
 
   /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -9374,7 +8755,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
-    dev: true
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -9391,7 +8771,6 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /papaparse@5.4.1:
     resolution: {integrity: sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==}
@@ -9431,7 +8810,6 @@ packages:
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -9541,6 +8919,15 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
     dev: true
+
+  /popmotion@11.0.3:
+    resolution: {integrity: sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==}
+    dependencies:
+      framesync: 6.0.1
+      hey-listen: 1.0.8
+      style-value-types: 5.0.0
+      tslib: 2.5.0
+    dev: false
 
   /postcss-import@14.1.0(postcss@8.4.21):
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
@@ -9706,6 +9093,13 @@ packages:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
 
+  /qs@6.11.1:
+    resolution: {integrity: sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -9765,14 +9159,8 @@ packages:
       dnd-core: 15.1.1
     dev: false
 
-  /react-dnd-html5-backend@16.0.1:
-    resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
-    dependencies:
-      dnd-core: 16.0.1
-    dev: false
-
-  /react-dnd@16.0.1(@types/react@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
+  /react-dnd@15.1.2(@types/react@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==}
     peerDependencies:
       '@types/hoist-non-react-statics': '>= 3.3.1'
       '@types/node': '>= 12'
@@ -9786,10 +9174,10 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@react-dnd/invariant': 4.0.2
-      '@react-dnd/shallowequal': 4.0.2
+      '@react-dnd/invariant': 3.0.1
+      '@react-dnd/shallowequal': 3.0.1
       '@types/react': 18.2.0
-      dnd-core: 16.0.1
+      dnd-core: 15.1.2
       fast-deep-equal: 3.1.3
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
@@ -9808,12 +9196,13 @@ packages:
     resolution: {integrity: sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==}
     dev: false
 
-  /react-hotkeys-hook@4.3.8(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-RmrIQ3M259c84MnYVEAQsmHkD6s7XUgLG0rW6S7qjt1Lh7q+SPIz5b6obVU8OJw1Utsj1mUCj6twtBPaK/ytww==}
+  /react-hotkeys-hook@3.4.7(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+bbPmhPAl6ns9VkXkNNyxlmCAIyDAcWbB76O4I0ntr3uWCRuIQf/aRLartUahe9chVMPj+OEzzfk3CQSjclUEQ==}
     peerDependencies:
       react: '>=16.8.1'
       react-dom: '>=16.8.1'
     dependencies:
+      hotkeys-js: 3.9.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -9857,18 +9246,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-textarea-autosize@8.4.0(@types/react@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  /react-sizeme@3.0.2:
+    resolution: {integrity: sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==}
     dependencies:
-      '@babel/runtime': 7.21.0
-      react: 18.2.0
-      use-composed-ref: 1.3.0(react@18.2.0)
-      use-latest: 1.2.1(@types/react@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
+      element-resize-detector: 1.2.4
+      invariant: 2.2.4
+      shallowequal: 1.1.0
+      throttle-debounce: 3.0.1
     dev: false
 
   /react-textarea-autosize@8.4.1(@types/react@18.2.0)(react@18.2.0):
@@ -10070,33 +9454,19 @@ packages:
       jsesc: 0.5.0
     dev: true
 
-  /remark-gfm@3.0.1:
-    resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      mdast-util-gfm: 2.0.2
-      micromark-extension-gfm: 2.0.1
-      unified: 10.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /remark-parse@10.0.1:
-    resolution: {integrity: sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==}
-    dependencies:
-      '@types/mdast': 3.0.11
-      mdast-util-from-markdown: 1.3.0
-      unified: 10.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /remark-parse@9.0.0:
     resolution: {integrity: sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==}
     dependencies:
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /remark-slate@1.8.6:
+    resolution: {integrity: sha512-1Gmt5MGw25MRVP+0xTXqw9JQDWfRNWujD4YFCPg036a9DZYhn7mLFjM6jreHB+9hKa6RCMOm5thiXznAmdn8Ug==}
+    dependencies:
+      '@types/escape-html': 1.0.2
+      escape-html: 1.0.3
     dev: false
 
   /require-directory@2.1.1:
@@ -10224,13 +9594,6 @@ packages:
       tslib: 2.5.0
     dev: true
 
-  /sade@1.8.1:
-    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
-    engines: {node: '>=6'}
-    dependencies:
-      mri: 1.2.0
-    dev: false
-
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
     dev: false
@@ -10351,7 +9714,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.1.3
       object-inspect: 1.12.2
-    dev: true
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -10389,26 +9751,26 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /slate-history@0.93.0(slate@0.93.0):
-    resolution: {integrity: sha512-Gr1GMGPipRuxIz41jD2/rbvzPj8eyar56TVMyJBvBeIpQSSjNISssvGNDYfJlSWM8eaRqf6DAcxMKzsLCYeX6g==}
+  /slate-history@0.66.0(slate@0.78.0):
+    resolution: {integrity: sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:
       is-plain-object: 5.0.0
-      slate: 0.93.0
+      slate: 0.78.0
     dev: false
 
-  /slate-hyperscript@0.77.0(slate@0.93.0):
+  /slate-hyperscript@0.77.0(slate@0.78.0):
     resolution: {integrity: sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:
       is-plain-object: 5.0.0
-      slate: 0.93.0
+      slate: 0.78.0
     dev: false
 
-  /slate-react@0.88.0(react-dom@18.2.0)(react@18.2.0)(slate@0.87.0):
-    resolution: {integrity: sha512-hmrl7VZAAdOUlReI/EkI2GuRSLWuQFD+n9ZZaVqSUMjJR3T/MGNMPsJQAfrjgke2+xf4LIGEDGWZHKbUFK1hhw==}
+  /slate-react@0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0):
+    resolution: {integrity: sha512-uPzYArGwHKq4QvpzRvP/DVvsDgB2Zw6x9Som/hJWaydu18r0Vp2vmgHL0Dbc4EU6pUNV6o83XbBJLLEwISzBHQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -10423,41 +9785,12 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 2.2.31
-      slate: 0.87.0
+      slate: 0.78.0
       tiny-invariant: 1.0.6
     dev: false
 
-  /slate-react@0.93.0(react-dom@18.2.0)(react@18.2.0)(slate@0.93.0):
-    resolution: {integrity: sha512-yzQYA91N7ELA8295TsY/Nig2sOq7mhi4HuvqX/Ay1jjs+Pnp8+BTYpIzmi9ruvnwovdwtDm+pdNO8LzPeJaKcQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.65.3'
-    dependencies:
-      '@juggle/resize-observer': 3.4.0
-      '@types/is-hotkey': 0.1.7
-      '@types/lodash': 4.14.192
-      direction: 1.0.4
-      is-hotkey: 0.1.8
-      is-plain-object: 5.0.0
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      scroll-into-view-if-needed: 2.2.31
-      slate: 0.93.0
-      tiny-invariant: 1.0.6
-    dev: false
-
-  /slate@0.87.0:
-    resolution: {integrity: sha512-m+IWERpdtb7Zna09MxHlUYIAoo4WVdxp2fSf7c+jSV9pDmJ4QvUTuHghX/TVrxtr+8BKGhyQCWIerZt32B1Ysg==}
-    dependencies:
-      immer: 9.0.21
-      is-plain-object: 5.0.0
-      tiny-warning: 1.0.3
-    dev: false
-
-  /slate@0.93.0:
-    resolution: {integrity: sha512-80IktTrGJU9/MzOp8T4fgXfMMedeG1qx0Y/EiABd68Qm9iFgJ9khnAt8clDfYyFDTs7erXJpjbQoZnV0XKuqfA==}
+  /slate@0.78.0:
+    resolution: {integrity: sha512-VwQ0RafT3JPf9SFrXI02Dh3S4Iz9en7d1nn50C/LJjjqjfgv+a2ORbgWMdYjhycPYldaxJwcI3OpP9D1g4SXEg==}
     dependencies:
       immer: 9.0.21
       is-plain-object: 5.0.0
@@ -10578,6 +9911,10 @@ packages:
     dependencies:
       internal-slot: 1.0.4
     dev: true
+
+  /store2@2.14.2:
+    resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
+    dev: false
 
   /stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
@@ -10702,28 +10039,11 @@ packages:
     resolution: {integrity: sha512-IgTveO0OGXMMi9iZtfPoYQY6IpeZR3ILtSsjMapFgLxofWaHG1sNlInV7yTRDV06YiNdwiKrK7505Fxq8ly+YA==}
     dev: false
 
-  /styled-components@5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==}
-    engines: {node: '>=10'}
-    requiresBuild: true
-    peerDependencies:
-      react: '>= 16.8.0'
-      react-dom: '>= 16.8.0'
-      react-is: '>= 16.8.0'
+  /style-value-types@5.0.0:
+    resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
     dependencies:
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/traverse': 7.21.4(supports-color@5.5.0)
-      '@emotion/is-prop-valid': 1.2.0
-      '@emotion/stylis': 0.8.5
-      '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.1(styled-components@5.3.6)
-      css-to-react-native: 3.2.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
-      shallowequal: 1.1.0
-      supports-color: 5.5.0
+      hey-listen: 1.0.8
+      tslib: 2.5.0
     dev: false
 
   /styled-components@5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
@@ -10784,10 +10104,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /tabbable@6.1.1:
-    resolution: {integrity: sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==}
-    dev: false
-
   /tailwindcss@3.3.1(postcss@8.4.21):
     resolution: {integrity: sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==}
     engines: {node: '>=12.13.0'}
@@ -10832,6 +10148,19 @@ packages:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.0
+    dev: false
+
+  /telejson@6.0.8:
+    resolution: {integrity: sha512-nerNXi+j8NK1QEfBHtZUN/aLdDcyupA//9kAboYLrtzZlPLpUfqbVGWb9zz91f/mIjRbAYhbgtnJHY8I1b5MBg==}
+    dependencies:
+      '@types/is-function': 1.0.1
+      global: 4.4.0
+      is-function: 1.0.2
+      is-regex: 1.1.4
+      is-symbol: 1.0.4
+      isobject: 4.0.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
     dev: false
 
   /term-size@2.2.1:
@@ -10966,8 +10295,9 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: false
 
-  /trough@2.1.0:
-    resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+  /ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
     dev: false
 
   /ts-easing@0.2.0:
@@ -11126,18 +10456,6 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /unified@10.1.2:
-    resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
-    dependencies:
-      '@types/unist': 2.0.6
-      bail: 2.0.2
-      extend: 3.0.2
-      is-buffer: 2.0.5
-      is-plain-obj: 4.1.0
-      trough: 2.1.0
-      vfile: 5.3.7
-    dev: false
-
   /unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
     dependencies:
@@ -11150,37 +10468,10 @@ packages:
       vfile: 4.2.1
     dev: false
 
-  /unist-util-is@5.2.1:
-    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
-    dependencies:
-      '@types/unist': 2.0.6
-    dev: false
-
   /unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
       '@types/unist': 2.0.6
-
-  /unist-util-stringify-position@3.0.3:
-    resolution: {integrity: sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==}
-    dependencies:
-      '@types/unist': 2.0.6
-    dev: false
-
-  /unist-util-visit-parents@5.1.3:
-    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-is: 5.2.1
-    dev: false
-
-  /unist-util-visit@4.1.2:
-    resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-is: 5.2.1
-      unist-util-visit-parents: 5.1.3
-    dev: false
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -11304,17 +10595,6 @@ packages:
       which-typed-array: 1.1.9
     dev: true
 
-  /uvu@0.5.6:
-    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      dequal: 2.0.3
-      diff: 5.1.0
-      kleur: 4.1.5
-      sade: 1.8.1
-    dev: false
-
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
@@ -11346,13 +10626,6 @@ packages:
       unist-util-stringify-position: 2.0.3
     dev: false
 
-  /vfile-message@3.1.4:
-    resolution: {integrity: sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==}
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-stringify-position: 3.0.3
-    dev: false
-
   /vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
     dependencies:
@@ -11360,15 +10633,6 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
-    dev: false
-
-  /vfile@5.3.7:
-    resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
-    dependencies:
-      '@types/unist': 2.0.6
-      is-buffer: 2.0.5
-      unist-util-stringify-position: 3.0.3
-      vfile-message: 3.1.4
     dev: false
 
   /vite-node@0.30.1(@types/node@18.15.11):
@@ -11891,8 +11155,4 @@ packages:
         optional: true
     dependencies:
       react: 18.2.0
-    dev: false
-
-  /zwitch@2.0.4:
-    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false


### PR DESCRIPTION
Get's rid of the old fondue version which results in an error when a block is being served with react 18.