### PR TITLE
fix(RTE): edit modal styles can be invisible

### DIFF
--- a/.changeset/wise-hotels-heal.md
+++ b/.changeset/wise-hotels-heal.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(RTE): edit modal styles can be invisible

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/EditButtonModal/EditModal.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/EditButtonModal/EditModal.tsx
@@ -2,17 +2,17 @@
 
 import { IconPen16, IconTrashBin16 } from '@frontify/fondue';
 import { FloatingButton, useFloatingButtonUrlInput } from '..';
-import { BlockStyles } from '../../../..';
 
 export const EditModal = () => {
     const urlHtmlProps = useFloatingButtonUrlInput({});
 
     return (
-        <div data-test-id="floating-button-edit" className="tw-bg-white tw-rounded tw-shadow tw-p-4 tw-min-w-[400px]">
-            <span data-test-id="preview-button-flyout" className="tw-flex tw-justify-between">
-                <span className="tw-pointer-events-none" style={BlockStyles.p}>
-                    {urlHtmlProps.defaultValue}
-                </span>
+        <div
+            data-test-id="floating-button-edit"
+            className="tw-bg-white tw-text-text tw-rounded tw-shadow tw-p-4 tw-min-w-[400px]"
+        >
+            <span data-test-id="preview-button-flyout" className="tw-flex tw-justify-between tw-items-center">
+                <span className="tw-pointer-events-none">{urlHtmlProps.defaultValue}</span>
                 <span className="tw-flex tw-gap-2">
                     <span
                         role="button"

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
@@ -3,17 +3,17 @@
 import { IconPen16, IconTrashBin16 } from '@frontify/fondue';
 import { useFloatingLinkUrlInput } from '@udecode/plate';
 import { FloatingLink } from '../FloatingLink';
-import { BlockStyles } from '../../../styles';
 
 export const EditModal = () => {
     const urlHtmlProps = useFloatingLinkUrlInput({});
 
     return (
-        <div data-test-id="floating-link-edit" className="tw-bg-white tw-rounded tw-shadow tw-p-4 tw-min-w-[400px]">
-            <span data-test-id={'preview-link-flyout'} className="tw-flex tw-justify-between">
-                <span className="tw-pointer-events-none" style={BlockStyles.p}>
-                    {urlHtmlProps.defaultValue}
-                </span>
+        <div
+            data-test-id="floating-link-edit"
+            className="tw-bg-white tw-text-text tw-rounded tw-shadow tw-p-4 tw-min-w-[400px]"
+        >
+            <span data-test-id={'preview-link-flyout'} className="tw-flex tw-justify-between tw-items-center">
+                <span className="tw-pointer-events-none">{urlHtmlProps.defaultValue}</span>
                 <span className="tw-flex tw-gap-2">
                     <span
                         role="button"


### PR DESCRIPTION
The edit modals were using the `BlockStyles.p` styles, which can be white color. My opinion is that the RTE edit modal styles should be consistent, regardless of the design settings, as that is only used for editing. Open for debating.

![Screenshot 2023-09-13 at 08 21 14](https://github.com/Frontify/brand-sdk/assets/30796791/fbc480a4-3d6c-4175-b0ae-36fa96cbac9a)
![Screenshot 2023-09-13 at 08 19 28](https://github.com/Frontify/brand-sdk/assets/30796791/5eadc9dd-445e-406d-b71c-acd0eb1edf84)

[23021/TASK-8529](https://app.clickup.com/t/2523021/TASK-8529)