### PR TITLE
fix(cli): never ignore manifest.json

### DIFF
--- a/.changeset/curly-tips-turn.md
+++ b/.changeset/curly-tips-turn.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+fix: never ignore manifest.json on deploy"

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -85,7 +85,9 @@ export const createDeployment = async (
 
             const buildFilesToIgnore = BUILD_FILE_BLOCK_LIST.map((path) => join(projectPath, path));
 
-            const gitignoreEntries = readFileLinesAsArray(join(projectPath, '.gitignore'));
+            const gitignoreEntries = readFileLinesAsArray(join(projectPath, '.gitignore')).filter(
+                (entry) => entry !== 'manifest.json',
+            );
             const sourceFilesToIgnore = [...gitignoreEntries, ...SOURCE_FILE_BLOCK_LIST].map((path) =>
                 join(projectPath, path),
             );


### PR DESCRIPTION
Just had a case in which an agency had the manifest.json in the `.gitignore`, so the file wasn't deployed and the Block data wasn't updated. So this PR just filters the `manifest.json` out of the `gitignoreEntries`, so it's never a problem. 


More Context:
- They deploy the Block on multiple instances and have an AppId for each, so they have multiple `manifest.json`'s 
- So they have a script deploy:instanceA which then renames the instancea.manifest.json to manifest.json and deploys