### PR TITLE
chore(guideline-block-settings): update sidebar settings

### DIFF
--- a/.changeset/five-mails-yell.md
+++ b/.changeset/five-mails-yell.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+Update @frontify/sidebar-settings to the latest version

--- a/packages/guideline-blocks-settings/package.json
+++ b/packages/guideline-blocks-settings/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.66",
-        "@frontify/sidebar-settings": "^0.3.3"
+        "@frontify/sidebar-settings": "^0.3.4"
     },
     "peerDependencies": {
         "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
         specifier: ^3.0.0-beta.66
         version: link:../app-bridge
       '@frontify/sidebar-settings':
-        specifier: ^0.3.3
+        specifier: ^0.3.4
         version: link:../sidebar-settings
     devDependencies:
       '@frontify/eslint-config-typescript':


### PR DESCRIPTION
Updates `@frontify/sidebar-settings` to have react 18 support