### PR TITLE
fix: add documentId and documentPageId to dependency array

### DIFF
--- a/packages/app-bridge/src/react/useTemplateAssets.ts
+++ b/packages/app-bridge/src/react/useTemplateAssets.ts
@@ -85,7 +85,7 @@ export const useTemplateAssets = (
             componentMounted = false;
             window.emitter.off('AppBridge:TemplateAssetsUpdated', updateTemplateAssetsFromEvent);
         };
-    }, [appBridge]);
+    }, [appBridge, documentId, documentPageId]);
 
     const emitUpdatedTemplateAssets = async () => {
         window.emitter.emit('AppBridge:TemplateAssetsUpdated', {


### PR DESCRIPTION
This array fixes an issue that we don’t fetch assets when the hook has initially been rendered without a documentId and documentPageId.