### PR TITLE
chore: bump appbridge version

### DIFF
--- a/.changeset/bump-appbridge-version.md
+++ b/.changeset/bump-appbridge-version.md
@@ -1,0 +1,6 @@
+---
+"@frontify/guideline-blocks-settings": patch
+"@frontify/sidebar-settings": patch
+---
+
+chore: bump app-bridge


### PR DESCRIPTION
To publish a version with the v90 app-bridge.