### PR TITLE
feat: Add language to getAssetBulkDownloadToken API (and pass it via hook)

### DIFF
--- a/packages/app-bridge/src/react/useAssetBulkDownload.spec.tsx
+++ b/packages/app-bridge/src/react/useAssetBulkDownload.spec.tsx
@@ -7,6 +7,7 @@ import { getAppBridgeBlockStub } from '../tests';
 import { AssetBulkDownloadState, useAssetBulkDownload } from './';
 
 const appBridgeError = new Error('Something went wrong');
+const DUMMY_LANGUAGE = 'de';
 
 describe('useAssetBulkDownload', () => {
     beforeEach(() => {
@@ -30,11 +31,13 @@ describe('useAssetBulkDownload', () => {
         const appBridgeStub = getAppBridgeBlockStub();
         const { result } = renderHook(() => useAssetBulkDownload(appBridgeStub));
         const settingIds = ['setting1', 'setting2'];
+
         result.current.generateBulkDownload(settingIds);
+
         await waitFor(() => {
             sinon.assert.calledWithExactly(appBridgeStub.api, {
                 name: 'getAssetBulkDownloadToken',
-                payload: { documentBlockId: appBridgeStub.getBlockId(), settingIds },
+                payload: { documentBlockId: appBridgeStub.getBlockId(), settingIds, language: 'en' },
             });
         });
     });

--- a/packages/app-bridge/src/react/useAssetBulkDownload.ts
+++ b/packages/app-bridge/src/react/useAssetBulkDownload.ts
@@ -22,7 +22,11 @@ export const useAssetBulkDownload = (appBridge: AppBridgeBlock) => {
 
             const { assetBulkDownloadToken } = await appBridge.api({
                 name: 'getAssetBulkDownloadToken',
-                payload: { settingIds, documentBlockId: appBridge.getBlockId() },
+                payload: {
+                    settingIds,
+                    documentBlockId: appBridge.getBlockId(),
+                    language: appBridge.getTranslationLanguage(),
+                },
             });
 
             setDownloadUrl(null);

--- a/packages/app-bridge/src/registries/api/GetAssetBulkDownloadToken.ts
+++ b/packages/app-bridge/src/registries/api/GetAssetBulkDownloadToken.ts
@@ -3,6 +3,7 @@
 export type GetAssetBulkDownloadTokenPayload = {
     documentBlockId: number;
     settingIds?: string[];
+    language?: string;
 };
 
 export type GetAssetBulkDownloadTokenResponse = {


### PR DESCRIPTION
- Adds a `language` to `getAssetBulkDownloadToken` AppBridgeBlock `api`
- Passes the new language parameter via `useAssetBulkDownload` hook