### PR TITLE
fix: export TextStyles enum correctly

### DIFF
--- a/.changeset/silver-keys-attack.md
+++ b/.changeset/silver-keys-attack.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix: export TextStyles enum correctly

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/styles.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/styles.ts
@@ -4,7 +4,7 @@ import type { CSSProperties } from 'react';
 import { LINK_PLUGIN } from './LinkPlugin/id';
 import { BlockButtonStyles } from './ButtonPlugin';
 
-export const enum TextStyles {
+export enum TextStyles {
     heading1 = 'heading1',
     heading2 = 'heading2',
     heading3 = 'heading3',


### PR DESCRIPTION
resolves that typecheck issue:
![Screenshot 2023-08-31 at 16 30 46](https://github.com/Frontify/brand-sdk/assets/9362990/12dabd6e-de15-4742-bcd1-273f40ccfc36)
