### PR TITLE
chore: bump app-bridge version 3.0.0-beta.73

### DIFF
--- a/packages/app-bridge/package.json
+++ b/packages/app-bridge/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@frontify/app-bridge",
     "author": "Frontify Developers <developers@frontify.com>",
-    "version": "3.0.0-beta.72",
+    "version": "3.0.0-beta.73",
     "description": "Package to establish communication between Frontify and marketplace apps",
     "repository": {
         "type": "git",


### PR DESCRIPTION
to release after https://github.com/Frontify/brand-sdk/pull/443 is being merged
