### PR TITLE
fix: RTE inconsistent numbered list style

### DIFF
--- a/.changeset/empty-monkeys-hang.md
+++ b/.changeset/empty-monkeys-hang.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(RTE): list style inconsistent between view and edit mode

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/SerializedText.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/SerializedText.tsx
@@ -18,7 +18,11 @@ export const SerializedText = ({ value = '', gap, columns, show = true, plugins 
     }
 
     return html !== null ? (
-        <div className="tw-w-full" data-test-id="rte-content-html" dangerouslySetInnerHTML={{ __html: html }} />
+        <div
+            className="tw-w-full tw-whitespace-pre-wrap"
+            data-test-id="rte-content-html"
+            dangerouslySetInnerHTML={{ __html: html }}
+        />
     ) : (
         <div className="tw-rounded-sm tw-bg-base-alt tw-animate-pulse tw-h-full tw-min-h-[10px] tw-w-full" />
     );


### PR DESCRIPTION
Plate adds by default `white-space: pre-wrap` around everything and this was missing and made the numbers jumping.

[Loom](https://www.loom.com/share/1e2751dc68f949f9a6ab63f2a67f3aed)
[Task](https://app.clickup.com/t/8692pynn1)