### PR TITLE
chore: Rename Bulk Asset download helper

### DIFF
--- a/packages/app-bridge/src/registries/api/GetAssetBulkDownloadToken.ts
+++ b/packages/app-bridge/src/registries/api/GetAssetBulkDownloadToken.ts
@@ -10,7 +10,7 @@ export type GetAssetBulkDownloadTokenResponse = {
     assetBulkDownloadToken: string;
 };
 
-export const getAssetBulkDownloadToken = (
+export const withGetAssetBulkDownloadTokenPayload = (
     blockAssets?: GetAssetBulkDownloadTokenPayload['blockAssets'],
 ): {
     name: 'getAssetBulkDownloadToken';


### PR DESCRIPTION
- We need to rename this helper method as there's an existing method with the same name in `web-app` to avoid the following error:
```
TS2308: Module './repositories' has already exported a member named 'getAssetBulkDownloadToken'. Consider explicitly re-exporting to resolve the ambiguity.
```