### PR TITLE
feat: export type for use in template block

### DIFF
--- a/.changeset/new-bobcats-leave.md
+++ b/.changeset/new-bobcats-leave.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": minor
+---
+
+chore: export type FlyoutToolbarItem

--- a/.changeset/three-flies-repeat.md
+++ b/.changeset/three-flies-repeat.md
@@ -1,5 +1,5 @@
 ---
-"@frontify/guideline-blocks-settings": minor
+"@frontify/guideline-blocks-settings": patch
 ---
 
 chore: export type FlyoutToolbarItem

--- a/.changeset/three-flies-repeat.md
+++ b/.changeset/three-flies-repeat.md
@@ -2,4 +2,4 @@
 "@frontify/guideline-blocks-settings": patch
 ---
 
-chore: export type FlyoutToolbarItem
+feat: export type FlyoutToolbarItem

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
@@ -40,7 +40,7 @@ type ButtonToolbarItem = BaseToolbarItem & {
 
 export type ToolbarItem = DraghandleToolbarItem | ButtonToolbarItem;
 
-type FlyoutToolbarItem = {
+export type FlyoutToolbarItem = {
     title: string;
     onClick: () => void;
     icon: JSX.Element;


### PR DESCRIPTION
Export a type for use in guidelines Template Block
Avoids having to duplicate the type here https://github.com/Frontify/guideline-blocks/pull/699/files#diff-830e07fe3324d4770dcc0c70549882a588f45cb1b829989ba044709b46eebfde