### PR TITLE
fix: BlockItemWrapper return type

### DIFF
--- a/.changeset/ten-rats-mate.md
+++ b/.changeset/ten-rats-mate.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix: BlockItemWrapper type issue

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useEffect, useRef, useState } from 'react';
+import { ReactElement, useEffect, useRef, useState } from 'react';
 import { joinClassNames } from '../../utilities';
 import { Toolbar } from './Toolbar';
 import { BlockItemWrapperProps, ToolbarItem } from './types';
@@ -15,7 +15,7 @@ export const BlockItemWrapper = ({
     shouldFillContainer,
     outlineOffset = 2,
     shouldBeShown = false,
-}: BlockItemWrapperProps) => {
+}: BlockItemWrapperProps): ReactElement => {
     const [isFlyoutOpen, setIsFlyoutOpen] = useState(shouldBeShown);
     const [isFlyoutDisabled, setIsFlyoutDisabled] = useState(false);
     const wrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -28,7 +28,8 @@ export const BlockItemWrapper = ({
     }, [isFlyoutOpen]);
 
     if (shouldHideWrapper) {
-        return children;
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        return <>{children}</>;
     }
 
     const items = toolbarItems?.filter((item): item is ToolbarItem => item !== undefined);


### PR DESCRIPTION
Ensuring that the BlockItemWrapper always returns an `Element`.

` error TS2786: 'BlockItemWrapper' cannot be used as a JSX component.`

@SamuelAlev maybe you see a better solution 