### PR TITLE
revert: fondue downgrade

### DIFF
--- a/packages/guideline-blocks-settings/package.json
+++ b/packages/guideline-blocks-settings/package.json
@@ -67,7 +67,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "workspace:^",
-        "@frontify/fondue": "11.3.0",
+        "@frontify/fondue": "12.0.0-beta.316",
         "@frontify/sidebar-settings": "workspace:^",
         "@react-aria/focus": "^3.14.0",
         "@react-stately/overlays": "^3.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
         specifier: workspace:^
         version: link:../app-bridge
       '@frontify/fondue':
-        specifier: 11.3.0
-        version: 11.3.0(@babel/core@7.22.11)(@types/node@18.17.12)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.316
+        version: 12.0.0-beta.316(@types/node@18.17.12)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.12.12)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
       '@frontify/sidebar-settings':
         specifier: workspace:^
         version: link:../sidebar-settings
@@ -1495,15 +1495,6 @@ packages:
       - supports-color
     dev: true
 
-  /@frontify/fondue-tokens@3.3.0(ts-node@10.9.1):
-    resolution: {integrity: sha512-UbuAa5Z8C8k+xz0YpeAUIGXWYkrA4JRhYMF/C88ESNHEXWJ5YXaqkkmINT43lAZH1n3CpliRg9o7Jdew3nhtkg==}
-    dependencies:
-      postcss: 8.4.29
-      tailwindcss: 3.3.3(ts-node@10.9.1)
-    transitivePeerDependencies:
-      - ts-node
-    dev: false
-
   /@frontify/fondue-tokens@3.3.0-next.5(ts-node@10.9.1):
     resolution: {integrity: sha512-6M919jnfqZnSW1GFSJ3jDiUx3Ml4L6FjA+IJR19LSVWK7de/xiXOiNDa4Rh1UAzZmA1NgzPAJKyu2FI3RZza/Q==}
     dependencies:
@@ -1511,96 +1502,6 @@ packages:
       tailwindcss: 3.3.3(ts-node@10.9.1)
     transitivePeerDependencies:
       - ts-node
-
-  /@frontify/fondue@11.3.0(@babel/core@7.22.11)(@types/node@18.17.12)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-2aXHPOLvX3QTb9KX2kI0wPTI2qTnkcvDaAZ1Gp/VZpu2t+pvzK+TbfsrkS7eCF9Ffvh/xB8hNRhkEyE3lwbcww==}
-    peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
-    dependencies:
-      '@frontify/fondue-tokens': 3.3.0(ts-node@10.9.1)
-      '@popperjs/core': 2.11.6
-      '@react-aria/accordion': 3.0.0-alpha.9(react@18.2.0)
-      '@react-aria/aria-modal-polyfill': 3.7.1(react@18.2.0)
-      '@react-aria/breadcrumbs': 3.5.2(react@18.2.0)
-      '@react-aria/button': 3.7.1(react@18.2.0)
-      '@react-aria/checkbox': 3.7.0(react@18.2.0)
-      '@react-aria/combobox': 3.4.3(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/dialog': 3.4.1(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/focus': 3.14.0(react@18.2.0)
-      '@react-aria/interactions': 3.17.0(react@18.2.0)
-      '@react-aria/link': 3.5.2(react@18.2.0)
-      '@react-aria/listbox': 3.7.2(react@18.2.0)
-      '@react-aria/menu': 3.7.1(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/overlays': 3.12.1(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/radio': 3.4.1(react@18.2.0)
-      '@react-aria/select': 3.8.3(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/selection': 3.14.0(react@18.2.0)
-      '@react-aria/table': 3.6.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/tooltip': 3.3.3(react@18.2.0)
-      '@react-aria/utils': 3.19.0(react@18.2.0)
-      '@react-aria/visually-hidden': 3.6.1(react@18.2.0)
-      '@react-stately/checkbox': 3.3.2(react@18.2.0)
-      '@react-stately/collections': 3.7.0(react@18.2.0)
-      '@react-stately/combobox': 3.5.0(react@18.2.0)
-      '@react-stately/list': 3.8.0(react@18.2.0)
-      '@react-stately/menu': 3.5.1(react@18.2.0)
-      '@react-stately/overlays': 3.6.1(react@18.2.0)
-      '@react-stately/radio': 3.8.0(react@18.2.0)
-      '@react-stately/select': 3.5.0(react@18.2.0)
-      '@react-stately/table': 3.9.0(react@18.2.0)
-      '@react-stately/toggle': 3.5.1(react@18.2.0)
-      '@react-stately/tooltip': 3.4.0(react@18.2.0)
-      '@react-stately/tree': 3.6.0(react@18.2.0)
-      '@storybook/addon-a11y': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate': 10.6.0(@babel/core@7.22.11)(@popperjs/core@2.11.6)(@types/node@18.17.12)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@xstate/immer': 0.3.1(immer@9.0.21)(xstate@4.28.1)
-      '@xstate/react': 1.6.3(@types/react@18.2.21)(react@18.2.0)(xstate@4.28.1)
-      date-fns: 2.29.3
-      framer-motion: 6.5.1(react-dom@18.2.0)(react@18.2.0)
-      immer: 9.0.21
-      react: 18.2.0
-      react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
-      react-datepicker: 4.8.0(react-dom@18.2.0)(react@18.2.0)
-      react-dnd: 15.1.2(@types/node@18.17.12)(@types/react@18.2.21)(react@18.2.0)
-      react-dnd-html5-backend: 15.1.2
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
-      react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0)
-      react-textarea-autosize: 8.4.0(@types/react@18.2.21)(react@18.2.0)
-      scheduler: 0.23.0
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-hyperscript: 0.77.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      tinycolor2: 1.4.2
-      xstate: 4.28.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - '@xstate/fsm'
-      - encoding
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - optics-ts
-      - react-query
-      - supports-color
-      - ts-node
-      - valtio
-      - wonka
-    dev: false
 
   /@frontify/fondue@12.0.0-beta.316(@types/node@18.17.12)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.12.12)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1):
     resolution: {integrity: sha512-LzNOGZBt1U+iqFZzlanut6ykgjyypuiv75tVVUGjTStkesEcgw24zzg4oGn9NxoJccq22t5i1J++Sy6MaihnuQ==}
@@ -1652,7 +1553,7 @@ packages:
       '@react-types/dialog': 3.4.5(react@18.2.0)
       '@react-types/shared': 3.16.0(react@18.2.0)
       '@tailwindcss/forms': 0.5.3(tailwindcss@3.3.3)
-      '@udecode/plate': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@xstate/immer': 0.3.1(immer@9.0.12)(xstate@4.28.1)
       '@xstate/react': 1.6.3(@types/react@18.2.21)(react@18.2.0)(xstate@4.28.1)
       date-fns: 2.29.3
@@ -1943,53 +1844,6 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
-  /@motionone/animation@10.15.1:
-    resolution: {integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==}
-    dependencies:
-      '@motionone/easing': 10.15.1
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.1
-    dev: false
-
-  /@motionone/dom@10.12.0:
-    resolution: {integrity: sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==}
-    dependencies:
-      '@motionone/animation': 10.15.1
-      '@motionone/generators': 10.15.1
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      hey-listen: 1.0.8
-      tslib: 2.6.1
-    dev: false
-
-  /@motionone/easing@10.15.1:
-    resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
-    dependencies:
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.1
-    dev: false
-
-  /@motionone/generators@10.15.1:
-    resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
-    dependencies:
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.1
-    dev: false
-
-  /@motionone/types@10.15.1:
-    resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
-    dev: false
-
-  /@motionone/utils@10.15.1:
-    resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
-    dependencies:
-      '@motionone/types': 10.15.1
-      hey-listen: 1.0.8
-      tslib: 2.6.1
-    dev: false
-
   /@mswjs/cookies@0.2.2:
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
     engines: {node: '>=14'}
@@ -2058,10 +1912,6 @@ packages:
   /@polka/url@1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
-
-  /@popperjs/core@2.10.2:
-    resolution: {integrity: sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==}
-    dev: false
 
   /@popperjs/core@2.11.6:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
@@ -2523,23 +2373,6 @@ packages:
       '@react-types/shared': 3.19.0(react@18.2.0)
       '@swc/helpers': 0.4.14
       react: 18.2.0
-
-  /@react-aria/accordion@3.0.0-alpha.9(react@18.2.0):
-    resolution: {integrity: sha512-3n55HzOKu9/JWdbASSdNE0KI4vKH1zsWVeoLgE9M5MXfgHYsOb/c7KkHIrBkC1oD03KdKioDlNENEXzBoOiI4w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@react-aria/button': 3.7.1(react@18.2.0)
-      '@react-aria/interactions': 3.17.0(react@18.2.0)
-      '@react-aria/selection': 3.14.0(react@18.2.0)
-      '@react-aria/utils': 3.19.0(react@18.2.0)
-      '@react-stately/tree': 3.6.0(react@18.2.0)
-      '@react-types/accordion': 3.0.0-alpha.7(react@18.2.0)
-      '@react-types/button': 3.7.2(react@18.2.0)
-      '@react-types/shared': 3.19.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
 
   /@react-aria/aria-modal-polyfill@3.7.1(react@18.2.0):
     resolution: {integrity: sha512-wF4/dF2+C2dwqTV4bLoSa4HBTWdTFLlWoJAxidDBsVz+3D+PB6a7rnfWv527Iqll789z5nvmRUQ9A8KiTMovJA==}
@@ -3083,45 +2916,17 @@ packages:
   /@react-dnd/asap@4.0.0:
     resolution: {integrity: sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==}
 
-  /@react-dnd/asap@4.0.1:
-    resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
-    dev: false
-
   /@react-dnd/asap@5.0.2:
     resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
-
-  /@react-dnd/invariant@2.0.0:
-    resolution: {integrity: sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==}
-    dev: false
 
   /@react-dnd/invariant@3.0.0:
     resolution: {integrity: sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==}
 
-  /@react-dnd/invariant@3.0.1:
-    resolution: {integrity: sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g==}
-    dev: false
-
   /@react-dnd/invariant@4.0.2:
     resolution: {integrity: sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==}
 
-  /@react-dnd/shallowequal@2.0.0:
-    resolution: {integrity: sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==}
-    dev: false
-
-  /@react-dnd/shallowequal@3.0.1:
-    resolution: {integrity: sha512-XjDVbs3ZU16CO1h5Q3Ew2RPJqmZBDE/EVf1LYp6ePEffs3V/MX9ZbL5bJr8qiK5SbGmUMuDoaFgyKacYz8prRA==}
-    dev: false
-
   /@react-dnd/shallowequal@4.0.2:
     resolution: {integrity: sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==}
-
-  /@react-hook/merged-ref@1.3.2(react@18.2.0):
-    resolution: {integrity: sha512-cQ9Y8m4zlrw/qotReo33E+3Sy9FVqMZb5JwUlb3wj3IJJ1cNJtxcgfWF6rS2NZQrfBJ2nAnckUdPJjMyIJTNZg==}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      react: 18.2.0
-    dev: false
 
   /@react-stately/checkbox@3.3.2(react@18.2.0):
     resolution: {integrity: sha512-eU3zvWgQrcqS8UK8ZVkb3fMP816PeuN9N0/dOJKuOXXhkoLPuxtuja1oEqKU3sFMa5+bx3czZhhNIRpr60NAdw==}
@@ -3461,15 +3266,6 @@ packages:
       '@react-types/shared': 3.19.0(react@18.2.0)
       react: 18.2.0
 
-  /@react-types/accordion@3.0.0-alpha.7(react@18.2.0):
-    resolution: {integrity: sha512-h5Nvf/+O+Cl/Vw6m3RNGD3hv7VwKX0ilJe1a473iJgjruzMQybSgpcCdWES31QZdEE+rkjpqTGoG22MusEOE+Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.19.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
   /@react-types/breadcrumbs@3.6.0(react@18.2.0):
     resolution: {integrity: sha512-EnZk/f59yMQUmH2DW21uo3ajQ7nLEZ/sIMSfEZYP69CFe1by0RKi9aFRjJSrYjxRC0PSHTVPTjIG72KeBSsUGA==}
     peerDependencies:
@@ -3719,168 +3515,6 @@ packages:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
 
-  /@storybook/addon-a11y@6.5.16(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-/e9s34o+TmEhy+Q3/YzbRJ5AJ/Sy0gjZXlvsCrcRpiQLdt5JRbN8s+Lbn/FWxy8U1Tb1wlLYlqjJ+fYi5RrS3A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/api': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/channels': 6.5.16
-      '@storybook/client-logger': 6.5.16
-      '@storybook/components': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      axe-core: 4.7.2
-      core-js: 3.32.1
-      global: 4.4.0
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-sizeme: 3.0.2
-      regenerator-runtime: 0.13.11
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/addons@6.5.16(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-p3DqQi+8QRL5k7jXhXmJZLsE/GqHqyY6PcoA1oNTJr0try48uhTGUOYkgzmqtDaa/qPFO5LP+xCPzZXckGtquQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/api': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/channels': 6.5.16
-      '@storybook/client-logger': 6.5.16
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/router': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@types/webpack-env': 1.18.1
-      core-js: 3.32.1
-      global: 4.4.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-    dev: false
-
-  /@storybook/api@6.5.16(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-HOsuT8iomqeTMQJrRx5U8nsC7lJTwRr1DhdD0SzlqL4c80S/7uuCy4IZvOt4sYQjOzW5fOo/kamcoBXyLproTA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/channels': 6.5.16
-      '@storybook/client-logger': 6.5.16
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/router': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      core-js: 3.32.1
-      fast-deep-equal: 3.1.3
-      global: 4.4.0
-      lodash: 4.17.21
-      memoizerific: 1.11.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-      store2: 2.14.2
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/channels@6.5.16:
-    resolution: {integrity: sha512-VylzaWQZaMozEwZPJdyJoz+0jpDa8GRyaqu9TGG6QGv+KU5POoZaGLDkRE7TzWkyyP0KQLo80K99MssZCpgSeg==}
-    dependencies:
-      core-js: 3.32.1
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/client-logger@6.5.16:
-    resolution: {integrity: sha512-pxcNaCj3ItDdicPTXTtmYJE3YC1SjxFrBmHcyrN+nffeNyiMuViJdOOZzzzucTUG0wcOOX8jaSyak+nnHg5H1Q==}
-    dependencies:
-      core-js: 3.32.1
-      global: 4.4.0
-    dev: false
-
-  /@storybook/components@6.5.16(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-LzBOFJKITLtDcbW9jXl0/PaG+4xAz25PK8JxPZpIALbmOpYWOAPcO6V9C2heX6e6NgWFMUxjplkULEk9RCQMNA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/theming': 6.5.16(react-dom@18.2.0)(react@18.2.0)
-      core-js: 3.32.1
-      memoizerific: 1.11.3
-      qs: 6.10.4
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/core-events@6.5.16:
-    resolution: {integrity: sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==}
-    dependencies:
-      core-js: 3.32.1
-    dev: false
-
-  /@storybook/csf@0.0.2--canary.4566f4d.1:
-    resolution: {integrity: sha512-9OVvMVh3t9znYZwb0Svf/YQoxX2gVOeQTGe2bses2yj+a3+OJnCrUF3/hGv6Em7KujtOdL2LL+JnG49oMVGFgQ==}
-    dependencies:
-      lodash: 4.17.21
-    dev: false
-
-  /@storybook/router@6.5.16(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-ZgeP8a5YV/iuKbv31V8DjPxlV4AzorRiR8OuSt/KqaiYXNXlOoQDz/qMmiNcrshrfLpmkzoq7fSo4T8lWo2UwQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.16
-      core-js: 3.32.1
-      memoizerific: 1.11.3
-      qs: 6.10.4
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-    dev: false
-
-  /@storybook/semver@7.3.2:
-    resolution: {integrity: sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      core-js: 3.32.1
-      find-up: 4.1.0
-    dev: false
-
-  /@storybook/theming@6.5.16(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-hNLctkjaYLRdk1+xYTkC1mg4dYz2wSv6SqbLpcKMbkPHTE0ElhddGPHQqB362md/w9emYXNkt1LSMD8Xk9JzVQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.16
-      core-js: 3.32.1
-      memoizerific: 1.11.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-    dev: false
-
   /@swc/helpers@0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
@@ -3976,10 +3610,6 @@ packages:
     dependencies:
       '@types/ms': 0.7.31
 
-  /@types/escape-html@1.0.2:
-    resolution: {integrity: sha512-gaBLT8pdcexFztLSPRtriHeXY/Kn4907uOCZ4Q3lncFBkheAWOuNt53ypsF8szgxbEJ513UeBzcf4utN0EzEwA==}
-    dev: false
-
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
@@ -3993,10 +3623,6 @@ packages:
     dependencies:
       ci-info: 3.8.0
     dev: true
-
-  /@types/is-function@1.0.1:
-    resolution: {integrity: sha512-A79HEEiwXTFtfY+Bcbo58M2GRYzCr9itHWzbzHVFNEYCcoU/MMGwYYf721gBrnhpj1s6RGVVha/IgNFnR0Iw/Q==}
-    dev: false
 
   /@types/is-hotkey@0.1.7:
     resolution: {integrity: sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ==}
@@ -4119,10 +3745,6 @@ packages:
 
   /@types/unist@2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
-
-  /@types/webpack-env@1.18.1:
-    resolution: {integrity: sha512-D0HJET2/UY6k9L6y3f5BL+IDxZmPkYmPT4+qBrRdmRLYRuV0qNKizMgTvYxXZYn+36zjPeoDZAEYBCM6XB+gww==}
-    dev: false
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
@@ -4270,33 +3892,6 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@udecode/plate-alignment@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-3edw9HIgKds72dxgfl3IaBA0dUOFZlDUoBvqWOp4UFxA0eMq32VZz8SIfgmmjt+9XF7bVzBv+VOwRIWpFZVP1g==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-alignment@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-gbcMYwxsLQryXiSvWNgW9VEOndPz9YJ0bgr641jZLQ66uMHADzb2tV585arefKqLifYnxLmXXGijCR3x42jJew==}
     peerDependencies:
@@ -4359,33 +3954,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-autoformat@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-7rG9jRysWtCVZoyx/4LbOc/nwTyN7rrV177PzoY5EY4TNRR2tydsMxWtUriNL3+HBnNNvsUq+OQHU6h1h6rV9Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-autoformat@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-ekwohyLREz53unJvPCwKUW8gte+QNXWu70BWCZDIbRtVMe8Fbtji2Wzuw/4Dm2/Wh5rE1K6TgA03uwGPsbro7w==}
@@ -4449,37 +4018,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-basic-elements@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-2SACTm0qKTHiNESfEwa4cScx242Mk1y+qg5+x+03DAT3Y8e11P5tjAYhnBlKA6no1rVlkkCCLlt4Uzg3h4ciHA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-block-quote': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-code-block': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-heading': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-paragraph': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-basic-elements@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-tB+MSDArmpKr+/EBlNpjIj5Tv9Fj3zB1ICxLVGieJ5BVXo8Qu8JYWbKI8juV1W7muf+HltC+N2hIedojA+r2Kg==}
@@ -4551,33 +4090,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-basic-marks@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-HQlHt+kdmtR+jz5VEOmj0bwZTY102vA3m4/tAWWlcgAvxiFH1GlN/+z6U8b6cCFK81d/AneklOnL8QRkkhnJDA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-basic-marks@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-15zTwE4+pu3duVnnb7DKCUeiKlEfdSzCMspViP3I5fPRFQFnWZVGPoN1tQskb1oxvzBGddlpz/6GCSeBW2JN6Q==}
@@ -4641,33 +4154,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-block-quote@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-z90pBVH6o5TMGeLdtc/n7p8gZTKrgOTIeANP2Cc1lZbgnOVzSnbasqrP43beOczvJMRub1QiGNhhYGAnmjrHYA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-block-quote@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-JNksR8F6yw7qgzGBZtolMWaFbseYcLKNo3z8AEBkcUCt95VSbBQP7P24/6aFoMkaAH1eD7DNRCegic9Kanru/w==}
@@ -4731,33 +4218,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-break@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-C7VfPFEAFeNMkmZAYIwkJ9mmDUw3gWQ6ebI8AH8qRnhfWnpM7Q1z2gUq3aMQTVtsaFLryxmV57LyXSZBP4e24A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-break@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-MotPRnMOthyHgX+sOWVhY9z/FnivkvWOhb/MM+xgK/B5PMFgz9GlHSlJIjyTOm3HzIhfo968shOYW8Z+9PAo5g==}
@@ -4821,6 +4282,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: true
 
   /@udecode/plate-button@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-lH8MjPFtWdOPUUVFUgvKIu9VR7bNo6SQhoBfAaGQPhPARqBQ+IrPlKAA2mC8IZr3ECFtuPDjg2uqGQoUTAedZQ==}
@@ -4884,34 +4346,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-code-block@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-J3M0HDVpzoYRHfIlXoSZgzfCFoSEOZJUxsZZKVnCMHEWKCB6UFYCoG5HGlQCMkUbquqHNRe/AJXJPIu8bf3+9A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      prismjs: 1.29.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-code-block@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-ZaioZnfBmFMFZWzulMGfoDLb3l9nOIcfbfleGNDBjTRiqorbzGuz1K9MKWTjPZacS+Zt035ncC/bouMXnppP1w==}
@@ -4977,36 +4412,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-combobox@10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-4wZpUqnAaf9M7nT6oNX5lJBoZ60q5cWwgBXDUmuoULgV9d8JdmA3JnKUoc3uXXU1cbmSlIBroT6PkOY6A1Oz3Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/zustood': 0.4.4(zustand@3.7.0)
-      downshift: 6.1.7(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      zustand: 3.7.0(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-combobox@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-LLMec+quBxG7P5IKFrqRrpBsJm4FPTVzKLQnd+TAh6h8yw0wLLMw90McnpIhmp9xfyHUsZa99ymnHrkYf7+8QQ==}
@@ -5019,41 +4425,6 @@ packages:
     dependencies:
       '@udecode/plate-common': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-floating': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      downshift: 6.1.12(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-combobox@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
-    resolution: {integrity: sha512-LLMec+quBxG7P5IKFrqRrpBsJm4FPTVzKLQnd+TAh6h8yw0wLLMw90McnpIhmp9xfyHUsZa99ymnHrkYf7+8QQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       downshift: 6.1.12(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -5177,6 +4548,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: true
 
   /@udecode/plate-common@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-jEkgcbSP2Kgk0vzmKMzhxqi7bfw9oaBGX5xuds0j9l079BKIRzvj/hBnPBneC5i5B+YqU+m+xI+mfbbNcaVgAA==}
@@ -5250,38 +4622,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-core@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-OBu02wPV80AC55GmFUtB8WAWKDEYLzLiV8M9FODZjQXpp5QkVkE5947nEZR6qwnTwIzYNm41oY8YrJF3PcmjoA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/zustood': 0.4.4(zustand@3.7.0)
-      clsx: 1.1.1
-      jotai: 1.5.3(@babel/core@7.22.11)(immer@9.0.21)(react@18.2.0)(xstate@4.28.1)
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      use-deep-compare: 1.1.0(react@18.2.0)
-      zustand: 3.7.0(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-core@21.5.0(@babel/core@7.22.11)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-A5qKsIORSvMTb8AdehNWHyVDKNTCXnTJ86p/qgfYG9WAerNxfbKNGqaPEyg3R72ZtHa0I3aTT4uNO7jEpWCQQQ==}
@@ -5363,6 +4704,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: true
 
   /@udecode/plate-emoji@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-rFL5E8QwwadpUrdhP8qT7G5fyjLTz0WVQHmaiQaUKyCw6Xlzt4R/OLmFfsX4UI2614/cGbO7tor0OSKedC46UQ==}
@@ -5376,41 +4718,6 @@ packages:
       '@emoji-mart/data': 1.1.2
       '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-common': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-emoji@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
-    resolution: {integrity: sha512-rFL5E8QwwadpUrdhP8qT7G5fyjLTz0WVQHmaiQaUKyCw6Xlzt4R/OLmFfsX4UI2614/cGbO7tor0OSKedC46UQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-    dependencies:
-      '@emoji-mart/data': 1.1.2
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -5468,33 +4775,6 @@ packages:
       - react-native
       - scheduler
     dev: true
-
-  /@udecode/plate-find-replace@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-aJWrjzi6vCAEiqVDTj+qhjm5qB4BmQzB4Lxov3Dl1fen4P/lQH05BNYIFTrTz3Vn4V7ERvUFB73aXwRElBNArQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
 
   /@udecode/plate-find-replace@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-ZMreo/MDeZG4vICdtgsWgF//ugs2bdjNwLROM/cPaEzC2LygfJCwA6dFaPh+7DjeMhIgxfIiGA+e+ZFzJzLsEQ==}
@@ -5558,6 +4838,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: true
 
   /@udecode/plate-floating@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-nBEXyqsdxEDkopetcbA3+wfPDZI04VNT0TCMv/ZUgc0KgjZrLK10TIo0cp3HU7okrKwkRE0bQjOEze2fPxQWSA==}
@@ -5571,41 +4852,6 @@ packages:
       '@floating-ui/react': 0.22.3(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-dropdown-menu': 2.0.5(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@udecode/plate-common': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-floating@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
-    resolution: {integrity: sha512-nBEXyqsdxEDkopetcbA3+wfPDZI04VNT0TCMv/ZUgc0KgjZrLK10TIo0cp3HU7okrKwkRE0bQjOEze2fPxQWSA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-    dependencies:
-      '@floating-ui/react': 0.22.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-dropdown-menu': 2.0.5(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -5663,33 +4909,6 @@ packages:
       - react-native
       - scheduler
     dev: true
-
-  /@udecode/plate-font@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-ryZfztmL9/sm7HfqOXtEIIX7A5ziO4BbEKMEFmIH1Gpq9oD2adRm1GfigvBJyWa/Shv55mZ48CctFbnrWydzmw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
 
   /@udecode/plate-font@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-suPdGeRCKlDep8FZCmZ0TbYNeUd7cHcnuY6YwrGfs7KUNv2WyklQH3RxPSLtio7Ei55SYHl5FcrSy8tfvpUHfA==}
@@ -5753,33 +4972,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-heading@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-mOPA86HMkwQ1cCxVnKq5BnLhr3rburHc9u/5iIfsc9kDQsCqTw83OBEDncJ1WD1JAqcRSf2kD7gbkOONdwSguw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-heading@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-4+6fKS5fXyiwuVxwwxM3Pu8d8zdxOGodJ8PsDSjfI4ZtrZGMnfa889tOnKw2FEtH/mgFl03Yk+ftUhDZPuNwhg==}
@@ -5843,70 +5036,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-headless@10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-JgZypic3z5dfAPbSxwg3hoQiOqF4kgugc4c8a0SLR3ooIAvf5XGJZdvd/5KBu9qD8bRFA7tEFVmeKWUJloEdQA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-alignment': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-autoformat': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-basic-elements': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-basic-marks': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-block-quote': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-break': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-code-block': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-combobox': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-find-replace': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-font': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-heading': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-highlight': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-horizontal-rule': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-image': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-indent': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-indent-list': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-juice': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-kbd': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-line-height': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-link': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-list': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-media-embed': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-mention': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-node-id': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-normalizers': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-paragraph': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-reset-node': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-select': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-serializer-csv': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-serializer-docx': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-serializer-md': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-table': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-trailing-block': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-hyperscript: 0.77.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - encoding
-      - immer
-      - optics-ts
-      - react-query
-      - supports-color
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-headless@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-KFEEQ/NdMs3HIzidv2yz44SReVnxZmMip8JGyERe+PU5oAvhcQcp8ACvF0CQuK2xBk041/DCJbznF6WG7rBEcg==}
@@ -5958,81 +5088,6 @@ packages:
       '@udecode/plate-table': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-trailing-block': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/resizable': 20.5.3(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-hyperscript: 0.77.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-      - supports-color
-    dev: false
-
-  /@udecode/plate-headless@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1):
-    resolution: {integrity: sha512-KFEEQ/NdMs3HIzidv2yz44SReVnxZmMip8JGyERe+PU5oAvhcQcp8ACvF0CQuK2xBk041/DCJbznF6WG7rBEcg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.94.0'
-    dependencies:
-      '@udecode/plate-alignment': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-autoformat': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-basic-elements': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-basic-marks': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-break': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-button': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-code-block': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-comments': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-emoji': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-font': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-heading': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-highlight': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-horizontal-rule': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-indent': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-indent-list': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-kbd': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-line-height': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-list': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-media': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-mention': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-node-id': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-normalizers': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-reset-node': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-select': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-serializer-csv': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-serializer-docx': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-serializer-html': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-serializer-md': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-suggestion': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-tabbable': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-trailing-block': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/resizable': 20.5.3(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6133,33 +5188,6 @@ packages:
       - supports-color
     dev: true
 
-  /@udecode/plate-highlight@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-HS0tz2XT2eQHq+nEcR6Icm/oZmg3Jtrp34nRY44H/cyExdI70ddXE1ju22b4wwNi2cooo4FhhkGBm3kgd/JNVA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-highlight@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-o11WrLmMqhM2u0/7mgLVJT+utzHJG8eP5u8swJuMAGkHE71QesUXj2ZgSxuubrF+VC/XESQXhGmeB8PkCBDIjw==}
     peerDependencies:
@@ -6222,33 +5250,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-horizontal-rule@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-UMeGEG1eDEBa8frkkDYkALixDw7n4upR6Sd9feSw++RpiiLaGnFJOTze5Fv0YcFjkRGEG/fhTw53LFyA4uaiAg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-horizontal-rule@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-3SX2HYr3yifptfFnQ1XH1+KYN9gQUVjy9bwPpz0RJm7kZZR+SrZQ6Op8LBK17rsDIB+lsnsklkDwYQm/OaUT6g==}
@@ -6312,62 +5314,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-image@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-C3y7zcU6Ze83BjYmb5gzgMmAlVNWyf1MhwKpGI2J4CSY6WyJXofo/WH/KJo+0pz/zddHcfF92siGP4CNnzEEEQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-indent-list@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-g3VVeUkaYfMg/TuwC74NPCDVh79kp0GkOp+6c00AH7Y9oL82V0VAlu96J377Z2HrTs/dl8CMIqQQ1ZHe3wM9Wg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-indent': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-list': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-indent-list@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-XJvcWNxlpfay1A5h/65tR3H9YP+9rd1Ui1yF4/FIEJpBazYJF02JLR/TKCP46pqBKFEmWc9jImeUXfbgeDkLlw==}
@@ -6435,33 +5382,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-indent@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-oyFIKIOBl6npBP6B3h1KVyaeKnsgYAmq/9QDScTcQQXEjRssvZGI37wgftkCW15Gr9dgHqL7EGt4u1lqI5xrzA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-indent@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-ETwGdPZuEesGv4DW+s9cmt0+Fo537y7sVtVJJi1juCitPgwnaqLwu+QRLDErFSIBdQebR0/gxX65R/+uH0NwnQ==}
@@ -6525,62 +5446,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-juice@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-MWZNhYUk6V1CMEumoU2h5yC6FDWLm7c9r8NGtUIBsH1G7Fwv3rnruSN7VZfPeKjR7buSeSsriTybtsJlK+WZHQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      juice: 8.0.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - encoding
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-kbd@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-6zPMj//Ie0zulplVUKpauUnpRd9gwfvo0YFvf0gchHGsqjtao0eqj9jF6qriX3o1DCWbtH8bPmWyPenh13rXuw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-kbd@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-KVerussGxitZox/6PJpPo/6TT+BGZ6rn3yvndSveAq1tD2HuDxw9nDbBhxiZYQBseZ97aTu4t4naCR/jJl0xwQ==}
@@ -6644,33 +5510,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-line-height@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-YT9O9GWeP8M7iLCb/527OjnsrL5YD078ogzy31LYWUvg5tdxVha1dBgkSZhpIjT5uGCI2CARN2ekpwIbaLvJhg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-line-height@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-JCBEjDZZw8MFulI56md3Noz1vuw6EiCmvLkX7pRcMc7dGocMo4BKOJLao1UGIfDVLkqjVlr8Av1fayQPGNuZGg==}
@@ -6734,34 +5574,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-link@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-2nbu7pcBXGWor1Jau2ED0dHSd64bftJ9aCd7LuBzAmrH74Szvw19Zvub1B2z27EhtrwYCTplV7XTTwtl3KQC6g==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-normalizers': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-link@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-UT2rW0HBNOYvS0iLxFC5dU7wiMAQ+L8Cgl1mIlxi+a/58B+K3ED1zwnO7MAotpKOy/GSA58+YYBQ3liSTolgRw==}
@@ -6829,34 +5642,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-list@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-Qhh8m2PuafA1X6dMuUojtp+yruGMFUJLUtd8tp9xHOzyxurqwR3oFz39f5CQfRfewAlpehZ+Lz/RjW3+zf8H8A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-reset-node': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-list@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-PkmlSmy1/W4FMcw5pzJakb6d3MbfqCT4xCOHgjXkv4glqaRFKAwMJPhvswwveEencfQe+c5J5HFE7t2q4dWwIg==}
@@ -6922,33 +5708,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-media-embed@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-T1+7MVz4HiaIjtaf8seSdFgj7ZP0d+jiIiyM2GEC4vX+ytYCdXUyNFdyFxoxFDa14IorbtVPjfuMw/L5xHKQVQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-media@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-7FY+vo0USGTZvUYKEtemfupHPjeUkK4zQZRODZCiP46t0mK1cImsSsP8OUZ2HjXKkyAMVla1ThH1+QOXb8I0cA==}
@@ -7020,34 +5780,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-mention@10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-WISiAhkNri6sJ+/EDGwTh4iocPhQhBRHgxc5WrnKqnN+FNn0cWN8XYZSQf2tX9gP1sPi14ryUioyhdRLQdtXUw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-combobox': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-mention@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-34iR9qk1uz0jPeWpE4mC+e/2sij0knM+nnOlcmWiEpQQP3ahaPFQups7+5Kpa23AXecpdHeRGqR1vUnWbAYnyQ==}
@@ -7060,40 +5793,6 @@ packages:
     dependencies:
       '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-common': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-mention@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
-    resolution: {integrity: sha512-34iR9qk1uz0jPeWpE4mC+e/2sij0knM+nnOlcmWiEpQQP3ahaPFQups7+5Kpa23AXecpdHeRGqR1vUnWbAYnyQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-    dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7150,33 +5849,6 @@ packages:
       - react-native
       - scheduler
     dev: true
-
-  /@udecode/plate-node-id@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-V3w9cMyrZ25DbV9dNJjlpWQ3HvCfhLVEE4IY+nEzuIdok0GQ/bRzXOJ5T9DQC7hk18qw2Nd+MR7VbqpWhqphRw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
 
   /@udecode/plate-node-id@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-emPHy5KXj8R3YMsuXsZ4hhlWpPLAoVmymiUA5uEihAMoiXDTAEkVpvcw79zqLmvOn50rYwCItqv+Y19YaL29nA==}
@@ -7240,33 +5912,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-normalizers@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-8AgUMx6sVPXzA20Yg0psvU0DD/5x/3a+iSVJ8ROCG21qL4+VH/7GV5VlRpD0NvXw3jTVosVmPH3XBw20c14/mg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-normalizers@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-X6dtZvT14vGxxm9WzuoeTN8RlU5plHIagWlFdVCV2EQM1mNlo5LEnNSsSIaS9Z+VBvKagmIn8JUaaMeFB/Yixg==}
@@ -7330,33 +5976,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-paragraph@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-89VV0tRIQtSh4uYxUsqrqdVQYkOmc0yx8t5BNPRrd/3D9h6IiX4UGpwUlo6AaGH4gyLAXF0AWEai5iccwS90gw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-paragraph@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-ujQwFQ3rQRl2JaHYHSxxS5mf0NuGXu4WtfGdYD2ITCnIKP+cy6vycg7iIfcPL+w7iYFz5F9wpyIZzR9upISRBg==}
@@ -7420,33 +6040,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-reset-node@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-Jmh0COs2a5NtB4eNU3vbZdB+dcG/jIjsme51eqbaZjiCslCNU95bBP/UCXnu8Wny6Sx11chnpxQxi/RfgTnXPg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-reset-node@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-rPCE7TzA3/GyNcOWUUuFRlbNrtm7Af4wIkrGTuoY6/T/Ypp8KeRc5HlOwzuQL+QRGMp3kyJQL3A/KDuPF1uq7A==}
@@ -7510,33 +6104,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-select@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-t/yMkcBA5AghIXv/Mppyu4OmHAQhP7bXrbAthVbS20Gza0qCYA/Zc2mWF9CBHkLNx378KJOXIj0AhcII0J0IxA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-select@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-trNzAIEpcf7Xtntau2XohxLmlLRoQ+9Tt0opkDyNqFW+Mp5xIL0D9OZEGZo05F/73WbxpcxH40tFkzhOhZQOmw==}
@@ -7600,36 +6168,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-serializer-csv@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-AuxguCW944S7o6yMuilL/HmMPfHaMEeZqD7Vd/81qftACEYUouAzTIiRdYAZ8Ohx9anpn1/swDFvoEDmKsUJkg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-table': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      papaparse: 5.4.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-hyperscript: 0.77.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - slate-history
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-serializer-csv@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-4wMqvDmHB2SLe6MvrDKI4jTq3z/Pp2NR3ptLwOO8UavnZJYvsk/PlCBP//YSbTIi8vhPaODCCjzc8U8iZu5etA==}
@@ -7699,42 +6238,7 @@ packages:
       - react-native
       - scheduler
       - slate-history
-
-  /@udecode/plate-serializer-docx@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-1k5f6RR+0raxiCY35vkTm5evfOt0iggTcxh08xoq0Rjij8NhdXBfBrBpKlJCp2bRRLRd3B3y21sbF5FGW89nzA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-heading': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-image': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-indent': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-indent-list': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-paragraph': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-table': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-hyperscript: 0.77.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      validator: 13.7.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-serializer-docx@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-ggxpIzNSUovjZj/HQqHxdExdEVGnOh1VSR5BpuVtV2BeXOvFZK1I+GXheXfK/r/b8Kj50FZMYrNXDS0Yf1qjPg==}
@@ -7753,47 +6257,6 @@ packages:
       '@udecode/plate-media': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-paragraph': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-table': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-hyperscript: 0.77.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      validator: 13.9.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-serializer-docx@21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1):
-    resolution: {integrity: sha512-ggxpIzNSUovjZj/HQqHxdExdEVGnOh1VSR5BpuVtV2BeXOvFZK1I+GXheXfK/r/b8Kj50FZMYrNXDS0Yf1qjPg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.94.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-heading': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-indent': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-indent-list': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-media': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7927,43 +6390,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-serializer-md@10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-d5ISdZKYVHQ+YXwR7ai3lKrxuwDm7RiBsh7RbXliISxWPYfY7NheKBvj83p53PD28/vcObmXfKl7He+vfaqfLA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-block-quote': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-code-block': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-heading': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-link': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-list': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-paragraph': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      remark-parse: 9.0.0
-      remark-slate: 1.8.6
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      unified: 9.2.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - supports-color
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-serializer-md@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-TXCzJolmmv/ROnfvEBrO4WpUJEcwwp1Jvg7MOOcdegv7824t08CycJEXZhWDKAXb2Af/MOG+1gIB55yhLwYYTg==}
@@ -8045,38 +6472,7 @@ packages:
       - react-native
       - scheduler
       - supports-color
-
-  /@udecode/plate-styled-components@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-FYgC53IWat68MNZ4ZN4t/e7aZi0aY/pV/95VKtbWfJlCeBecJr4HLmNWP9PPZRfBeIUFpLyawf6y1yxRFkCv/A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      react-is: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      clsx: 1.2.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-styled-components@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-+ooCADdk3O1b+yaMe09e8M/Yxf9++Lk6YVMjHxSGS0pwTKIyfdTGwcbZ9oImCYxhlv1yGDOOgPEvuoog0cX3tw==}
@@ -8150,6 +6546,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: true
 
   /@udecode/plate-suggestion@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-6oeyYLMgRXn6DQiizCIWrpjNaFrS6UBHz3jHPmfLSvzJK6LxCXgAKdwzOb7/mBq2KSzRyJJK2Ua9UN12R9tP8A==}
@@ -8213,6 +6610,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: true
 
   /@udecode/plate-tabbable@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-RS4C2yFvSP3ZDxggg4is6ewcWCHbgGtwQcG/2dBl/PdDubnU9CkFl0MasX6A+cMajD/ZZj2XPo0wYFsUEah+Vg==}
@@ -8278,33 +6676,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-table@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-0/6GAI9YeY92hdyPjGlaFeMeMQ1BcttguwW3DBRDeK6whknvOABubc6MsHc49xvYZlJYoC1xuv1pqBFTa8FLpg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-table@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-sPFvXjn0m8kCuHTCquMYnOWKyUBCBKz7lQSBgX23cayu7a0oBxcbH/cHOA77+WbpZ0ZybrLb4Kbkfcr+bdyoQA==}
@@ -8370,33 +6742,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-trailing-block@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-bwT6GHfw5u0SXfCaPdoTB/xEYVP/5qS83Ucs5STbEN/6nTBas8UJ5+RZutve6uTttWy8sfBZx06goS16RBJ4pw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-trailing-block@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-sGD4tLpUpl7cKlvnXA8BVg4/Wwwrj6rcXjPGvMRqOcAYYys5HIOlET/SqypPdP5QK0JZQZX3UMGKS6+fto+5Qg==}
@@ -8460,40 +6806,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate-ui-alignment@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-/sMEBPM8NVRVx2TKx5o70obmMN3xKEGeoCuycSAbVTn8Wc4aewgfEr9v/knt4ZiuWc0DDcG5eSsmdI1r85bJIA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-alignment': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-tCqLx6dxkUFesi3OfMFv4RFJFk4tIfIu07KpCzSpaX0B7u+cgV1rBWXeV+HvDquPKC4lsrVJ6lh3Yyx7LDdPBw==}
@@ -8509,45 +6822,6 @@ packages:
       '@udecode/plate-common': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-tCqLx6dxkUFesi3OfMFv4RFJFk4tIfIu07KpCzSpaX0B7u+cgV1rBWXeV+HvDquPKC4lsrVJ6lh3Yyx7LDdPBw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-alignment': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8611,38 +6885,6 @@ packages:
       - react-native
       - scheduler
     dev: true
-
-  /@udecode/plate-ui-block-quote@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-by/tNFJv3iJEALAws+TRKUtJjh+CW7uS/1JmLykiGO4VXBq7XQUkFa8yGYzTE9jUvT5BAi7+jyTQe93Y1tnJGw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-block-quote': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
 
   /@udecode/plate-ui-block-quote@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-5YOjAeejfJ3zp3vpYr2G+TzpveZbdv8VLUe9YpcSNlPF/r/wAzojeUwbCEkN6WuVALWCGv8ylddNUZ/DNxpg8g==}
@@ -8716,37 +6958,7 @@ packages:
       - react-is
       - react-native
       - scheduler
-
-  /@udecode/plate-ui-button@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-WS1vPfRTKpMDoEgcb/OHwjdFkgt8qrM6akYLAA1ZvM0MXi93NjVdfgpa6FSsPH3n3hU3lbSfNiEDY4cTI/wzTg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-ui-button@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-HVIIPshNJoDcjVs71zGCMOj5pC6OQfaiItxKggiG/EYw9eFXm4l/pCCGdny74vIQdTywWYj15yEYcMg0w1eY1Q==}
@@ -8820,40 +7032,7 @@ packages:
       - react-is
       - react-native
       - scheduler
-
-  /@udecode/plate-ui-code-block@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-sdf2j29ydGriOqtB65DJwU8FikKDia7UXFWsie3qYMlQcvilGzVIrhMwcL6TGWYoilclZCUL1ucP42QAqmF25w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-code-block': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-xN62xPasT5IVzi9k/pbdoR1U3ZobbolXVWDVqjvYaiPWgVtyt4VNxwaIjfqhtb2lTtQZakwV5XjaQcIcjeZO1g==}
@@ -8869,45 +7048,6 @@ packages:
       '@udecode/plate-common': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-xN62xPasT5IVzi9k/pbdoR1U3ZobbolXVWDVqjvYaiPWgVtyt4VNxwaIjfqhtb2lTtQZakwV5XjaQcIcjeZO1g==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-code-block': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8972,39 +7112,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-combobox@10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-bJ1A+Dqx6Ydh3KSZoQPVaXKs4KnY5mUAY72Xt7rF4XT5l/qNKuhM+QDud6apBLd5qlqFfDo5dO3/W3u+U556Vw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-popper': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-QJys2QEc+KlslbKQ1M+PxhYl7JoYr4Lr948iaPIOuYyQQAPSZIR5DFTsKgwst8vDL9TqXQIb/lL/jcUCyC8GWw==}
     peerDependencies:
@@ -9019,45 +7126,6 @@ packages:
       '@udecode/plate-common': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-floating': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-QJys2QEc+KlslbKQ1M+PxhYl7JoYr4Lr948iaPIOuYyQQAPSZIR5DFTsKgwst8vDL9TqXQIb/lL/jcUCyC8GWw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -9137,46 +7205,6 @@ packages:
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-comments@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-+XjpARWNGt/xXWIEb+wEjD47piKSw3Fh7Y4P1fO9zl5FwIJXBankhW6V2HJQP6nw9WkTYx/DABI/C4OFAHr19w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-comments': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -9312,44 +7340,7 @@ packages:
       - react-is
       - react-native
       - scheduler
-
-  /@udecode/plate-ui-dnd@10.5.3(@babel/core@7.22.11)(@types/node@18.17.12)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-3VC9WtfcB+QB6l2cPD3rVWF6Qb9Vyhk13i2qR//q1uZq5XtQMDCeAQL/dRRd5ux1boIS1RtPJgzuWhFqKdTjjg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@react-hook/merged-ref': 1.3.2(react@18.2.0)
-      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dnd: 14.0.5(@types/node@18.17.12)(@types/react@18.2.21)(react@18.2.0)
-      react-dnd-html5-backend: 14.1.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-ui-emoji@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-EzweF/YUbs6KEyGAnyBHHuduK1iW03fuPrT07YcN83RFxIu+sFPLDFbHmOVklVG1xOuo1k6WYyE37OvaNXEkeA==}
@@ -9367,47 +7358,6 @@ packages:
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-emoji@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-EzweF/YUbs6KEyGAnyBHHuduK1iW03fuPrT07YcN83RFxIu+sFPLDFbHmOVklVG1xOuo1k6WYyE37OvaNXEkeA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-emoji': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -9474,40 +7424,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-find-replace@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-AQYNMyQcMQgfw2ItEZ68SlG7QzR7D1mDgz1y+IdsjAZjQ3cc5f+XE0fd9v2M9tlIzJXMbDTPEibOl+QeSI+F/Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-find-replace': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-b21VoIiKJbj60rMC8MPrTkayysZlGEoksJ+QpAwPi8whDtq/DCWeCY/8brGJPD/ivRKLmvlttnAkPQGCsL12JQ==}
     peerDependencies:
@@ -9522,45 +7438,6 @@ packages:
       '@udecode/plate-find-replace': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-b21VoIiKJbj60rMC8MPrTkayysZlGEoksJ+QpAwPi8whDtq/DCWeCY/8brGJPD/ivRKLmvlttnAkPQGCsL12JQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -9625,41 +7502,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-font@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-jsX1+UP2yZWeRy7ZXqYjavNLWLHivFXGbAznE/3kP3/2GYp0z0T5cfzemaqdqTEVohzLAO5V7I7q97Iget0l/Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-font': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-button': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-font@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-wGy1TXSSF2KpWauKqpW7RBZ5EPgc16ds1r3bPNrw8utHO3WH4vuluGnWKJdIemguJeeTgiPiOp9LyVEA9PPZjQ==}
     peerDependencies:
@@ -9675,46 +7517,6 @@ packages:
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-font@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-wGy1TXSSF2KpWauKqpW7RBZ5EPgc16ds1r3bPNrw8utHO3WH4vuluGnWKJdIemguJeeTgiPiOp9LyVEA9PPZjQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-font': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -9780,77 +7582,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-image@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-UhJmfAp/VXQMuzwv2QJkBSmmrb8O08NBaY9PVbbEZFXPzDt1k8U20TTHrCzlX5O8aklDwnXeoACrKdpAP8DuQg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-image': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      re-resizable: 6.9.11(react-dom@18.2.0)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-textarea-autosize: 8.4.0(@types/react@18.2.21)(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-line-height@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-b6+Fov+UGecbSsJrHtnPpovld4yT4/NWc+qGZPYLVBjGX8swbkQWGJimNUEmjmP0tHCj4W/CKQIPQASYlEnwVg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-line-height': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-ddkxbNark/DbQLc2gNPfVnlA+5YUWuLeEMGl0nEAmuvq5IZCBZXz2icSccMjv+EqcioQVKBrHi+PqP0EUYMY2w==}
     peerDependencies:
@@ -9865,45 +7596,6 @@ packages:
       '@udecode/plate-line-height': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-ddkxbNark/DbQLc2gNPfVnlA+5YUWuLeEMGl0nEAmuvq5IZCBZXz2icSccMjv+EqcioQVKBrHi+PqP0EUYMY2w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-line-height': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -9968,40 +7660,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-link@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-OooB8MEmtV/6NE13/fbnLn8TbQoNxi5iaZcofmjxKb2X/HUOkG+ZY3yn1oVCXedVUsdgbEzUvoyBPBcnJL5PjA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-link': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-link@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-kk3gNmSqTFGfna/+fHDPl1iQ3jClOk44zrVgHanN72d4dWHzgyUSocrHrldUuQkECfFhCg4S5gIn82rKBK5rYg==}
     peerDependencies:
@@ -10017,46 +7675,6 @@ packages:
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-link@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-kk3gNmSqTFGfna/+fHDPl1iQ3jClOk44zrVgHanN72d4dWHzgyUSocrHrldUuQkECfFhCg4S5gIn82rKBK5rYg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -10122,40 +7740,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-list@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-LNrJMs1St3x6RR+4Uoeg8ZuuqnwU+5DPOEKSorSwzFxkoyHDvUZsluzQIzfRCYirXLWFhkadKvaxnyVmhGSkSA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-list': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-list@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-dtq4fMH3aJOxkq8klBC7AHLZgQDu9gD0ObFbvahqLFxyyHbRZmWWtKnOVZauCSvvU/Dsi6oK96wSBHHNezi3/w==}
     peerDependencies:
@@ -10170,45 +7754,6 @@ packages:
       '@udecode/plate-list': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-list@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-dtq4fMH3aJOxkq8klBC7AHLZgQDu9gD0ObFbvahqLFxyyHbRZmWWtKnOVZauCSvvU/Dsi6oK96wSBHHNezi3/w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-list': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -10273,40 +7818,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-media-embed@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-hwbHoYYldZjSTkUqcVGhZ8M8Vvc18jZPQKoBM9ZdKbxfQTeZNUfZEq12mzqJ+EtKjaw0vZqOHrsD3ydK+wFyew==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-media-embed': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-media@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-QYByExzxchHeXflxdMz/aI5reUeTHyPILj3vaunObE1b2q2Vi5TDFW2kBl/ikA5FtcJWgqFq6SH1cKUztSlVPg==}
     peerDependencies:
@@ -10324,49 +7835,6 @@ packages:
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      js-video-url-parser: 0.5.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-media@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-QYByExzxchHeXflxdMz/aI5reUeTHyPILj3vaunObE1b2q2Vi5TDFW2kBl/ikA5FtcJWgqFq6SH1cKUztSlVPg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-media': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       js-video-url-parser: 0.5.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -10436,40 +7904,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-mention@10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-z+EqRXMAPAu0DdYaEbxOGj9Ny5FqB2lQVJgVSUnCL2o+gNx+C7nfbK1pHOj2XDGH839UNv3ambC7rJrcT1IhCg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-mention': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-combobox': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-mention@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-dD5QV/05oY9DJrF4Ls8rYlhZrZTqYD2oS2+eY31fo9TKsvbEArypVA9gbLAB+JtY3flWTF/XK8ZtQDK4Ky/Srw==}
     peerDependencies:
@@ -10485,46 +7919,6 @@ packages:
       '@udecode/plate-mention': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-mention@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-dD5QV/05oY9DJrF4Ls8rYlhZrZTqYD2oS2+eY31fo9TKsvbEArypVA9gbLAB+JtY3flWTF/XK8ZtQDK4Ky/Srw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-mention': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -10589,37 +7983,6 @@ packages:
       - react-native
       - scheduler
     dev: true
-
-  /@udecode/plate-ui-placeholder@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-t6R2qIFWDU6vd6J5Jpp9f7prQNgIf/1qjJUjeq5nO1/ZamovfAmNvRkJmRDPcl1eN6oZki6AgmLmNehVhKyqKA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
 
   /@udecode/plate-ui-placeholder@21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-scZVD6/fWGMRYYAmlJ2OLGvYCeTD4zEOj2EPWeI5ztspqbVjqmGkOB/N54cSZkEZne2rwCfqNmJ8wkZr91T8Ig==}
@@ -10691,113 +8054,7 @@ packages:
       - react-is
       - react-native
       - scheduler
-
-  /@udecode/plate-ui-popover@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-ex5wqC01XV+vxZmfmmPcaSCuZbOrmyNQazm0bVs95TW8vV3bsRdPieWd6vX3a4jfX8sWGnXQMgWq3wpdWz6o7Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - styled-components
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-popper@10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-OoIlEgxdphITc+qEyO6Hw5bqNaoVv6RgJY8kLHZHSaKrPh60reZT/QyvRzZPz4TM4HEcBIfabNwBetAkcwL21A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-    dependencies:
-      '@popperjs/core': 2.10.2
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-popper: 2.2.5(@popperjs/core@2.10.2)(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-table@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-mCT0CA8phY95kQVruSuUH3KNdRkZANC49LsEE1bsr1oj9RN+hESHM0XGnmvmpFRq94pKIfNhtnBD5QLMIFsGGw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-table': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-ui-button': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-popover': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      jotai: 1.13.1(@babel/core@7.22.11)(react@18.2.0)
-      re-resizable: 6.9.11(react-dom@18.2.0)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate-ui-table@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-7ZN/RMbkINTFMV5i/3KD9UnAqHRTUlJ9NA554ahoRio3+GNzXfnf2wXF98Q4NnELz245nasqkOqZ3qj18u/l3Q==}
@@ -10815,47 +8072,6 @@ packages:
       '@udecode/plate-table': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-table@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-7ZN/RMbkINTFMV5i/3KD9UnAqHRTUlJ9NA554ahoRio3+GNzXfnf2wXF98Q4NnELz245nasqkOqZ3qj18u/l3Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -10922,42 +8138,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui-toolbar@10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-iLcjG6THgifVQWiBySRGpnQweGJCrd+hYg68+hk4OeNkMU5iTk1pw440bz3F2uAjx7I6ZzGRICBTiB00fceBPw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-core': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-popper': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0)
-      react-use: 17.4.0(react-dom@18.2.0)(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-query
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-toolbar@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-V5Z/Y64RtAyeoeZGqz+xTKKdiKE3M0CC23kF9tQx0ciHRSM+/VdV58Xp20Oe6RKlIe91BXNQrprIezbabZA1HA==}
     peerDependencies:
@@ -10973,47 +8153,6 @@ packages:
       '@udecode/plate-floating': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-use: 17.4.0(react-dom@18.2.0)(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-toolbar@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-V5Z/Y64RtAyeoeZGqz+xTKKdiKE3M0CC23kF9tQx0ciHRSM+/VdV58Xp20Oe6RKlIe91BXNQrprIezbabZA1HA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-use: 17.4.0(react-dom@18.2.0)(react@18.2.0)
@@ -11081,73 +8220,6 @@ packages:
       - scheduler
     dev: true
 
-  /@udecode/plate-ui@10.6.0(@babel/core@7.22.11)(@popperjs/core@2.11.6)(@types/node@18.17.12)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-TIp4yhXyNMQR+xRxBUZFc1qhhR4JtIRRUjzOThugkmykLCtyLXJcykBO2A6HSD9dNTDurIzBcnJs6h2HQFp3rA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-headless': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-styled-components': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-alignment': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-block-quote': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-button': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-code-block': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-combobox': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-dnd': 10.5.3(@babel/core@7.22.11)(@types/node@18.17.12)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-find-replace': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-font': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-image': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-line-height': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-link': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-list': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-media-embed': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-mention': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-placeholder': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-popover': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-popper': 10.5.3(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-ui-table': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      '@udecode/plate-ui-toolbar': 10.5.3(@babel/core@7.22.11)(@popperjs/core@2.11.6)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-hyperscript: 0.77.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - encoding
-      - immer
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - optics-ts
-      - react-is
-      - react-query
-      - supports-color
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-F5Llhi04azilhnq8AmuwoalDCGsK0HHQyzPsQ0G0GpZfjSf6sRN3dxfBE7AZ6WzK7hShS1CFdN+SV/2LF/K+qw==}
     peerDependencies:
@@ -11181,69 +8253,6 @@ packages:
       '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.22.11)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-table': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dnd: 16.0.1(@types/node@18.17.12)(@types/react@18.2.21)(react@18.2.0)
-      react-dnd-html5-backend: 15.1.2
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-hyperscript: 0.77.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      use-context-selector: 1.4.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-      - supports-color
-    dev: false
-
-  /@udecode/plate-ui@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-F5Llhi04azilhnq8AmuwoalDCGsK0HHQyzPsQ0G0GpZfjSf6sRN3dxfBE7AZ6WzK7hShS1CFdN+SV/2LF/K+qw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dnd: '>=14.0.0'
-      react-dnd-html5-backend: '>=14.0.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-headless': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.22.9)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dnd: 16.0.1(@types/node@18.17.12)(@types/react@18.2.21)(react@18.2.0)
       react-dnd-html5-backend: 15.1.2
@@ -11409,54 +8418,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
-
-  /@udecode/plate@10.6.0(@babel/core@7.22.11)(@popperjs/core@2.11.6)(@types/node@18.17.12)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1):
-    resolution: {integrity: sha512-6HKb6p+2dYF+c3PtHNcErfymLFI8XOiaV805wgJUWXKY9CT7r4OpEXFqerjFQrhx+wk+Lc/HW5sYgGmzT74RdQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.66.1'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.74.2'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-headless': 10.6.0(@babel/core@7.22.11)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(xstate@4.28.1)
-      '@udecode/plate-ui': 10.6.0(@babel/core@7.22.11)(@popperjs/core@2.11.6)(@types/node@18.17.12)(@types/react@18.2.21)(immer@9.0.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(slate-history@0.66.0)(slate-hyperscript@0.77.0)(slate-react@0.79.0)(slate@0.78.0)(styled-components@5.3.6)(xstate@4.28.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.78.0
-      slate-history: 0.66.0(slate@0.78.0)
-      slate-hyperscript: 0.77.0(slate@0.78.0)
-      slate-react: 0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@popperjs/core'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - encoding
-      - immer
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - optics-ts
-      - react-is
-      - react-query
-      - supports-color
-      - valtio
-      - wonka
-      - xstate
-    dev: false
+    dev: true
 
   /@udecode/plate@21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
     resolution: {integrity: sha512-uKAmKHwPgzo/XzrYWrbJ0FuqJRvU394aXZMkx4bXnHzVuCvQT4HNxZM4yM+RagdRHXr6xKZxdxQG70xKF2/5Jg==}
@@ -11471,48 +8433,6 @@ packages:
     dependencies:
       '@udecode/plate-headless': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
       '@udecode/plate-ui': 21.5.0(@babel/core@7.22.11)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-hyperscript: 0.77.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-dnd
-      - react-dnd-html5-backend
-      - react-is
-      - react-native
-      - scheduler
-      - supports-color
-    dev: false
-
-  /@udecode/plate@21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-uKAmKHwPgzo/XzrYWrbJ0FuqJRvU394aXZMkx4bXnHzVuCvQT4HNxZM4yM+RagdRHXr6xKZxdxQG70xKF2/5Jg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-headless': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-ui': 21.5.0(@babel/core@7.22.9)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.2)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -11646,6 +8566,7 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: true
 
   /@udecode/slate-react@21.4.1(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1):
     resolution: {integrity: sha512-IXuH3Icafegm4hmlRvOoBIzTN+INcR3tb8s+ZuRsa78ItNvTrlJ6O8yw0Bgqtl0sZ5PfwHwnPjELxwq0aWg8bg==}
@@ -11688,15 +8609,6 @@ packages:
 
   /@udecode/utils@19.7.1:
     resolution: {integrity: sha512-FqPvq/0MOI8qvX3KvQfTKNUkvh8CwHxke9CyoqMck5dxeOmge3vHMkHkCE1BXw2w19EFGkC58Tkw8+RpT8qFSQ==}
-
-  /@udecode/zustood@0.4.4(zustand@3.7.0):
-    resolution: {integrity: sha512-OtkRGu8TKBkidOOf28TY4tqYJRhMAiVt+BF6lHbF/FnXRmOa8eLal8Q/k9sqQcGzQAHBaZYcx0pR1+wlQzaurg==}
-    peerDependencies:
-      zustand: '>=3.5.10'
-    dependencies:
-      immer: 9.0.6
-      zustand: 3.7.0(react@18.2.0)
-    dev: false
 
   /@udecode/zustood@1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@3.7.2):
     resolution: {integrity: sha512-f3mxHDaOF+q2XvDh/mMvLhCNs0LfCLhIBl8jGmvZT/i3WWq7YujzGXgnbK8mxIkun9irfe6wlPhg9sTIB9Gnug==}
@@ -11902,16 +8814,6 @@ packages:
       immer: 9.0.12
       xstate: 4.28.1
 
-  /@xstate/immer@0.3.1(immer@9.0.21)(xstate@4.28.1):
-    resolution: {integrity: sha512-YE+KY08IjEEmXo6XKKpeSGW4j9LfcXw+5JVixLLUO3fWQ3M95joWJ40VtGzx0w0zQSzoCNk8NgfvwWBGSbIaTA==}
-    peerDependencies:
-      immer: ^9.0.6
-      xstate: ^4.29.0
-    dependencies:
-      immer: 9.0.21
-      xstate: 4.28.1
-    dev: false
-
   /@xstate/react@1.6.3(@types/react@18.2.21)(react@18.2.0)(xstate@4.28.1):
     resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
     peerDependencies:
@@ -12011,6 +8913,7 @@ packages:
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+    dev: true
 
   /ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -12284,11 +9187,6 @@ packages:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     dev: true
 
-  /axe-core@4.7.2:
-    resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
-    engines: {node: '>=4'}
-    dev: false
-
   /babel-plugin-styled-components@2.1.1(styled-components@5.3.6):
     resolution: {integrity: sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==}
     peerDependencies:
@@ -12315,10 +9213,6 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  /batch-processor@1.0.0:
-    resolution: {integrity: sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==}
-    dev: false
 
   /bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -12358,6 +9252,7 @@ packages:
 
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: true
 
   /bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
@@ -12469,6 +9364,7 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.2.0
+    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -12563,30 +9459,6 @@ packages:
     resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
     engines: {node: '>= 0.8.0'}
     dev: true
-
-  /cheerio-select@2.1.0:
-    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
-    dependencies:
-      boolbase: 1.0.0
-      css-select: 5.1.0
-      css-what: 6.1.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.0.1
-    dev: false
-
-  /cheerio@1.0.0-rc.12:
-    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
-    engines: {node: '>= 6'}
-    dependencies:
-      cheerio-select: 2.1.0
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      domutils: 3.0.1
-      htmlparser2: 8.0.1
-      parse5: 7.1.2
-      parse5-htmlparser2-tree-adapter: 7.0.0
-    dev: false
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -12686,11 +9558,6 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
-  /clsx@1.1.1:
-    resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
-    engines: {node: '>=6'}
-    dev: false
-
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
@@ -12743,6 +9610,7 @@ packages:
   /commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
+    dev: true
 
   /common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
@@ -12796,11 +9664,6 @@ packages:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
     dependencies:
       toggle-selection: 1.0.6
-
-  /core-js@3.32.1:
-    resolution: {integrity: sha512-lqufgNn9NLnESg5mQeYsxQP5w7wrViSj0jr/kv6ECQiByzQkrn1MKvV0L3acttpDqfQrHLwr2KCMgX5b8X+lyQ==}
-    requiresBuild: true
-    dev: false
 
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -12862,16 +9725,6 @@ packages:
       nth-check: 2.1.1
     dev: true
 
-  /css-select@5.1.0:
-    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.1.0
-      domhandler: 5.0.3
-      domutils: 3.0.1
-      nth-check: 2.1.1
-    dev: false
-
   /css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
     dependencies:
@@ -12889,6 +9742,7 @@ packages:
   /css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
+    dev: true
 
   /css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -13190,28 +10044,12 @@ packages:
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  /dnd-core@14.0.1:
-    resolution: {integrity: sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==}
-    dependencies:
-      '@react-dnd/asap': 4.0.0
-      '@react-dnd/invariant': 2.0.0
-      redux: 4.2.1
-    dev: false
-
   /dnd-core@15.1.1:
     resolution: {integrity: sha512-Mtj/Sltcx7stVXzeDg4g7roTe/AmzRuIf/FYOxX6F8gULbY54w066BlErBOzQfn9RIJ3gAYLGX7wvVvoBSq7ig==}
     dependencies:
       '@react-dnd/asap': 4.0.0
       '@react-dnd/invariant': 3.0.0
       redux: 4.2.1
-
-  /dnd-core@15.1.2:
-    resolution: {integrity: sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==}
-    dependencies:
-      '@react-dnd/asap': 4.0.1
-      '@react-dnd/invariant': 3.0.1
-      redux: 4.2.1
-    dev: false
 
   /dnd-core@16.0.1:
     resolution: {integrity: sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==}
@@ -13244,6 +10082,7 @@ packages:
       domelementtype: 2.3.0
       domhandler: 4.3.1
       entities: 2.2.0
+    dev: true
 
   /dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -13251,32 +10090,25 @@ packages:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       entities: 4.5.0
-
-  /dom-walk@0.1.2:
-    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
-    dev: false
+    dev: true
 
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-
-  /domhandler@3.3.0:
-    resolution: {integrity: sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==}
-    engines: {node: '>= 4'}
-    dependencies:
-      domelementtype: 2.3.0
-    dev: false
+    dev: true
 
   /domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
+    dev: true
 
   /domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
+    dev: true
 
   /domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -13284,6 +10116,7 @@ packages:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
+    dev: true
 
   /domutils@3.0.1:
     resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
@@ -13291,6 +10124,7 @@ packages:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+    dev: true
 
   /dot-prop@7.2.0:
     resolution: {integrity: sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==}
@@ -13316,19 +10150,6 @@ packages:
       react-is: 17.0.2
       tslib: 2.6.1
 
-  /downshift@6.1.7(react@18.2.0):
-    resolution: {integrity: sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==}
-    peerDependencies:
-      react: '>=16.12.0'
-    dependencies:
-      '@babel/runtime': 7.21.0
-      compute-scroll-into-view: 1.0.20
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-is: 17.0.2
-      tslib: 2.6.1
-    dev: false
-
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
@@ -13346,12 +10167,6 @@ packages:
   /electron-to-chromium@1.4.508:
     resolution: {integrity: sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg==}
     dev: true
-
-  /element-resize-detector@1.2.4:
-    resolution: {integrity: sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==}
-    dependencies:
-      batch-processor: 1.0.0
-    dev: false
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -13375,10 +10190,12 @@ packages:
 
   /entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+    dev: true
 
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+    dev: true
 
   /env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -13509,11 +10326,6 @@ packages:
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
-
-  /escape-goat@3.0.0:
-    resolution: {integrity: sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==}
-    engines: {node: '>=10'}
-    dev: false
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -14093,6 +10905,7 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+    dev: true
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -14197,30 +11010,6 @@ packages:
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
 
-  /framer-motion@6.5.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
-    peerDependencies:
-      react: '>=16.8 || ^17.0.0 || ^18.0.0'
-      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
-    dependencies:
-      '@motionone/dom': 10.12.0
-      framesync: 6.0.1
-      hey-listen: 1.0.8
-      popmotion: 11.0.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      style-value-types: 5.0.0
-      tslib: 2.6.1
-    optionalDependencies:
-      '@emotion/is-prop-valid': 0.8.8
-    dev: false
-
-  /framesync@6.0.1:
-    resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
-    dependencies:
-      tslib: 2.6.1
-    dev: false
-
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: false
@@ -14316,6 +11105,7 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
+    dev: true
 
   /get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -14406,13 +11196,6 @@ packages:
     dependencies:
       ini: 2.0.0
     dev: true
-
-  /global@4.4.0:
-    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
-    dependencies:
-      min-document: 2.19.0
-      process: 0.11.10
-    dev: false
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -14508,12 +11291,14 @@ packages:
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
 
   /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -14537,10 +11322,6 @@ packages:
       set-cookie-parser: 2.6.0
     dev: true
 
-  /hey-listen@1.0.8:
-    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
-    dev: false
-
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -14557,15 +11338,6 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /htmlparser2@4.1.0:
-    resolution: {integrity: sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==}
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 3.3.0
-      domutils: 2.8.0
-      entities: 2.2.0
-    dev: false
-
   /htmlparser2@8.0.1:
     resolution: {integrity: sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==}
     dependencies:
@@ -14573,6 +11345,7 @@ packages:
       domhandler: 5.0.3
       domutils: 3.0.1
       entities: 4.5.0
+    dev: true
 
   /http-signature@1.3.6:
     resolution: {integrity: sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==}
@@ -14634,10 +11407,6 @@ packages:
 
   /immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
-
-  /immer@9.0.6:
-    resolution: {integrity: sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==}
-    dev: false
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -14836,10 +11605,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /is-function@1.0.2:
-    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
-    dev: false
-
   /is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
@@ -14934,6 +11699,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
+    dev: true
 
   /is-set@2.0.2:
     resolution: {integrity: sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==}
@@ -14972,6 +11738,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
 
   /is-typed-array@1.1.10:
     resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
@@ -15035,11 +11802,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  /isobject@4.0.0:
-    resolution: {integrity: sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -15181,46 +11943,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       react: 18.2.0
-
-  /jotai@1.5.3(@babel/core@7.22.11)(immer@9.0.21)(react@18.2.0)(xstate@4.28.1):
-    resolution: {integrity: sha512-iD8MkbehxTjfRUtIJJdyQcjbAe2MqjW1+oFc5lvfgRjLHwjRQyWnZC3gdGAOQCOqUSPZHOBGgWyP/8gBDckaNQ==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      '@babel/template': '*'
-      '@urql/core': '*'
-      immer: '*'
-      optics-ts: '*'
-      react: '>=16.8'
-      react-query: '*'
-      valtio: '*'
-      wonka: '*'
-      xstate: '*'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
-      '@urql/core':
-        optional: true
-      immer:
-        optional: true
-      optics-ts:
-        optional: true
-      react-query:
-        optional: true
-      valtio:
-        optional: true
-      wonka:
-        optional: true
-      xstate:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.11
-      immer: 9.0.21
-      react: 18.2.0
-      xstate: 4.28.1
-    dev: false
+    dev: true
 
   /js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
@@ -15349,20 +12072,6 @@ packages:
       object.assign: 4.1.4
     dev: true
 
-  /juice@8.0.0:
-    resolution: {integrity: sha512-LRCfXBOqI1wt+zYR/5xwDnf+ZyiJiDt44DGZaBSAVwZWyWv3BliaiGTLS6KCvadv3uw6XGiPPFcTfY7CdF7Z/Q==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    dependencies:
-      cheerio: 1.0.0-rc.12
-      commander: 6.2.1
-      mensch: 0.3.4
-      slick: 1.12.2
-      web-resource-inliner: 5.0.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /just-extend@4.2.1:
     resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
     dev: true
@@ -15459,6 +12168,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
+    dev: true
 
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -15614,10 +12324,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /map-or-similar@1.5.0:
-    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
-    dev: false
-
   /markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
 
@@ -15736,16 +12442,6 @@ packages:
 
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-
-  /memoizerific@1.11.3:
-    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
-    dependencies:
-      map-or-similar: 1.5.0
-    dev: false
-
-  /mensch@0.3.4:
-    resolution: {integrity: sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==}
-    dev: false
 
   /meow@6.1.1:
     resolution: {integrity: sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==}
@@ -16022,12 +12718,6 @@ packages:
       mime-db: 1.52.0
     dev: true
 
-  /mime@2.6.0:
-    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
-    dev: false
-
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -16035,12 +12725,6 @@ packages:
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
-
-  /min-document@2.19.0:
-    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
-    dependencies:
-      dom-walk: 0.1.2
-    dev: false
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -16282,6 +12966,7 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
 
   /node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -16340,6 +13025,7 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
+    dev: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -16351,6 +13037,7 @@ packages:
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
+    dev: true
 
   /object-is@1.1.5:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
@@ -16499,6 +13186,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
+    dev: true
 
   /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -16519,6 +13207,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
+    dev: true
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -16549,6 +13238,7 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /papaparse@5.4.1:
     resolution: {integrity: sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==}
@@ -16580,22 +13270,10 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
-  /parse5-htmlparser2-tree-adapter@7.0.0:
-    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
-    dependencies:
-      domhandler: 5.0.3
-      parse5: 7.1.2
-    dev: false
-
-  /parse5@7.1.2:
-    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
-    dependencies:
-      entities: 4.5.0
-    dev: false
-
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+    dev: true
 
   /path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
@@ -16723,15 +13401,6 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
     dev: true
-
-  /popmotion@11.0.3:
-    resolution: {integrity: sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==}
-    dependencies:
-      framesync: 6.0.1
-      hey-listen: 1.0.8
-      style-value-types: 5.0.0
-      tslib: 2.6.1
-    dev: false
 
   /postcss-import@15.1.0(postcss@8.4.29):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -16929,6 +13598,7 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
+    dev: true
 
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -16945,16 +13615,6 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
     dev: true
-
-  /re-resizable@6.9.11(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-a3hiLWck/NkmyLvGWUuvkAmN1VhwAz4yOhS6FdMTaxCUVN9joIWkT11wsO68coG/iEYuwn+p/7qAmfQzRhiPLQ==}
-    peerDependencies:
-      react: ^16.13.1 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
@@ -16980,66 +13640,10 @@ packages:
       react-onclickoutside: 6.12.2(react-dom@18.2.0)(react@18.2.0)
       react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0)
 
-  /react-dnd-html5-backend@14.1.0:
-    resolution: {integrity: sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==}
-    dependencies:
-      dnd-core: 14.0.1
-    dev: false
-
   /react-dnd-html5-backend@15.1.2:
     resolution: {integrity: sha512-mem9QbutUF+aA2YC1y47G3ECjnYV/sCYKSnu5Jd7cbg3fLMPAwbnTf/JayYdnCH5l3eg9akD9dQt+cD0UdF8QQ==}
     dependencies:
       dnd-core: 15.1.1
-
-  /react-dnd@14.0.5(@types/node@18.17.12)(@types/react@18.2.21)(react@18.2.0):
-    resolution: {integrity: sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==}
-    peerDependencies:
-      '@types/hoist-non-react-statics': '>= 3.3.1'
-      '@types/node': '>= 12'
-      '@types/react': '>= 16'
-      react: '>= 16.14'
-    peerDependenciesMeta:
-      '@types/hoist-non-react-statics':
-        optional: true
-      '@types/node':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@react-dnd/invariant': 2.0.0
-      '@react-dnd/shallowequal': 2.0.0
-      '@types/node': 18.17.12
-      '@types/react': 18.2.21
-      dnd-core: 14.0.1
-      fast-deep-equal: 3.1.3
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    dev: false
-
-  /react-dnd@15.1.2(@types/node@18.17.12)(@types/react@18.2.21)(react@18.2.0):
-    resolution: {integrity: sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==}
-    peerDependencies:
-      '@types/hoist-non-react-statics': '>= 3.3.1'
-      '@types/node': '>= 12'
-      '@types/react': '>= 16'
-      react: '>= 16.14'
-    peerDependenciesMeta:
-      '@types/hoist-non-react-statics':
-        optional: true
-      '@types/node':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@react-dnd/invariant': 3.0.1
-      '@react-dnd/shallowequal': 3.0.1
-      '@types/node': 18.17.12
-      '@types/react': 18.2.21
-      dnd-core: 15.1.2
-      fast-deep-equal: 3.1.3
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    dev: false
 
   /react-dnd@16.0.1(@types/node@18.17.12)(@types/react@18.2.21)(react@18.2.0):
     resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
@@ -17104,18 +13708,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /react-popper@2.2.5(@popperjs/core@2.10.2)(react@18.2.0):
-    resolution: {integrity: sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==}
-    peerDependencies:
-      '@popperjs/core': ^2.0.0
-      react: ^16.8.0 || ^17
-    dependencies:
-      '@popperjs/core': 2.10.2
-      react: 18.2.0
-      react-fast-compare: 3.2.1
-      warning: 4.0.3
-    dev: false
-
   /react-popper@2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
@@ -17165,15 +13757,6 @@ packages:
       tslib: 2.6.1
       use-callback-ref: 1.3.0(@types/react@18.2.21)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.21)(react@18.2.0)
-
-  /react-sizeme@3.0.2:
-    resolution: {integrity: sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==}
-    dependencies:
-      element-resize-detector: 1.2.4
-      invariant: 2.2.4
-      shallowequal: 1.1.0
-      throttle-debounce: 3.0.1
-    dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.21)(react@18.2.0):
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
@@ -17409,13 +13992,6 @@ packages:
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
-
-  /remark-slate@1.8.6:
-    resolution: {integrity: sha512-1Gmt5MGw25MRVP+0xTXqw9JQDWfRNWujD4YFCPg036a9DZYhn7mLFjM6jreHB+9hKa6RCMOm5thiXznAmdn8Ug==}
-    dependencies:
-      '@types/escape-html': 1.0.2
-      escape-html: 1.0.3
-    dev: false
 
   /request-progress@3.0.0:
     resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
@@ -17666,6 +14242,7 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
       object-inspect: 1.12.3
+    dev: true
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -17708,15 +14285,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /slate-history@0.66.0(slate@0.78.0):
-    resolution: {integrity: sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==}
-    peerDependencies:
-      slate: '>=0.65.3'
-    dependencies:
-      is-plain-object: 5.0.0
-      slate: 0.78.0
-    dev: false
-
   /slate-history@0.93.0(slate@0.94.1):
     resolution: {integrity: sha512-Gr1GMGPipRuxIz41jD2/rbvzPj8eyar56TVMyJBvBeIpQSSjNISssvGNDYfJlSWM8eaRqf6DAcxMKzsLCYeX6g==}
     peerDependencies:
@@ -17725,15 +14293,6 @@ packages:
       is-plain-object: 5.0.0
       slate: 0.94.1
 
-  /slate-hyperscript@0.77.0(slate@0.78.0):
-    resolution: {integrity: sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==}
-    peerDependencies:
-      slate: '>=0.65.3'
-    dependencies:
-      is-plain-object: 5.0.0
-      slate: 0.78.0
-    dev: false
-
   /slate-hyperscript@0.77.0(slate@0.94.1):
     resolution: {integrity: sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==}
     peerDependencies:
@@ -17741,26 +14300,6 @@ packages:
     dependencies:
       is-plain-object: 5.0.0
       slate: 0.94.1
-
-  /slate-react@0.79.0(react-dom@18.2.0)(react@18.2.0)(slate@0.78.0):
-    resolution: {integrity: sha512-uPzYArGwHKq4QvpzRvP/DVvsDgB2Zw6x9Som/hJWaydu18r0Vp2vmgHL0Dbc4EU6pUNV6o83XbBJLLEwISzBHQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.65.3'
-    dependencies:
-      '@types/is-hotkey': 0.1.7
-      '@types/lodash': 4.14.192
-      direction: 1.0.4
-      is-hotkey: 0.1.8
-      is-plain-object: 5.0.0
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      scroll-into-view-if-needed: 2.2.31
-      slate: 0.78.0
-      tiny-invariant: 1.0.6
-    dev: false
 
   /slate-react@0.98.2(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1):
     resolution: {integrity: sha512-1GOi0DRuGMpzAmkW0DYSebEBHhE4ryffCW/bprlo4B2wdkMgt0dC9NtXHK76B3QjJwtGQZ+OsiFtwT9O3hRamQ==}
@@ -17802,14 +14341,6 @@ packages:
       slate: 0.94.1
       tiny-invariant: 1.0.6
 
-  /slate@0.78.0:
-    resolution: {integrity: sha512-VwQ0RafT3JPf9SFrXI02Dh3S4Iz9en7d1nn50C/LJjjqjfgv+a2ORbgWMdYjhycPYldaxJwcI3OpP9D1g4SXEg==}
-    dependencies:
-      immer: 9.0.21
-      is-plain-object: 5.0.0
-      tiny-warning: 1.0.3
-    dev: false
-
   /slate@0.94.1:
     resolution: {integrity: sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==}
     dependencies:
@@ -17834,10 +14365,6 @@ packages:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
     dev: true
-
-  /slick@1.12.2:
-    resolution: {integrity: sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==}
-    dev: false
 
   /smartwrap@2.0.2:
     resolution: {integrity: sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==}
@@ -17963,10 +14490,6 @@ packages:
     dependencies:
       internal-slot: 1.0.5
     dev: true
-
-  /store2@2.14.2:
-    resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
-    dev: false
 
   /stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
@@ -18105,13 +14628,6 @@ packages:
     resolution: {integrity: sha512-IgTveO0OGXMMi9iZtfPoYQY6IpeZR3ILtSsjMapFgLxofWaHG1sNlInV7yTRDV06YiNdwiKrK7505Fxq8ly+YA==}
     dev: false
 
-  /style-value-types@5.0.0:
-    resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
-    dependencies:
-      hey-listen: 1.0.8
-      tslib: 2.6.1
-    dev: false
-
   /styled-components@5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==}
     engines: {node: '>=10'}
@@ -18224,19 +14740,6 @@ packages:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.0
-    dev: false
-
-  /telejson@6.0.8:
-    resolution: {integrity: sha512-nerNXi+j8NK1QEfBHtZUN/aLdDcyupA//9kAboYLrtzZlPLpUfqbVGWb9zz91f/mIjRbAYhbgtnJHY8I1b5MBg==}
-    dependencies:
-      '@types/is-function': 1.0.1
-      global: 4.4.0
-      is-function: 1.0.2
-      is-regex: 1.1.4
-      is-symbol: 1.0.4
-      isobject: 4.0.0
-      lodash: 4.17.21
-      memoizerific: 1.11.3
     dev: false
 
   /term-size@2.2.1:
@@ -18367,6 +14870,7 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
 
   /trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
@@ -18387,11 +14891,6 @@ packages:
     dependencies:
       typescript: 5.2.2
     dev: true
-
-  /ts-dedent@2.2.0:
-    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
-    engines: {node: '>=6.10'}
-    dev: false
 
   /ts-easing@0.2.0:
     resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
@@ -18779,22 +15278,12 @@ packages:
       convert-source-map: 1.9.0
     dev: true
 
-  /valid-data-url@3.0.1:
-    resolution: {integrity: sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==}
-    engines: {node: '>=10'}
-    dev: false
-
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: true
-
-  /validator@13.7.0:
-    resolution: {integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==}
-    engines: {node: '>= 0.10'}
-    dev: false
 
   /validator@13.9.0:
     resolution: {integrity: sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==}
@@ -19048,20 +15537,6 @@ packages:
       '@zxing/text-encoding': 0.9.0
     dev: true
 
-  /web-resource-inliner@5.0.0:
-    resolution: {integrity: sha512-AIihwH+ZmdHfkJm7BjSXiEClVt4zUFqX4YlFAzjL13wLtDuUneSaFvDBTbdYRecs35SiU7iNKbMnN+++wVfb6A==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      ansi-colors: 4.1.3
-      escape-goat: 3.0.0
-      htmlparser2: 4.1.0
-      mime: 2.6.0
-      node-fetch: 2.6.9
-      valid-data-url: 3.0.1
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /web-streams-polyfill@3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
@@ -19069,6 +15544,7 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
 
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -19092,6 +15568,7 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+    dev: true
 
   /when-exit@2.0.0:
     resolution: {integrity: sha512-17lB0PWIgOuil9dgC/vdQY0aq5lwT0umemaIsOTNDBsc1TwclvocXOvkwenwUXEawN5mW3F64X52xPkTFnihDw==}
@@ -19329,18 +15806,6 @@ packages:
       archiver-utils: 2.1.0
       compress-commons: 4.1.1
       readable-stream: 3.6.0
-    dev: false
-
-  /zustand@3.7.0(react@18.2.0):
-    resolution: {integrity: sha512-USzVzLGrvZ8VK1/sEsOAmeqa8N7D3OBdZskVaL7DL89Q4QLTYD053iIlZ5KDidyZ+Od80Dttin/f8ZulOLFFDQ==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      react: '>=16.8'
-    peerDependenciesMeta:
-      react:
-        optional: true
-    dependencies:
-      react: 18.2.0
     dev: false
 
   /zustand@3.7.2(react@18.2.0):


### PR DESCRIPTION
I think accidentally fondue got downgraded to 11.3 at [Commit](https://github.com/Frontify/brand-sdk/commit/6c5d4f63ef8c5995790aa444dc29469b095d63ba)

Should resolve that