### PR TITLE
feat(sidebarSettings): add footer event to notification block

### DIFF
--- a/.changeset/tidy-needles-divide.md
+++ b/.changeset/tidy-needles-divide.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": minor
+---
+
+Add footer event 'general-settings.open' to notification block

--- a/packages/sidebar-settings/src/blocks/notification.ts
+++ b/packages/sidebar-settings/src/blocks/notification.ts
@@ -9,7 +9,7 @@ export enum NotificationStyleType {
     Info = 'Info',
 }
 
-export type NotificationFooterEvent = 'design-settings.open';
+export type NotificationFooterEvent = 'design-settings.open' | 'general-settings.open';
 
 type LinkOrEvent = { href: string; target?: '_self' | '_blank' } | { event: NotificationFooterEvent };
 


### PR DESCRIPTION
* `'general-settings.open'` type added to `NotificationFooterEvent`

This event will open these settings:
<img width="368" alt="image" src="https://github.com/Frontify/brand-sdk/assets/42832501/9bc13c87-f0ca-4def-ae87-2bb4297c195b">

See implementation within web-app: https://github.com/Frontify/web-app/pull/329
