### PR TITLE
chore: bump app-bridge 3.0.0-beta.72

### DIFF
--- a/packages/app-bridge/package.json
+++ b/packages/app-bridge/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@frontify/app-bridge",
     "author": "Frontify Developers <developers@frontify.com>",
-    "version": "3.0.0-beta.71",
+    "version": "3.0.0-beta.72",
     "description": "Package to establish communication between Frontify and marketplace apps",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fixes for `useCategorizedDocumentPages` and `useUncategorizedDocumentPages.spec` regarding moving pages to last position