### PR TITLE
fix(BlockItemWrapper): fix toolbar focus style

### DIFF
--- a/.changeset/clean-tips-invent.md
+++ b/.changeset/clean-tips-invent.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(BlockItemWRapper): fix toolbar focus style

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
@@ -45,7 +45,7 @@ export const Toolbar = ({
                                     {...item.draggableProps}
                                     className={joinClassNames([
                                         FOCUS_VISIBLE_STYLE,
-                                        'tw-bg-base tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm',
+                                        'tw-bg-base tw-relative tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm focus-visible:tw-z-10',
                                         isDragging
                                             ? 'tw-cursor-grabbing tw-bg-box-selected-pressed'
                                             : 'tw-cursor-grab hover:tw-bg-box-selected-hover',


### PR DESCRIPTION
To fix this issue:

![image](https://github.com/Frontify/brand-sdk/assets/30796791/003b9474-b2a4-4b73-9eef-809bc9a19683)
