### PR TITLE
fix: update react hook to return undefined and appBridge

### DIFF
--- a/packages/app-bridge/src/react/usePlatformAppBridge.spec.ts
+++ b/packages/app-bridge/src/react/usePlatformAppBridge.spec.ts
@@ -19,18 +19,14 @@ describe('usePlatformAppBridge', () => {
     afterEach(() => {
         vi.clearAllMocks();
     });
-    it('should return platformAppBridge', async () => {
+    it('should return undefined platformApp if not initiated', async () => {
         const { result } = renderHook(() => usePlatformAppBridge());
-        expect(result.current.platformAppBridge).toBeDefined();
+        expect(result.current).toBeUndefined();
     });
-    it('should return initiated false', async () => {
-        const { result } = renderHook(() => usePlatformAppBridge());
-        expect(result.current.connected).toBe(false);
-    });
-    it('should return initiated true after waiting', async () => {
+    it('should return platformApp after initiation and waiting', async () => {
         const { result } = renderHook(() => usePlatformAppBridge());
         await waitFor(() => {
-            expect(result.current.connected).toBe(true);
+            expect(result.current).toBeTypeOf('object');
         });
     });
 });

--- a/packages/app-bridge/src/react/usePlatformAppBridge.spec.ts
+++ b/packages/app-bridge/src/react/usePlatformAppBridge.spec.ts
@@ -26,7 +26,7 @@ describe('usePlatformAppBridge', () => {
     it('should return platformApp after initiation and waiting', async () => {
         const { result } = renderHook(() => usePlatformAppBridge());
         await waitFor(() => {
-            expect(result.current).toBeTypeOf('object');
+            expect(result.current).toBeDefined();
         });
     });
 });

--- a/packages/app-bridge/src/react/usePlatformAppBridge.ts
+++ b/packages/app-bridge/src/react/usePlatformAppBridge.ts
@@ -15,6 +15,5 @@ export const usePlatformAppBridge = () => {
             appBridge.dispatch({ name: 'openConnection' });
         })();
     }, []);
-
     return platformAppBridge;
 };

--- a/packages/app-bridge/src/react/usePlatformAppBridge.ts
+++ b/packages/app-bridge/src/react/usePlatformAppBridge.ts
@@ -4,17 +4,17 @@ import { AppBridgePlatformApp } from '../AppBridgePlatformApp';
 import { useEffect, useState } from 'react';
 
 export const usePlatformAppBridge = () => {
-    const [platformAppBridge] = useState<AppBridgePlatformApp>(new AppBridgePlatformApp());
-    const [connected, setConnected] = useState<boolean>(false);
+    const [platformAppBridge, setPlatformAppBridge] = useState<AppBridgePlatformApp | undefined>();
 
     useEffect(() => {
         (async () => {
-            platformAppBridge.subscribe('Context.connected', () => {
-                setConnected(true);
+            const appBridge = new AppBridgePlatformApp();
+            appBridge.subscribe('Context.connected', () => {
+                setPlatformAppBridge(appBridge);
             });
-            platformAppBridge.dispatch({ name: 'openConnection' });
+            appBridge.dispatch({ name: 'openConnection' });
         })();
     }, []);
 
-    return { platformAppBridge, connected };
+    return platformAppBridge;
 };


### PR DESCRIPTION
…ws easier handling in the app. 

@getflourish 

Now we can do 
```
const appBridge = usePlatformAppBridge();
[…]
const context = appBridge?.context().get();
```

