### PR TITLE
fix: positioning toolbar icon within block item wrapper

### DIFF
--- a/.changeset/tidy-cherries-rhyme.md
+++ b/.changeset/tidy-cherries-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix: positioning of toolbar icons within the block item wrapper

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
@@ -45,7 +45,7 @@ export const Toolbar = ({
                                     {...item.draggableProps}
                                     className={joinClassNames([
                                         FOCUS_VISIBLE_STYLE,
-                                        'tw-bg-base tw-relative tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm focus-visible:tw-z-10',
+                                        'tw-bg-base tw-relative tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm tw-mt-[3px] focus-visible:tw-z-10',
                                         isDragging
                                             ? 'tw-cursor-grabbing tw-bg-box-selected-pressed'
                                             : 'tw-cursor-grab hover:tw-bg-box-selected-hover',
@@ -69,7 +69,7 @@ export const Toolbar = ({
                                     data-test-id="block-item-wrapper-toolbar-btn"
                                     onClick={item.onClick}
                                     className={joinClassNames([
-                                        'tw-bg-base tw-relative hover:tw-bg-box-selected-hover active:tw-bg-box-selected-pressed tw-cursor-pointer tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm focus-visible:tw-z-10',
+                                        'tw-bg-base tw-relative hover:tw-bg-box-selected-hover active:tw-bg-box-selected-pressed tw-cursor-pointer tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm tw-mt-[3px] focus-visible:tw-z-10',
                                         FOCUS_VISIBLE_STYLE,
                                     ])}
                                 >


### PR DESCRIPTION
With the latest fondue the position overlapps the outline:

![288806167-df975c01-1692-4579-8cc2-f22cb77b1f5b](https://github.com/Frontify/brand-sdk/assets/9362990/5cd80a0e-e6db-4c60-94c5-360027d6ca09)

Fixed:
![Screenshot 2023-12-14 at 08 38 54](https://github.com/Frontify/brand-sdk/assets/9362990/847fc9e5-2f2d-4e38-b610-b4eb53adecc8)
