### PR TITLE
fix(LinkSelector): initial click triggers twice

### DIFF
--- a/.changeset/tiny-wasps-arrive.md
+++ b/.changeset/tiny-wasps-arrive.md
@@ -2,4 +2,4 @@
 "@frontify/guideline-blocks-settings": patch
 ---
 
-fix(LinkSelector): bug fixes and qol changes
+fix(LinkSelector): initial click triggered twice

--- a/.changeset/tiny-wasps-arrive.md
+++ b/.changeset/tiny-wasps-arrive.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(LinkSelector): bug fixes and qol changes

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLink.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLink.tsx
@@ -45,15 +45,13 @@ export const DocumentLink = ({
                         : 'hover:tw-bg-box-neutral-hover hover:tw-text-box-neutral-inverse-hover',
                 ])}
                 onClick={() => onSelectUrl(document.permanentLink)}
-                onFocus={() => onSelectUrl(document.permanentLink)}
             >
-                <div
+                <button
                     role="button"
                     tabIndex={0}
                     data-test-id="tree-item-toggle"
                     className="tw-flex tw-items-center tw-justify-center tw-p-1.5 tw-cursor-pointer"
                     onClick={() => setIsExpanded(!isExpanded)}
-                    onFocus={() => setIsExpanded(!isExpanded)}
                 >
                     <div
                         className={merge([
@@ -61,7 +59,7 @@ export const DocumentLink = ({
                             isExpanded ? 'tw-rotate-90' : '',
                         ])}
                     ></div>
-                </div>
+                </button>
                 <IconColorFan16 />
                 <span className="tw-text-s">{document.title}</span>
                 <span className="tw-flex-auto tw-font-sans tw-text-xs tw-text-right">Document</span>

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLink.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLink.tsx
@@ -39,7 +39,7 @@ export const DocumentLink = ({
             <button
                 data-test-id="internal-link-selector-document-link"
                 className={merge([
-                    'tw-flex tw-flex-1 tw-space-x-2 tw-items-center tw-py-2 tw-px-2.5 tw-leading-5 tw-cursor-pointer tw-w-full',
+                    'tw-flex tw-flex-1 tw-space-x-2 tw-items-center tw-py-2 tw-pr-2.5 tw-leading-5 tw-cursor-pointer tw-w-full',
                     isActive
                         ? 'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover:hover hover:tw-text-box-selected-strong-inverse-hover:hover'
                         : 'hover:tw-bg-box-neutral-hover hover:tw-text-box-neutral-inverse-hover',
@@ -50,7 +50,7 @@ export const DocumentLink = ({
                     role="button"
                     tabIndex={0}
                     data-test-id="tree-item-toggle"
-                    className="tw-flex tw-items-center tw-justify-center tw-p-1.5 tw-cursor-pointer"
+                    className="tw-flex tw-items-center tw-justify-center -tw-mr-2 tw-pr-3.5 tw-pt-1.5 tw-pb-1.5 tw-pl-3.5 tw-cursor-pointer"
                     onClick={() => setIsExpanded(!isExpanded)}
                 >
                     <div

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLinks.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLinks.tsx
@@ -3,8 +3,8 @@
 import type { AppBridgeBlock, AppBridgeTheme, Document } from '@frontify/app-bridge';
 import { ReactElement, useEffect, useState } from 'react';
 import { DocumentLink } from './DocumentLink';
+import { LoadingIndicator } from './LoadingIndicator';
 import { InitiallyExpandedItems } from '../';
-import { LoadingIndicator } from 'src/components/Link/LinkSelector/LoadingIndicator';
 
 type DocumentLinksProps = {
     appBridge: AppBridgeBlock | AppBridgeTheme;

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLinks.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLinks.tsx
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import type { AppBridgeBlock, AppBridgeTheme, Document } from '@frontify/app-bridge';
-import { LoadingCircle, LoadingCircleSize } from '@frontify/fondue';
 import { ReactElement, useEffect, useState } from 'react';
 import { DocumentLink } from './DocumentLink';
 import { InitiallyExpandedItems } from '../';
+import { LoadingIndicator } from 'src/components/Link/LinkSelector/LoadingIndicator';
 
 type DocumentLinksProps = {
     appBridge: AppBridgeBlock | AppBridgeTheme;
@@ -75,9 +75,7 @@ export const DocumentLinks = ({ appBridge, selectedUrl, onSelectUrl }: DocumentL
     };
 
     return isLoading ? (
-        <div className="tw-flex tw-justify-center  tw-h-10 tw-items-center">
-            <LoadingCircle size={LoadingCircleSize.Small} />
-        </div>
+        <LoadingIndicator />
     ) : (
         <>
             {documentArray.map((document) => {

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLinks.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/DocumentLinks.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import type { AppBridgeBlock, AppBridgeTheme, Document } from '@frontify/app-bridge';
-import { LoadingCircle } from '@frontify/fondue';
+import { LoadingCircle, LoadingCircleSize } from '@frontify/fondue';
 import { ReactElement, useEffect, useState } from 'react';
 import { DocumentLink } from './DocumentLink';
 import { InitiallyExpandedItems } from '../';
@@ -75,8 +75,8 @@ export const DocumentLinks = ({ appBridge, selectedUrl, onSelectUrl }: DocumentL
     };
 
     return isLoading ? (
-        <div className="tw-flex tw-justify-center tw-p-4">
-            <LoadingCircle />
+        <div className="tw-flex tw-justify-center  tw-h-10 tw-items-center">
+            <LoadingCircle size={LoadingCircleSize.Small} />
         </div>
     ) : (
         <>

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/LinkSelector.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/LinkSelector.spec.ct.tsx
@@ -127,11 +127,14 @@ describe('Link Selector', () => {
         cy.get(DocumentLinkSelector).should('have.length', 2);
         cy.realPress('Tab');
         cy.realPress('Tab');
+        cy.realPress('Enter');
         cy.get(PageLinkSelector).should('have.length', 3);
         cy.realPress('Tab');
         cy.realPress('Tab');
+        cy.realPress('Enter');
         cy.get(SectionLinkSelector).should('have.length', 4);
         cy.realPress('Tab');
+        cy.realPress('Space');
         cy.realPress('Enter');
         cy.get('@urlChange').should('be.calledWith', '/6');
     });

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/LoadingIndicator.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/LoadingIndicator.tsx
@@ -1,0 +1,11 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { LoadingCircle, LoadingCircleSize } from '@frontify/fondue';
+
+export const LoadingIndicator = () => {
+    return (
+        <div className="tw-flex tw-justify-center tw-h-10 tw-items-center">
+            <LoadingCircle size={LoadingCircleSize.Small} />
+        </div>
+    );
+};

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLink.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLink.tsx
@@ -36,7 +36,7 @@ export const PageLink = ({ page, selectedUrl, onSelectUrl, itemsToExpandInitiall
             <button
                 data-test-id="internal-link-selector-page-link"
                 className={merge([
-                    'tw-py-2 tw-px-2.5 tw-leading-5 tw-cursor-pointer tw-flex tw-w-full',
+                    'tw-py-2 tw-pr-2.5 tw-leading-5 tw-cursor-pointer tw-flex tw-w-full',
                     hasSections ? 'tw-pl-7' : 'tw-pl-12',
                     isActive
                         ? 'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover:hover hover:tw-text-box-selected-strong-inverse-hover:hover'
@@ -48,7 +48,7 @@ export const PageLink = ({ page, selectedUrl, onSelectUrl, itemsToExpandInitiall
                     {hasSections && (
                         <button
                             data-test-id="tree-item-toggle"
-                            className="tw-flex tw-items-center tw-justify-center tw-p-1.5 tw-cursor-pointer"
+                            className="tw-flex tw-items-center tw-justify-center -tw-mr-2 tw-pr-3.5 tw-pt-1.5 tw-pb-1.5 tw-pl-3.5 tw-cursor-pointer"
                             onClick={() => setIsExpanded(!isExpanded)}
                         >
                             <div

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLink.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLink.tsx
@@ -33,18 +33,16 @@ export const PageLink = ({ page, selectedUrl, onSelectUrl, itemsToExpandInitiall
 
     return (
         <>
-            <div
-                tabIndex={0}
+            <button
                 data-test-id="internal-link-selector-page-link"
                 className={merge([
-                    'tw-py-2 tw-px-2.5 tw-leading-5 tw-cursor-pointer',
+                    'tw-py-2 tw-px-2.5 tw-leading-5 tw-cursor-pointer tw-flex tw-w-full',
                     hasSections ? 'tw-pl-7' : 'tw-pl-12',
                     isActive
                         ? 'tw-bg-box-selected-strong tw-text-box-selected-strong-inverse hover:tw-bg-box-selected-strong-hover:hover hover:tw-text-box-selected-strong-inverse-hover:hover'
                         : 'hover:tw-bg-box-neutral-hover hover:tw-text-box-neutral-inverse-hover',
                 ])}
                 onClick={() => onSelectUrl(page.permanentLink)}
-                onFocus={() => onSelectUrl(page.permanentLink)}
             >
                 <div key={page.id} className="tw-flex tw-flex-1 tw-space-x-1 tw-items-center tw-h-6">
                     {hasSections && (
@@ -52,7 +50,6 @@ export const PageLink = ({ page, selectedUrl, onSelectUrl, itemsToExpandInitiall
                             data-test-id="tree-item-toggle"
                             className="tw-flex tw-items-center tw-justify-center tw-p-1.5 tw-cursor-pointer"
                             onClick={() => setIsExpanded(!isExpanded)}
-                            onFocus={() => setIsExpanded(!isExpanded)}
                         >
                             <div
                                 className={merge([
@@ -65,7 +62,7 @@ export const PageLink = ({ page, selectedUrl, onSelectUrl, itemsToExpandInitiall
                     <span className="tw-text-s">{page.title}</span>
                     <span className="tw-flex-auto tw-font-sans tw-text-xs tw-text-right">Page</span>
                 </div>
-            </div>
+            </button>
             {isExpanded &&
                 sectionsArray.length > 0 &&
                 sectionsArray.map((section) => {

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLinks.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLinks.tsx
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import type { AppBridgeBlock, AppBridgeTheme, DocumentPage } from '@frontify/app-bridge';
-import { LoadingCircle, LoadingCircleSize } from '@frontify/fondue';
 import { ReactElement, useEffect, useState } from 'react';
 import { InitiallyExpandedItems } from '../';
 import { PageLink } from './PageLink';
+import { LoadingIndicator } from 'src/components/Link/LinkSelector/LoadingIndicator';
 
 type PageLinksProps = {
     appBridge: AppBridgeBlock | AppBridgeTheme;
@@ -44,11 +44,7 @@ export const PageLinks = ({
     }, []);
 
     if (isLoading) {
-        return (
-            <div className="tw-flex tw-justify-center tw-h-10 tw-items-center">
-                <LoadingCircle size={LoadingCircleSize.Small} />
-            </div>
-        );
+        return <LoadingIndicator />;
     }
 
     return hasPages ? (

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLinks.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLinks.tsx
@@ -4,7 +4,7 @@ import type { AppBridgeBlock, AppBridgeTheme, DocumentPage } from '@frontify/app
 import { ReactElement, useEffect, useState } from 'react';
 import { InitiallyExpandedItems } from '../';
 import { PageLink } from './PageLink';
-import { LoadingIndicator } from 'src/components/Link/LinkSelector/LoadingIndicator';
+import { LoadingIndicator } from './LoadingIndicator';
 
 type PageLinksProps = {
     appBridge: AppBridgeBlock | AppBridgeTheme;

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLinks.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/PageLinks.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import type { AppBridgeBlock, AppBridgeTheme, DocumentPage } from '@frontify/app-bridge';
-import { LoadingCircle } from '@frontify/fondue';
+import { LoadingCircle, LoadingCircleSize } from '@frontify/fondue';
 import { ReactElement, useEffect, useState } from 'react';
 import { InitiallyExpandedItems } from '../';
 import { PageLink } from './PageLink';
@@ -45,8 +45,8 @@ export const PageLinks = ({
 
     if (isLoading) {
         return (
-            <div className="tw-flex tw-justify-center tw-p-4">
-                <LoadingCircle />
+            <div className="tw-flex tw-justify-center tw-h-10 tw-items-center">
+                <LoadingCircle size={LoadingCircleSize.Small} />
             </div>
         );
     }
@@ -67,7 +67,7 @@ export const PageLinks = ({
             })}
         </>
     ) : (
-        <div className="tw-py-2 tw-px-2.5 tw-pl-7 tw-leading-5 tw-text-s tw-text-text-weak">
+        <div className="tw-h-10 tw-flex tw-items-center tw-pr-2.5 tw-pl-7 tw-leading-5 tw-text-s tw-text-text-weak">
             This document does not contain any pages.
         </div>
     );

--- a/packages/guideline-blocks-settings/src/components/Link/LinkSelector/SectionLink.tsx
+++ b/packages/guideline-blocks-settings/src/components/Link/LinkSelector/SectionLink.tsx
@@ -25,7 +25,6 @@ export const SectionLink = ({ section, selectedUrl, onSelectUrl }: SectionLinkPr
                     : 'hover:tw-bg-box-neutral-hover hover:tw-text-box-neutral-inverse-hover',
             ])}
             onClick={() => onSelectUrl(section.permanentLink)}
-            onFocus={() => onSelectUrl(section.permanentLink)}
         >
             <div className="tw-flex tw-flex-1 tw-space-x-2 tw-items-center tw-h-6">
                 <IconDocumentText16 />


### PR DESCRIPTION
onClick and onFocus did the same thing, so initial click on a link item resulted in toggling it twice => essentially canceling the action.

Removed the onFocus handlers, and changed the arrow buttons to be <button> elements so the link chooser is still accessible.

https://www.loom.com/share/309c34b38c6c4a94a84cd1177ac6a848