### PR TITLE
fix: export PageTemplateAsset type

### DIFF
--- a/packages/app-bridge/src/types/index.ts
+++ b/packages/app-bridge/src/types/index.ts
@@ -23,6 +23,7 @@ export * from './FileType';
 export * from './GuidelineSearchResult';
 export * from './Notify';
 export * from './OauthTokens';
+export * from './PageTemplateAsset';
 export * from './PrivacySettings';
 export * from './PostExternalAssetParams';
 export * from './Project';


### PR DESCRIPTION
This PR fixes a missing export of the type `PageTemplateAsset`.