### PR TITLE
feat: add duration units to Unit type

### DIFF
--- a/.changeset/tame-bears-guess.md
+++ b/.changeset/tame-bears-guess.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": minor
+---
+
+add time unit types

--- a/packages/sidebar-settings/src/helpers/appendUnit.ts
+++ b/packages/sidebar-settings/src/helpers/appendUnit.ts
@@ -8,7 +8,7 @@ import { Unit } from './types';
  *
  * @param {Bundle} bundle Sidebar bundle object
  * @param {string} settingId Setting id
- * @param {('px'|'em'|'rem'|'%')} [unit='px'] Unit
+ * @param {('px'|'em'|'rem'|'%'|'s'|'ms')} [unit='px'] Unit
  * @returns {string} Set block value to string with unit
  */
 export const appendUnit = <AppBridge = unknown>(

--- a/packages/sidebar-settings/src/helpers/types.ts
+++ b/packages/sidebar-settings/src/helpers/types.ts
@@ -1,5 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export type Unit = 'px' | 'em' | 'rem' | '%';
+export type Unit = 'px' | 'em' | 'rem' | '%' | 's' | 'ms';
 
 export type MultiInputTuple = [string, string, string, string];


### PR DESCRIPTION
adds [time](https://developer.mozilla.org/en-US/docs/Web/CSS/time) units so `appendUnit` can be used for animation/transition durations.