### PR TITLE
chore: make the ecosystem team the code owner of the types

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@ pnpm-lock.yaml
 # Specific paths
 
 # App Bridge
+packages/app-bridge/src/types @Frontify/ecosystem
 packages/app-bridge/src/react/useAssetChooser.ts @Frontify/guidelines-one @Frontify/guidelines-navigation-themes @SamuelAlev
 packages/app-bridge/src/react/useAssetChooser.spec.tsx @Frontify/guidelines-one @Frontify/guidelines-navigation-themes @SamuelAlev
 packages/app-bridge/src/react/useAssetUpload.ts @Frontify/guidelines-one @Frontify/guidelines-navigation-themes @SamuelAlev

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,3 +38,5 @@ packages/app-bridge/src/registries/api @Frontify/integration
 
 # Guideline Blocks Settings
 packages/guideline-blocks-settings @Frontify/guidelines-one @SamuelAlev
+
+CODEOWNERS @Frontify/architecture


### PR DESCRIPTION
Currently G2 is still owner of the types in the brand sdk. From my understanding this should now also be part of ecosystem.

Also I saw that for Web-App and App-Server the Codeowners file is owned by the architecture team. I assume, this should be the same here, right?