### PR TITLE
feat(sidebarSettings): add hasSwitch type to sectionHeading

### DIFF
--- a/.changeset/chilly-vans-develop.md
+++ b/.changeset/chilly-vans-develop.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": minor
+---
+
+Updated types of sectionHeading settings block

--- a/packages/sidebar-settings/src/blocks/sectionHeading.ts
+++ b/packages/sidebar-settings/src/blocks/sectionHeading.ts
@@ -13,4 +13,10 @@ export type SectionHeadingBlock<AppBridge> = {
      * The list of blocks that make up the section.
      */
     blocks: SettingBlock<AppBridge>[];
-} & BaseBlock<AppBridge>;
+
+    /**
+     * A switch which can toggle the blocks on and off.
+     * @default false
+     */
+    hasSwitch?: boolean;
+} & BaseBlock<AppBridge, boolean>;


### PR DESCRIPTION
* added `hasSwitch` type to `sectionHeading`
* `hasSwitch` can be true or false and the defaultValue can be set. Leading us to three different states of section heading
1. switch on:
```
 {
            id: 'styleSection',
            type: 'sectionHeading',
            label: 'Section Heading with Switch',
            hasSwitch: true,
            defaultValue: true,
            blocks: [
                getBorderSettings(),
                getGutterSettings({
                    id: 'isColumnGutterCustom',
                    dependentSettingId: COLUMN_NR_ID,
                    spacingChoiceId: SIMPLE_GUTTER_ID,
                    spacingCustomId: CUSTOM_GUTTER_ID,
                    defaultValueChoices: GutterSpacing.Auto,
                }),
            ],
        },
```
![image](https://github.com/Frontify/brand-sdk/assets/42832501/c67d629b-d08f-4a7c-8bbd-e49d1984d2bd)
2. switch off
```
 {
            ...
            hasSwitch: true,
            defaultValue: false,
            blocks: [
            ...],
        },
```
![image](https://github.com/Frontify/brand-sdk/assets/42832501/d81c65de-440b-4ed9-bfd2-561f16895855)
3. without switch
```
{
            id: 'styleSection',
            type: 'sectionHeading',
            label: 'Section Heading',
            blocks: [
              ...
            ],
        },
```
![image](https://github.com/Frontify/brand-sdk/assets/42832501/8424de16-66a2-4f7d-a830-0445fbb084ff)

**See usage in web-app: https://github.com/Frontify/web-app/pull/66**
See ticket: https://app.clickup.com/t/38a1jfy