### PR TITLE
feat: add missing methods for page template assets

### DIFF
--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -58,7 +58,7 @@ export interface AppBridgeTheme extends AppBridgeBase {
 
     getLibraryPageTemplateAssets(documentId: number): Promise<Record<string, Asset[]>>;
 
-    deleteAssetIdsFromLibraryPageTemplateAssetKey(documentId: string, key: string, assetIds: number[]): Promise<void>;
+    deleteAssetIdsFromLibraryPageTemplateAssetKey(documentId: number, key: string, assetIds: number[]): Promise<void>;
 
     addAssetIdsToDocumentPageTemplateAssetKey(
         documentPageId: number,

--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -44,31 +44,35 @@ export interface AppBridgeTheme extends AppBridgeBase {
 
     updateDocumentPageTemplateSettings(documentPageId: number, settings: Record<string, unknown>): Promise<void>;
 
-    createCoverPageTemplateAssets(settingId: string, assetIds: number[]): Promise<Record<string, Asset[]>>;
+    addAssetIdsToCoverPageTemplateAssetKey(key: string, assetIds: number[]): Promise<Record<string, Asset[]>>;
 
     getCoverPageTemplateAssets(): Promise<Record<string, Asset[]>>;
 
-    deleteCoverPageTemplateAssets(settingId: string, assetIds: number[]): Promise<void>;
+    deleteAssetIdsFromCoverPageTemplateAssetKey(key: string, assetIds: number[]): Promise<void>;
 
-    createLibraryPageTemplateAssets(
+    addAssetIdsToLibraryPageTemplateAssetKey(
         documentId: number,
-        settingId: string,
+        key: string,
         assetIds: number[],
     ): Promise<Record<string, Asset[]>>;
 
     getLibraryPageTemplateAssets(documentId: number): Promise<Record<string, Asset[]>>;
 
-    deleteLibraryPageTemplateAssets(documentId: string, settingId: string, assetIds: number[]): Promise<void>;
+    deleteAssetIdsFromLibraryPageTemplateAssetKey(documentId: string, key: string, assetIds: number[]): Promise<void>;
 
-    createDocumentPageTemplateAssets(
+    addAssetIdsToDocumentPageTemplateAssetKey(
         documentPageId: number,
-        settingId: string,
+        key: string,
         assetIds: number[],
     ): Promise<Record<string, Asset[]>>;
 
     getDocumentPageTemplateAssets(documentPageId: number): Promise<Record<string, Asset[]>>;
 
-    deleteDocumentPageTemplateAssets(documentPageId: number, settingId: string, assetIds: number[]): Promise<void>;
+    deleteAssetIdsFromDocumentPageTemplateAssetKey(
+        documentPageId: number,
+        key: string,
+        assetIds: number[],
+    ): Promise<void>;
 
     getLibraryPageTemplateSettings<Settings>(documentId: number): Promise<Settings>;
 

--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -2,6 +2,7 @@
 
 import { AppBridgeBase } from './AppBridgeBase';
 import type {
+    Asset,
     BrandportalLink,
     CoverPage,
     CoverPageCreate,
@@ -42,6 +43,32 @@ export interface AppBridgeTheme extends AppBridgeBase {
     getDocumentPageTemplateSettings<Settings>(documentPageId: number): Promise<Settings>;
 
     updateDocumentPageTemplateSettings(documentPageId: number, settings: Record<string, unknown>): Promise<void>;
+
+    createCoverPageTemplateAssets(settingId: string, assetIds: number[]): Promise<Record<string, Asset[]>>;
+
+    getCoverPageTemplateAssets(): Promise<Record<string, Asset[]>>;
+
+    deleteCoverPageTemplateAssets(settingId: string, assetIds: number[]): Promise<void>;
+
+    createLibraryPageTemplateAssets(
+        documentId: number,
+        settingId: string,
+        assetIds: number[],
+    ): Promise<Record<string, Asset[]>>;
+
+    getLibraryPageTemplateAssets(documentId: number): Promise<Record<string, Asset[]>>;
+
+    deleteLibraryPageTemplateAssets(documentId: string, settingId: string, assetIds: number[]): Promise<void>;
+
+    createDocumentPageTemplateAssets(
+        documentPageId: number,
+        settingId: string,
+        assetIds: number[],
+    ): Promise<Record<string, Asset[]>>;
+
+    getDocumentPageTemplateAssets(documentPageId: number): Promise<Record<string, Asset[]>>;
+
+    deleteDocumentPageTemplateAssets(documentPageId: number, settingId: string, assetIds: number[]): Promise<void>;
 
     getLibraryPageTemplateSettings<Settings>(documentId: number): Promise<Settings>;
 

--- a/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
@@ -23,6 +23,7 @@ import {
     UpdateTargetsDummy,
 } from '.';
 import { GuidelineSearchResultDummy } from './GuidelineSearchResultDummy';
+import { Asset } from '../types';
 
 const BRAND_ID = 234551;
 const PROJECT_ID = 3452;
@@ -63,6 +64,7 @@ export type getAppBridgeThemeStubProps = {
     portalId?: number;
     projectId?: number;
     pageTemplateSettings?: Record<string, unknown>;
+    pageTemplateAssets?: Record<string, Asset[]>;
     language?: string;
 };
 
@@ -72,6 +74,7 @@ export const getAppBridgeThemeStub = ({
     portalId = PORTAL_ID,
     projectId = PROJECT_ID,
     pageTemplateSettings = {},
+    pageTemplateAssets = {},
     language = 'en',
 }: getAppBridgeThemeStubProps = {}): SinonStubbedInstance<AppBridgeTheme> => {
     window.emitter = spy(mitt()) as unknown as Emitter<EmitterEvents>;
@@ -190,6 +193,26 @@ export const getAppBridgeThemeStub = ({
         getDocumentPageTargets: stub<Parameters<AppBridgeTheme['getDocumentPageTargets']>>().resolves(
             DocumentPageTargetsDummy.with(DOCUMENT_PAGE_ID_1),
         ),
+        addAssetIdsToCoverPageTemplateAssetKey:
+            stub<Parameters<AppBridgeTheme['addAssetIdsToCoverPageTemplateAssetKey']>>().resolves(pageTemplateAssets),
+        addAssetIdsToLibraryPageTemplateAssetKey:
+            stub<Parameters<AppBridgeTheme['addAssetIdsToLibraryPageTemplateAssetKey']>>().resolves(pageTemplateAssets),
+        addAssetIdsToDocumentPageTemplateAssetKey:
+            stub<Parameters<AppBridgeTheme['addAssetIdsToDocumentPageTemplateAssetKey']>>().resolves(
+                pageTemplateAssets,
+            ),
+        getCoverPageTemplateAssets:
+            stub<Parameters<AppBridgeTheme['getCoverPageTemplateAssets']>>().resolves(pageTemplateAssets),
+        getLibraryPageTemplateAssets:
+            stub<Parameters<AppBridgeTheme['getLibraryPageTemplateAssets']>>().resolves(pageTemplateAssets),
+        getDocumentPageTemplateAssets:
+            stub<Parameters<AppBridgeTheme['getDocumentPageTemplateAssets']>>().resolves(pageTemplateAssets),
+        deleteAssetIdsFromCoverPageTemplateAssetKey:
+            stub<Parameters<AppBridgeTheme['deleteAssetIdsFromCoverPageTemplateAssetKey']>>().resolves(),
+        deleteAssetIdsFromLibraryPageTemplateAssetKey:
+            stub<Parameters<AppBridgeTheme['deleteAssetIdsFromLibraryPageTemplateAssetKey']>>().resolves(),
+        deleteAssetIdsFromDocumentPageTemplateAssetKey:
+            stub<Parameters<AppBridgeTheme['deleteAssetIdsFromDocumentPageTemplateAssetKey']>>().resolves(),
         getCoverPageTemplateSettings:
             stub<Parameters<AppBridgeTheme['getCoverPageTemplateSettings']>>().resolves(localPageTemplateSettings),
         getDocumentPageTemplateSettings:


### PR DESCRIPTION
This PR adds the missing methods to `AppBridgeTheme` for page template assets.