### PR TITLE
WIP | POC: Commands API: Dispatch based method calls for App Bridge events [#8677xch6z]

### DIFF
--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -14,9 +14,12 @@ import type {
     Template,
     User,
 } from './types';
-import { PrivacySettings } from './types/PrivacySettings';
+import { PrivacySettings } from './types';
+import { DispatchActions, DispatchPayload, EventResponse } from './types/AppBridgeBlock';
 
 export interface AppBridgeBlock extends AppBridgeBase {
+    dispatch(eventName: DispatchActions, payload?: DispatchPayload): EventResponse;
+
     getBlockId(): number;
 
     getSectionId(): number | undefined;

--- a/packages/app-bridge/src/react/useAssetChooser.spec.tsx
+++ b/packages/app-bridge/src/react/useAssetChooser.spec.tsx
@@ -1,14 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { cleanup, render } from '@testing-library/react';
 import React from 'react';
 import sinon from 'sinon';
 import { afterEach, describe, it } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
-
-import type { Asset } from '../types/Asset';
 import { AppBridgeBlock } from '../AppBridgeBlock';
+import { withAppBridgeBlockStubs } from '../tests';
+
+import type { Asset } from '../types';
 import { useAssetChooser } from './useAssetChooser';
-import { withAppBridgeBlockStubs } from '../tests/withAppBridgeBlockStubs';
 
 const OPEN_ASSET_CHOOSER_BUTTON_ID = 'open-asset-chooser';
 const CLOSE_ASSET_CHOOSER_BUTTON_ID = 'close-asset-chooser';

--- a/packages/app-bridge/src/react/useBlockSettings.ts
+++ b/packages/app-bridge/src/react/useBlockSettings.ts
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useEffect, useState } from 'react';
-
-import { mergeDeep } from '../utilities/object';
 import type { AppBridgeBlock } from '../AppBridgeBlock';
+
+import { mergeDeep } from '../utilities';
 
 export type BlockSettingsUpdateEvent<T = Record<string, unknown>> = {
     blockId: number;

--- a/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
@@ -81,6 +81,9 @@ export const getAppBridgeBlockStub = ({
                 return assetsDiff;
             }, {});
         }),
+        'AppBridge:OnBlockSettingsUpdated': stub<Parameters<AppBridgeBlock['dispatch']>>(),
+        'AppBridge:OffBlockSettingsUpdated': stub<Parameters<AppBridgeBlock['dispatch']>>(),
+        'AppBridge:BlockSettingsUpdated': stub<Parameters<AppBridgeBlock['dispatch']>>(),
     };
 
     const dispatchCallStub = stub<Parameters<AppBridgeBlock['dispatch']>>();

--- a/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
@@ -87,9 +87,9 @@ export const getAppBridgeBlockStub = ({
     };
 
     const dispatchCallStub = stub<Parameters<AppBridgeBlock['dispatch']>>();
-    for (const action of DISPATCH_CALL_ACTIONS) {
-        dispatchCallStub.withArgs(action).set(dispatchReturnStubs[action]);
-    }
+    // for (const action of DISPATCH_CALL_ACTIONS) {
+    //     dispatchCallStub.withArgs(action).set(dispatchReturnStubs[action]);
+    // }
 
     return {
         dispatch: dispatchCallStub,

--- a/packages/app-bridge/src/types/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/types/AppBridgeBlock.ts
@@ -1,0 +1,34 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { BlockSettingsUpdateEvent } from '../react';
+import { Asset } from './Asset';
+import { AssetChooserOptions } from './Terrific';
+
+export type DispatchActions =
+    | 'openAssetChooser'
+    | 'closeAssetChooser'
+    | 'getBlockAssets'
+    | 'AppBridge:OnBlockSettingsUpdated'
+    | 'AppBridge:OffBlockSettingsUpdated'
+    | 'AppBridge:BlockSettingsUpdated';
+
+export type OpenAssetChooserPayload = {
+    callback: (selectedAssets: Asset[]) => void;
+    options?: AssetChooserOptions;
+};
+
+export type UpdateBlockSettingsFromEventCallback = (event: BlockSettingsUpdateEvent) => void;
+
+export type BlockSettingsUpdatedEventPayload = {
+    blockId: number;
+    blockSettings: Record<string, unknown>;
+};
+
+export type BlockAssets = Record<string, Asset[]>;
+
+export type DispatchPayload =
+    | OpenAssetChooserPayload
+    | UpdateBlockSettingsFromEventCallback
+    | BlockSettingsUpdatedEventPayload;
+
+export type EventResponse = Promise<BlockAssets> | BlockSettingsUpdateEvent | void;


### PR DESCRIPTION
- A backward-compatible alternative to the present Commands API (unlike #412) 
- Adds a `dispatch` method, accepting all events with the expected payload and returning event update data, where necessary