### PR TITLE
chore(cli): templates use stable version

### DIFF
--- a/.changeset/popular-points-bathe.md
+++ b/.changeset/popular-points-bathe.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+chore: templates using stable version of app-bridge

--- a/packages/cli/templates/content-block-css-modules/package.json
+++ b/packages/cli/templates/content-block-css-modules/package.json
@@ -10,7 +10,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.99",
+        "@frontify/app-bridge": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/packages/cli/templates/content-block-css/package.json
+++ b/packages/cli/templates/content-block-css/package.json
@@ -10,7 +10,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.99",
+        "@frontify/app-bridge": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/packages/cli/templates/content-block-tailwind/package.json
+++ b/packages/cli/templates/content-block-tailwind/package.json
@@ -10,7 +10,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.99",
+        "@frontify/app-bridge": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/packages/cli/templates/platform-app-css-modules/package.json
+++ b/packages/cli/templates/platform-app-css-modules/package.json
@@ -10,7 +10,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.99",
+        "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
         "@frontify/fondue-tokens": "^3.4.0",
         "react": "^18.2.0",

--- a/packages/cli/templates/platform-app-css/package.json
+++ b/packages/cli/templates/platform-app-css/package.json
@@ -10,7 +10,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.99",
+        "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
         "@frontify/fondue-tokens": "^3.4.0",
         "react": "^18.2.0",

--- a/packages/cli/templates/platform-app-tailwind/package.json
+++ b/packages/cli/templates/platform-app-tailwind/package.json
@@ -10,7 +10,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.99",
+        "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
         "@frontify/fondue-tokens": "^3.4.0",
         "react": "^18.2.0",


### PR DESCRIPTION
Should be merged and released after (or the same time), with: https://github.com/Frontify/brand-sdk/pull/620