### PR TITLE
chore: add package.json script for frozen-lockfile installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "test": "pnpm --stream --filter {packages/**} --parallel test",
         "typecheck": "pnpm --stream --filter {packages/**} --parallel typecheck",
         "prepare": "is-ci || husky install",
-        "ci:publish": "pnpm build && pnpm publish -r --access public"
+        "ci:publish": "pnpm build && pnpm publish -r --access public",
+        "ci": "pnpm install --frozen-lockfile"
     },
     "devDependencies": {
         "@changesets/changelog-github": "0.4.8",


### PR DESCRIPTION
Adding the `ci` script to `package.json` so we can run `pnpm run ci` for installing dependencies without updating the lock file. This way, we avoid unintentional `pnpm-lock.yaml` file updates in feature or fix branches.

> The same script is used in the `web-app` and `Fondue`.