### PR TITLE
fix: blockItemWrapper Toolbar z-index

### DIFF
--- a/.changeset/shy-keys-promise.md
+++ b/.changeset/shy-keys-promise.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix: blockItemWrapper Toolbar z-index

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -57,7 +57,7 @@ export const BlockItemWrapper = ({
                     bottom: `calc(100% - ${2 + outlineOffset}px)`,
                 }}
                 className={joinClassNames([
-                    'tw-pointer-events-none tw-absolute tw-bottom-[calc(100%-4px)] tw-right-[-3px] tw-w-full tw-opacity-0 tw-z-10',
+                    'tw-pointer-events-none tw-absolute tw-bottom-[calc(100%-4px)] tw-right-[-3px] tw-w-full tw-opacity-0 tw-z-[60]',
                     'group-hover:tw-opacity-100 group-focus:tw-opacity-100 focus-within:tw-opacity-100',
                     (isFlyoutOpen || shouldBeShown) && 'tw-opacity-100',
                 ])}


### PR DESCRIPTION
Fixes a compatibility if you were tabbing through elements 
<img width="853" alt="Screenshot 2023-08-30 at 10 27 37" src="https://github.com/Frontify/brand-sdk/assets/9362990/6157c9b6-c415-4428-91ca-7b22ceb85604">


So we need to higher the `z-index` to 60 (cm toolbar is 50), so its higher as the content manager
![Screenshot 2023-09-05 at 14 48 36](https://github.com/Frontify/brand-sdk/assets/9362990/9da14c2a-b8a2-48a1-b092-06261944f78b)
