### PR TITLE
feat(cli): add app bridge version to build

### DIFF
--- a/.changeset/warm-apples-press.md
+++ b/.changeset/warm-apples-press.md
@@ -2,4 +2,4 @@
 "@frontify/frontify-cli": minor
 ---
 
-feat: adds the appBridge version to the window
+feat: adds the appBridge version to the block bundle

--- a/.changeset/warm-apples-press.md
+++ b/.changeset/warm-apples-press.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": minor
+---
+
+feat: adds the appBridge version to the window

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import { createServer } from 'vite';
 import { viteExternalsPlugin } from 'vite-plugin-externals';
 import { Logger } from '../utils/logger.js';
+import { getAppBridgeVersion } from '../utils/appBridgeVersion.js';
 import pkg from '../../package.json';
 
 class PlatformAppDevelopmentServer {
@@ -56,6 +57,7 @@ class DevelopmentServer {
                 ],
                 define: {
                     'process.env.NODE_ENV': JSON.stringify('development'),
+                    'DevCustomBlock.packages.appBridge': getAppBridgeVersion(process.cwd()),
                 },
                 base: `http://localhost:${this.port}/`,
                 appType: 'custom',

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -57,7 +57,7 @@ class DevelopmentServer {
                 ],
                 define: {
                     'process.env.NODE_ENV': JSON.stringify('development'),
-                    'DevCustomBlock.packages.appBridge': getAppBridgeVersion(process.cwd()),
+                    'DevCustomBlock.packages.appBridge': JSON.stringify(getAppBridgeVersion(process.cwd())),
                 },
                 base: `http://localhost:${this.port}/`,
                 appType: 'custom',

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -57,7 +57,7 @@ class DevelopmentServer {
                 ],
                 define: {
                     'process.env.NODE_ENV': JSON.stringify('development'),
-                    'DevCustomBlock.packages.appBridge': JSON.stringify(getAppBridgeVersion(process.cwd())),
+                    'DevCustomBlock.dependencies.appBridge': JSON.stringify(getAppBridgeVersion(process.cwd())),
                 },
                 base: `http://localhost:${this.port}/`,
                 appType: 'custom',

--- a/packages/cli/src/utils/appBridgeVersion.ts
+++ b/packages/cli/src/utils/appBridgeVersion.ts
@@ -1,0 +1,15 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { join } from 'node:path';
+import { reactiveJson } from './reactiveJson.js';
+import { PackageJson } from './npm.js';
+
+export const getAppBridgeVersion = (rootPath: string) => {
+    const packageJson = reactiveJson<PackageJson>(join(rootPath, 'package.json'));
+    return getMajorVersion(packageJson.dependencies['@frontify/app-bridge']);
+};
+
+export const getMajorVersion = (version: string) => {
+    const match = version.match(/^[>^~]?\d+/);
+    return match ? parseInt(match[0].replace(/^[>^~]/, ''), 10) : 0;
+};

--- a/packages/cli/src/utils/appBridgeVersion.ts
+++ b/packages/cli/src/utils/appBridgeVersion.ts
@@ -6,10 +6,5 @@ import { PackageJson } from './npm.js';
 
 export const getAppBridgeVersion = (rootPath: string) => {
     const packageJson = reactiveJson<PackageJson>(join(rootPath, 'package.json'));
-    return getMajorVersion(packageJson.dependencies['@frontify/app-bridge']);
-};
-
-export const getMajorVersion = (version: string) => {
-    const match = /^\W*(\d+)/.exec(version);
-    return match ? parseInt(match[1], 10) : 0;
+    return packageJson.dependencies['@frontify/app-bridge'];
 };

--- a/packages/cli/src/utils/appBridgeVersion.ts
+++ b/packages/cli/src/utils/appBridgeVersion.ts
@@ -10,6 +10,6 @@ export const getAppBridgeVersion = (rootPath: string) => {
 };
 
 export const getMajorVersion = (version: string) => {
-    const match = version.match(/^[>^~]?\d+/);
-    return match ? parseInt(match[0].replace(/^[>^~]/, ''), 10) : 0;
+    const match = /^\W*(\d+)/.exec(version);
+    return match ? parseInt(match[1], 10) : 0;
 };

--- a/packages/cli/src/utils/compiler.ts
+++ b/packages/cli/src/utils/compiler.ts
@@ -44,8 +44,8 @@ export const compileBlock = async ({ projectPath, entryFile, outputName }: Compi
                     },
                     footer: `
                         window.${outputName} = ${outputName}; 
-                        window.${outputName}.packages = window.${outputName}.packages || {};
-                        window.${outputName}.packages['@frontify/app-bridge'] = '${appBridgeVersion}';
+                        window.${outputName}.dependencies = window.${outputName}.packages || {};
+                        window.${outputName}.dependencies['@frontify/app-bridge'] = '${appBridgeVersion}';
                     `,
                 },
             },

--- a/packages/cli/src/utils/compiler.ts
+++ b/packages/cli/src/utils/compiler.ts
@@ -45,7 +45,7 @@ export const compileBlock = async ({ projectPath, entryFile, outputName }: Compi
                     footer: `
                         window.${outputName} = ${outputName}; 
                         window.${outputName}.packages = window.${outputName}.packages || {};
-                        window.${outputName}.packages.appBridge = '${appBridgeVersion}';
+                        window.${outputName}.packages['@frontify/app-bridge'] = '${appBridgeVersion}';
                     `,
                 },
             },

--- a/packages/cli/src/utils/compiler.ts
+++ b/packages/cli/src/utils/compiler.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import { build } from 'vite';
 import { viteExternalsPlugin } from 'vite-plugin-externals';
 import { createHash } from 'crypto';
+import { getAppBridgeVersion } from './appBridgeVersion.js';
 
 export type CompilerOptions = {
     projectPath: string;
@@ -11,8 +12,9 @@ export type CompilerOptions = {
     outputName: string;
 };
 
-export const compileBlock = async ({ projectPath, entryFile, outputName }: CompilerOptions) =>
-    build({
+export const compileBlock = async ({ projectPath, entryFile, outputName }: CompilerOptions) => {
+    const appBridgeVersion = getAppBridgeVersion(projectPath);
+    return build({
         plugins: [
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             //@ts-ignore
@@ -40,11 +42,16 @@ export const compileBlock = async ({ projectPath, entryFile, outputName }: Compi
                         react: 'React',
                         'react-dom': 'ReactDOM',
                     },
-                    footer: `window.${outputName} = ${outputName};`,
+                    footer: `
+                        window.${outputName} = ${outputName}; 
+                        window.${outputName}.packages = window.${outputName}.packages || {};
+                        window.${outputName}.packages.appBridge = '${appBridgeVersion}';
+                    `,
                 },
             },
         },
     });
+};
 
 export const compilePlatformApp = async ({ outputName, projectPath = '' }: CompilerOptions) => {
     const getHash = (text) => createHash('sha256').update(text).digest('hex');

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+export * from './appBridgeVersion.js';
 export * from './compiler.js';
 export * from './configuration.js';
 export * from './date.js';

--- a/packages/cli/src/utils/npm.ts
+++ b/packages/cli/src/utils/npm.ts
@@ -5,10 +5,11 @@ import { resolve } from 'node:path';
 import { isDirectoryEmpty } from './file.js';
 import { reactiveJson } from './reactiveJson.js';
 
-type PackageJson = {
+export type PackageJson = {
     name: string;
     version: string;
     main: string;
+    dependencies: Record<string, string>;
 };
 
 export const updatePackageJsonProjectName = (folderPath: string): void => {

--- a/packages/cli/tests/files/compile-test-files/package.json
+++ b/packages/cli/tests/files/compile-test-files/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "test-block",
+    "version": "1.0.0",
+    "main": "src/index.ts",
+    "dependencies": {
+        "@frontify/app-bridge": "^3.0.0-beta.99"
+    }
+}

--- a/packages/cli/tests/utils/appBridgeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeVersion.spec.ts
@@ -1,23 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { describe, expect, it } from 'vitest';
-import { getAppBridgeVersion, getMajorVersion } from '../../src/utils/appBridgeVersion.js';
+import { getAppBridgeVersion } from '../../src/utils/appBridgeVersion.js';
 
 const rootPath = `${__dirname}/../files/compile-test-files`;
 
 describe('AppBridgeVersion utils', async () => {
-    it.each([
-        ['', 0],
-        ['hello world', 0],
-        ['3.0.0-beta.99', 3],
-        ['>1.2.3-alpha.1', 1],
-        ['^2.3.4', 2],
-        ['~3.4.5', 3],
-    ])('should return the correct major version', (version, expected) => {
-        expect(getMajorVersion(version)).toEqual(expected);
-    });
-
     it('should return the correct major version from package.json', () => {
-        expect(getAppBridgeVersion(rootPath)).toEqual(3);
+        expect(getAppBridgeVersion(rootPath)).toEqual('^3.0.0-beta.99');
     });
 });

--- a/packages/cli/tests/utils/appBridgeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeVersion.spec.ts
@@ -1,12 +1,43 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { describe, expect, it } from 'vitest';
+import mockFs from 'mock-fs';
+import { afterEach, describe, expect, it } from 'vitest';
 import { getAppBridgeVersion } from '../../src/utils/appBridgeVersion.js';
 
-const rootPath = `${__dirname}/../files/compile-test-files`;
+const rootPath = 'frontify-cli';
 
 describe('AppBridgeVersion utils', async () => {
-    it('should return the correct major version from package.json', () => {
-        expect(getAppBridgeVersion(rootPath)).toEqual('^3.0.0-beta.99');
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return the 3 as version from package.json', () => {
+        mockFs({
+            'frontify-cli': {
+                'package.json': JSON.parse('{"dependencies": {"@frontify/app-bridge": "3"}'),
+            },
+        });
+
+        expect(getAppBridgeVersion(rootPath)).toEqual('3');
+    });
+
+    it('should return the 3.0.0-beta.99 as version from package.json', () => {
+        mockFs({
+            'frontify-cli': {
+                'package.json': JSON.parse('{"dependencies": {"@frontify/app-bridge": "3.0.0-beta.99"}'),
+            },
+        });
+
+        expect(getAppBridgeVersion(rootPath)).toEqual('3.0.0-beta.99');
+    });
+
+    it('should return the ^3.0.0 as version from package.json', () => {
+        mockFs({
+            'frontify-cli': {
+                'package.json': JSON.parse('{"dependencies": {"@frontify/app-bridge": "^3.0.0"}'),
+            },
+        });
+
+        expect(getAppBridgeVersion(rootPath)).toEqual('^3.0.0');
     });
 });

--- a/packages/cli/tests/utils/appBridgeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeVersion.spec.ts
@@ -14,7 +14,7 @@ describe('AppBridgeVersion utils', async () => {
     it('should return the 3 as version from package.json', () => {
         mockFs({
             'frontify-cli': {
-                'package.json': '{"dependencies": {"@frontify/app-bridge": "3"}',
+                'package.json': '{"dependencies": {"@frontify/app-bridge": "3"}}',
             },
         });
 
@@ -24,7 +24,7 @@ describe('AppBridgeVersion utils', async () => {
     it('should return the 3.0.0-beta.99 as version from package.json', () => {
         mockFs({
             'frontify-cli': {
-                'package.json': '{"dependencies": {"@frontify/app-bridge": "3.0.0-beta.99"}',
+                'package.json': '{"dependencies": {"@frontify/app-bridge": "3.0.0-beta.99"}}',
             },
         });
 
@@ -34,7 +34,7 @@ describe('AppBridgeVersion utils', async () => {
     it('should return the ^3.0.0 as version from package.json', () => {
         mockFs({
             'frontify-cli': {
-                'package.json': '{"dependencies": {"@frontify/app-bridge": "^3.0.0"}',
+                'package.json': '{"dependencies": {"@frontify/app-bridge": "^3.0.0"}}',
             },
         });
 

--- a/packages/cli/tests/utils/appBridgeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeVersion.spec.ts
@@ -1,0 +1,23 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { describe, expect, it } from 'vitest';
+import { getAppBridgeVersion, getMajorVersion } from '../../src/utils/appBridgeVersion.js';
+
+const rootPath = `${__dirname}/../files/compile-test-files`;
+
+describe('AppBridgeVersion utils', async () => {
+    it.each([
+        ['', 0],
+        ['hello world', 0],
+        ['3.0.0-beta.99', 3],
+        ['>1.2.3-alpha.1', 1],
+        ['^2.3.4', 2],
+        ['~3.4.5', 3],
+    ])('should return the correct major version', (version, expected) => {
+        expect(getMajorVersion(version)).toEqual(expected);
+    });
+
+    it('should return the correct major version from package.json', () => {
+        expect(getAppBridgeVersion(rootPath)).toEqual(3);
+    });
+});

--- a/packages/cli/tests/utils/appBridgeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeVersion.spec.ts
@@ -24,7 +24,7 @@ describe('AppBridgeVersion utils', async () => {
     it('should return the 3.0.0-beta.99 as version from package.json', () => {
         mockFs({
             'frontify-cli': {
-                'package.json': JSON.parse('{"dependencies": {"@frontify/app-bridge": "3.0.0-beta.99"}'),
+                'package.json': '{"dependencies": {"@frontify/app-bridge": "3.0.0-beta.99"}',
             },
         });
 
@@ -34,7 +34,7 @@ describe('AppBridgeVersion utils', async () => {
     it('should return the ^3.0.0 as version from package.json', () => {
         mockFs({
             'frontify-cli': {
-                'package.json': JSON.parse('{"dependencies": {"@frontify/app-bridge": "^3.0.0"}'),
+                'package.json': '{"dependencies": {"@frontify/app-bridge": "^3.0.0"}',
             },
         });
 

--- a/packages/cli/tests/utils/appBridgeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeVersion.spec.ts
@@ -14,7 +14,7 @@ describe('AppBridgeVersion utils', async () => {
     it('should return the 3 as version from package.json', () => {
         mockFs({
             'frontify-cli': {
-                'package.json': JSON.parse('{"dependencies": {"@frontify/app-bridge": "3"}'),
+                'package.json': '{"dependencies": {"@frontify/app-bridge": "3"}',
             },
         });
 

--- a/packages/cli/tests/utils/compiler.spec.ts
+++ b/packages/cli/tests/utils/compiler.spec.ts
@@ -36,7 +36,7 @@ describe('Compiler utils', async () => {
             expect(global.window).toHaveProperty('index');
             expect(global.window?.index.block).toBe('this is a block');
             expect(global.window?.index.settings).toMatchObject({ some: 'settings' });
-            expect(global.window?.index.packages['@frontify/app-bridge']).toBe('^3.0.0-beta.99');
+            expect(global.window?.index.dependencies['@frontify/app-bridge']).toBe('^3.0.0-beta.99');
         });
     });
 

--- a/packages/cli/tests/utils/compiler.spec.ts
+++ b/packages/cli/tests/utils/compiler.spec.ts
@@ -30,12 +30,13 @@ describe('Compiler utils', async () => {
     });
 
     describe('compile Block', () => {
-        test('should provide a valid build with block and settings', async () => {
+        test('should provide a valid build with block, settings and appBridge version', async () => {
             await compileBlock({ projectPath: rootPath, entryFile: pathToIndex, outputName: 'index' });
             await import(outputFile);
             expect(global.window).toHaveProperty('index');
             expect(global.window?.index.block).toBe('this is a block');
             expect(global.window?.index.settings).toMatchObject({ some: 'settings' });
+            expect(global.window?.index.packages.appBridge).toBe('3');
         });
     });
 

--- a/packages/cli/tests/utils/compiler.spec.ts
+++ b/packages/cli/tests/utils/compiler.spec.ts
@@ -36,7 +36,7 @@ describe('Compiler utils', async () => {
             expect(global.window).toHaveProperty('index');
             expect(global.window?.index.block).toBe('this is a block');
             expect(global.window?.index.settings).toMatchObject({ some: 'settings' });
-            expect(global.window?.index.packages['@frontify/app-bridge']).toBe('3');
+            expect(global.window?.index.packages['@frontify/app-bridge']).toBe('^3.0.0-beta.99');
         });
     });
 

--- a/packages/cli/tests/utils/compiler.spec.ts
+++ b/packages/cli/tests/utils/compiler.spec.ts
@@ -36,7 +36,7 @@ describe('Compiler utils', async () => {
             expect(global.window).toHaveProperty('index');
             expect(global.window?.index.block).toBe('this is a block');
             expect(global.window?.index.settings).toMatchObject({ some: 'settings' });
-            expect(global.window?.index.packages.appBridge).toBe('3');
+            expect(global.window?.index.packages['@frontify/app-bridge']).toBe('3');
         });
     });
 


### PR DESCRIPTION
Adds the appBridge version to the window. 

`serve`: `window.DevCustomBlock.dependencies.appBridge`

`deploy`: `window.<appId>.dependencies['@frontify/app-bridge']`


[Task](https://app.clickup.com/t/869309vxt)