### PR TITLE
fix: page moved to last position in the tree disappears

### DIFF
--- a/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
@@ -55,15 +55,14 @@ export const useCategorizedDocumentPages = (
             ) {
                 refetch();
             } else if ((action === 'delete' || action === 'move') && documentPages.has(documentPage.id)) {
-                setDocumentPages(
-                    produce((draft) => {
-                        if (action === 'move') {
-                            draft = moveDocumentPage(draft, documentPage);
-                        } else if (action === 'delete') {
-                            draft.delete(documentPage.id);
-                        }
-                    }),
-                );
+                setDocumentPages((previousState) => {
+                    if (action === 'move') {
+                        return moveDocumentPage(previousState, documentPage);
+                    } else if (action === 'delete') {
+                        previousState.delete(documentPage.id);
+                    }
+                    return previousState;
+                });
             }
         };
 

--- a/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
@@ -58,26 +58,7 @@ export const useCategorizedDocumentPages = (
                 setDocumentPages(
                     produce((draft) => {
                         if (action === 'move') {
-                            const documentPagesAsArray: DocumentPage[] = [...draft.values()];
-                            let isPageOnLastPosition = true;
-
-                            draft.clear();
-
-                            for (const currentDocumentPage of documentPagesAsArray) {
-                                if (currentDocumentPage.id === documentPage.id) {
-                                    continue;
-                                }
-                                if (draft.size === documentPage.sort - 1) {
-                                    draft.set(documentPage.id, documentPage);
-                                    isPageOnLastPosition = false;
-                                }
-
-                                draft.set(currentDocumentPage.id, currentDocumentPage);
-                            }
-
-                            if (isPageOnLastPosition) {
-                                draft.set(documentPage.id, documentPage);
-                            }
+                            draft = moveDocumentPage(draft, documentPage);
                         } else if (action === 'delete') {
                             draft.delete(documentPage.id);
                         }
@@ -96,6 +77,31 @@ export const useCategorizedDocumentPages = (
     }, [documentCategoryId, refetch, documentPages]);
 
     return { documentPages: Array.from(documentPages.values()), refetch, isLoading };
+};
+
+const moveDocumentPage = (draft: Map<number, DocumentPage>, documentPage: DocumentPage) => {
+    const documentPagesAsArray: DocumentPage[] = [...draft.values()];
+    let isPageOnLastPosition = true;
+
+    draft.clear();
+
+    for (const currentDocumentPage of documentPagesAsArray) {
+        if (currentDocumentPage.id === documentPage.id) {
+            continue;
+        }
+        if (draft.size === documentPage.sort - 1) {
+            draft.set(documentPage.id, documentPage);
+            isPageOnLastPosition = false;
+        }
+
+        draft.set(currentDocumentPage.id, currentDocumentPage);
+    }
+
+    if (isPageOnLastPosition) {
+        draft.set(documentPage.id, documentPage);
+    }
+
+    return draft;
 };
 
 const fetchDocumentPagesByDocumentCategoryId = async (

--- a/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
@@ -59,6 +59,7 @@ export const useCategorizedDocumentPages = (
                     produce((draft) => {
                         if (action === 'move') {
                             const documentPagesAsArray: DocumentPage[] = [...draft.values()];
+                            let isPageOnLastPosition = true;
 
                             draft.clear();
 
@@ -68,9 +69,14 @@ export const useCategorizedDocumentPages = (
                                 }
                                 if (draft.size === documentPage.sort - 1) {
                                     draft.set(documentPage.id, documentPage);
+                                    isPageOnLastPosition = false;
                                 }
 
                                 draft.set(currentDocumentPage.id, currentDocumentPage);
+                            }
+
+                            if (isPageOnLastPosition) {
+                                draft.set(documentPage.id, documentPage);
                             }
                         } else if (action === 'delete') {
                             draft.delete(documentPage.id);
@@ -97,5 +103,5 @@ const fetchDocumentPagesByDocumentCategoryId = async (
     documentCategoryId: number,
 ) => {
     const pages = await appBridge.getDocumentPagesByDocumentCategoryId(documentCategoryId);
-    return new Map(pages.sort(sortDocumentPages).map((page) => [page.id, page]));
+    return new Map([...pages].sort(sortDocumentPages).map((page) => [page.id, page]));
 };

--- a/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useCategorizedDocumentPages.ts
@@ -55,14 +55,15 @@ export const useCategorizedDocumentPages = (
             ) {
                 refetch();
             } else if ((action === 'delete' || action === 'move') && documentPages.has(documentPage.id)) {
-                setDocumentPages((previousState) => {
-                    if (action === 'move') {
-                        return moveDocumentPage(previousState, documentPage);
-                    } else if (action === 'delete') {
-                        previousState.delete(documentPage.id);
-                    }
-                    return previousState;
-                });
+                setDocumentPages(
+                    produce((draft) => {
+                        if (action === 'move') {
+                            moveDocumentPage(draft, documentPage);
+                        } else if (action === 'delete') {
+                            draft.delete(documentPage.id);
+                        }
+                    }),
+                );
             }
         };
 

--- a/packages/app-bridge/src/react/useDocumentCategories.ts
+++ b/packages/app-bridge/src/react/useDocumentCategories.ts
@@ -126,5 +126,5 @@ const actionHandlers = {
 
 const fetchDocumentCategories = async (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {
     const categories = await appBridge.getDocumentCategoriesByDocumentId(documentId);
-    return new Map(categories.sort(sortDocumentCategories).map((category) => [category.id, category]));
+    return new Map([...categories].sort(sortDocumentCategories).map((category) => [category.id, category]));
 };

--- a/packages/app-bridge/src/react/useDocumentGroups.ts
+++ b/packages/app-bridge/src/react/useDocumentGroups.ts
@@ -92,5 +92,5 @@ const actionHandlers = {
 
 const fetchDocumentGroups = async (appBridge: AppBridgeBlock | AppBridgeTheme) => {
     const documentGroups = await appBridge.getDocumentGroups();
-    return new Map(documentGroups.sort(sortDocumentGroups).map((group) => [group.id, group]));
+    return new Map([...documentGroups].sort(sortDocumentGroups).map((group) => [group.id, group]));
 };

--- a/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
@@ -55,14 +55,15 @@ export const useUncategorizedDocumentPages = (
             ) {
                 refetch();
             } else if ((action === 'delete' || action === 'move') && documentPages.has(documentPage.id)) {
-                setDocumentPages((previousState) => {
-                    if (action === 'move') {
-                        return moveDocumentPage(previousState, documentPage);
-                    } else if (action === 'delete') {
-                        previousState.delete(documentPage.id);
-                    }
-                    return previousState;
-                });
+                setDocumentPages(
+                    produce((draft) => {
+                        if (action === 'move') {
+                            moveDocumentPage(draft, documentPage);
+                        } else if (action === 'delete') {
+                            draft.delete(documentPage.id);
+                        }
+                    }),
+                );
             }
         };
 

--- a/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
@@ -59,6 +59,7 @@ export const useUncategorizedDocumentPages = (
                     produce((draft) => {
                         if (action === 'move') {
                             const documentPagesAsArray: DocumentPage[] = [...draft.values()];
+                            let isPageOnLastPosition = true;
 
                             draft.clear();
 
@@ -66,11 +67,17 @@ export const useUncategorizedDocumentPages = (
                                 if (currentDocumentPage.id === documentPage.id) {
                                     continue;
                                 }
+
                                 if (draft.size === documentPage.sort - 1) {
                                     draft.set(documentPage.id, documentPage);
+                                    isPageOnLastPosition = false;
                                 }
 
                                 draft.set(currentDocumentPage.id, currentDocumentPage);
+                            }
+
+                            if (isPageOnLastPosition) {
+                                draft.set(documentPage.id, documentPage);
                             }
                         } else if (action === 'delete') {
                             draft.delete(documentPage.id);
@@ -94,5 +101,5 @@ export const useUncategorizedDocumentPages = (
 
 const fetchDocumentPagesByDocumentId = async (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {
     const pages = await appBridge.getUncategorizedDocumentPagesByDocumentId(documentId);
-    return new Map(pages.sort(sortDocumentPages).map((page) => [page.id, page]));
+    return new Map([...pages].sort(sortDocumentPages).map((page) => [page.id, page]));
 };

--- a/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
@@ -58,27 +58,7 @@ export const useUncategorizedDocumentPages = (
                 setDocumentPages(
                     produce((draft) => {
                         if (action === 'move') {
-                            const documentPagesAsArray: DocumentPage[] = [...draft.values()];
-                            let isPageOnLastPosition = true;
-
-                            draft.clear();
-
-                            for (const currentDocumentPage of documentPagesAsArray) {
-                                if (currentDocumentPage.id === documentPage.id) {
-                                    continue;
-                                }
-
-                                if (draft.size === documentPage.sort - 1) {
-                                    draft.set(documentPage.id, documentPage);
-                                    isPageOnLastPosition = false;
-                                }
-
-                                draft.set(currentDocumentPage.id, currentDocumentPage);
-                            }
-
-                            if (isPageOnLastPosition) {
-                                draft.set(documentPage.id, documentPage);
-                            }
+                            draft = moveDocumentPage(draft, documentPage);
                         } else if (action === 'delete') {
                             draft.delete(documentPage.id);
                         }
@@ -97,6 +77,32 @@ export const useUncategorizedDocumentPages = (
     }, [documentId, refetch, documentPages]);
 
     return { documentPages: Array.from(documentPages.values()), refetch, isLoading };
+};
+
+const moveDocumentPage = (draft: Map<number, DocumentPage>, documentPage: DocumentPage) => {
+    const documentPagesAsArray: DocumentPage[] = [...draft.values()];
+    let isPageOnLastPosition = true;
+
+    draft.clear();
+
+    for (const currentDocumentPage of documentPagesAsArray) {
+        if (currentDocumentPage.id === documentPage.id) {
+            continue;
+        }
+
+        if (draft.size === documentPage.sort - 1) {
+            draft.set(documentPage.id, documentPage);
+            isPageOnLastPosition = false;
+        }
+
+        draft.set(currentDocumentPage.id, currentDocumentPage);
+    }
+
+    if (isPageOnLastPosition) {
+        draft.set(documentPage.id, documentPage);
+    }
+
+    return draft;
 };
 
 const fetchDocumentPagesByDocumentId = async (appBridge: AppBridgeBlock | AppBridgeTheme, documentId: number) => {

--- a/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
+++ b/packages/app-bridge/src/react/useUncategorizedDocumentPages.ts
@@ -55,15 +55,14 @@ export const useUncategorizedDocumentPages = (
             ) {
                 refetch();
             } else if ((action === 'delete' || action === 'move') && documentPages.has(documentPage.id)) {
-                setDocumentPages(
-                    produce((draft) => {
-                        if (action === 'move') {
-                            draft = moveDocumentPage(draft, documentPage);
-                        } else if (action === 'delete') {
-                            draft.delete(documentPage.id);
-                        }
-                    }),
-                );
+                setDocumentPages((previousState) => {
+                    if (action === 'move') {
+                        return moveDocumentPage(previousState, documentPage);
+                    } else if (action === 'delete') {
+                        previousState.delete(documentPage.id);
+                    }
+                    return previousState;
+                });
             }
         };
 

--- a/packages/app-bridge/src/react/useUngroupedDocuments.ts
+++ b/packages/app-bridge/src/react/useUngroupedDocuments.ts
@@ -163,5 +163,5 @@ const actionHandlers = {
 
 const fetchUngroupedDocuments = async (appBridge: AppBridgeBlock | AppBridgeTheme) => {
     const documents = await appBridge.getUngroupedDocuments();
-    return new Map(documents.sort(sortDocuments).map((document) => [document.id, document]));
+    return new Map([...documents].sort(sortDocuments).map((document) => [document.id, document]));
 };


### PR DESCRIPTION
When a page is moved to the last position under its parent, it disappears.
Also some potential array mutations errors are fixed