### PR TITLE
feat: add info message in case browser window couldn't be opened automatically

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -121,8 +121,11 @@ export const loginUser = async (instanceUrl: string, port: number): Promise<void
 
         const loginUrl = authenticator.getLoginUrl();
 
-        Logger.info('Opening OAuth login page...');
+        Logger.info('Attempting to open OAuth login page...');
         await open(loginUrl);
+        Logger.info(
+            `If a browser window doesn't automatically open, please open the following link manually: ${loginUrl}`,
+        );
     } catch {
         Logger.error('You need to enter a valid Frontify instance URL.');
         process.exit(-1);


### PR DESCRIPTION
This PR adds an info message in case the browser window couldn't be opened automatically during login (we've ran into issues with enterprise customers who had security settings in place that prevented opening browser windows from the cli).

Once the user opens the url and approves the oauth request, the rest of the process stays the same.