### PR TITLE
fix: blockItemWrapper typing issue

### DIFF
--- a/.changeset/two-windows-prove.md
+++ b/.changeset/two-windows-prove.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix: BlockItemWrapper typing issue

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { joinClassNames } from '../../utilities';
 import { Toolbar } from './Toolbar';
 import { BlockItemWrapperProps, ToolbarItem } from './types';
@@ -15,7 +15,7 @@ export const BlockItemWrapper = ({
     shouldFillContainer,
     outlineOffset = 2,
     shouldBeShown = false,
-}: PropsWithChildren<BlockItemWrapperProps>) => {
+}: BlockItemWrapperProps) => {
     const [isFlyoutOpen, setIsFlyoutOpen] = useState(shouldBeShown);
     const [isFlyoutDisabled, setIsFlyoutDisabled] = useState(false);
     const wrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
@@ -1,8 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { MenuItemStyle } from '@frontify/fondue';
+import { ReactElement } from 'react';
 
 export type BlockItemWrapperProps = {
+    children: ReactElement;
     shouldHideWrapper?: boolean;
     shouldHideComponent?: boolean;
     toolbarItems: (ToolbarItem | undefined)[];


### PR DESCRIPTION
resolves that typecheck issue: 
![Screenshot 2023-08-31 at 16 43 17](https://github.com/Frontify/brand-sdk/assets/9362990/d2c53a71-23af-40f7-8c57-dee19bfb6fa5)

The problem was that with PropsWithChildren the children could be `undefined`