### PR TITLE
feat: add link type and mark linkchooser as deprecated

### DIFF
--- a/packages/sidebar-settings/src/blocks/link.ts
+++ b/packages/sidebar-settings/src/blocks/link.ts
@@ -5,11 +5,11 @@ import type { BaseBlock } from './base';
 
 export type SearchResult = SearchResultFondue;
 
-export type LinkChooserBlock<AppBridge> = {
+export type LinkBlock<AppBridge> = {
     /**
-     * @deprecated Use `type: 'link'` instead.
+     * The setting type.
      */
-    type: 'linkChooser';
+    type: 'link';
 
     /**
      * The placeholder text for the link chooser.
@@ -22,14 +22,13 @@ export type LinkChooserBlock<AppBridge> = {
     openInNewTab?: boolean;
 
     /**
-     * Whether the link chooser is disabled or not.
-     */
-    disabled?: boolean;
-
-    /**
      * Whether the link chooser can be cleared or not.
      */
     clearable?: boolean;
 
-    required?: boolean;
-} & BaseBlock<AppBridge, { link: SearchResult | null; openInNewTab: boolean | null }>;
+    /**
+     * Whether the internal link chooser is hidden.
+     * @default false
+     */
+    hideInternalLinkButton?: boolean;
+} & BaseBlock<AppBridge, { link: string | null; openInNewTab: boolean | null }>;


### PR DESCRIPTION
creates a new link type which will look like this: 
<img width="309" alt="image" src="https://github.com/Frontify/brand-sdk/assets/42832501/626d00e5-b675-4e64-a352-2daa8bf54e1a">

can be used e.g. like this
  ```
{
            id: 'link',
            type: 'link',
            label: 'Link',
            clearable: true,
            required: true,
            defaultValue: { link: 'https://www.frontify.com', openInNewTab: false },
        },
```