### PR TITLE
fix: Update Platform/Dev server's port when updated

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -8,7 +8,11 @@ import { getAppBridgeVersion } from '../utils/appBridgeVersion.js';
 import pkg from '../../package.json';
 
 class PlatformAppDevelopmentServer {
-    constructor(private readonly port: number) {}
+    constructor(private port: number) {}
+
+    private setPort(port: number): void {
+        this.port = port;
+    }
 
     async serve(): Promise<void> {
         try {
@@ -27,6 +31,11 @@ class PlatformAppDevelopmentServer {
             });
 
             const server = await viteServer.listen(this.port, true);
+
+            if (viteServer.config.server?.port && viteServer.config.server?.port !== this.port) {
+                this.setPort(viteServer.config.server?.port);
+            }
+
             server.printUrls();
         } catch (error) {
             console.error(error);
@@ -38,9 +47,13 @@ class PlatformAppDevelopmentServer {
 class DevelopmentServer {
     constructor(
         private readonly entryFilePath: string,
-        private readonly port: number,
+        private port: number,
         private readonly allowExternal: boolean,
     ) {}
+
+    private setPort(port: number): void {
+        this.port = port;
+    }
 
     async serve(): Promise<void> {
         try {
@@ -100,6 +113,11 @@ class DevelopmentServer {
             });
 
             const server = await viteServer.listen(this.port, true);
+
+            if (viteServer.config.server?.port && viteServer.config.server?.port !== this.port) {
+                this.setPort(viteServer.config.server?.port);
+            }
+
             server.printUrls();
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
- Note: **Low priority** and can be closed if not necessary, as this is an edge case
- Noticed a bug where loading more than one type of custom block at the same time incorrectly loads the first loaded block for the second (or consequent) blocks as well
- This happens because `this.port` does not get updated for `PlatformAppDevServer` / `DevelopmentServer` when `viteServer` automatically picks another port in case `5600` is already in use
- This is incorrectly picked [here](https://github.com/Frontify/web-app/blob/a552c6f57a335f984006b792a872b7c42b32860b/application/addons/styleguide/blocks/localblockdevelopment/localblockdevelopment.ts#L100), hence the first block is _always_ loaded
- How to test:
    - Go to `packages/cli/` and run `pnpm build`
    - Go to any custom block and serve the block by running `<path to brand-sdk>/packages/cli/dist/index.mjs serve`
    - Go to another custom block and serve the same way as above (this time the port should be different)
    - Go to any guideline > "Add block" >  "Local Development block" and connect using the default port (5600)
    - The first custom block should load
    - Add another "Local Development block" and connect using the _new_ port (possibly 5601)
    - The second block should load as expected