### PR TITLE
fix: platform app compiler

### DIFF
--- a/.changeset/unlucky-mice-give.md
+++ b/.changeset/unlucky-mice-give.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+fix: platform app compiler

--- a/packages/cli/src/utils/compiler.ts
+++ b/packages/cli/src/utils/compiler.ts
@@ -57,7 +57,7 @@ export const compilePlatformApp = async ({ outputName, projectPath = '' }: Compi
         name: 'html-hash',
         enforce: 'post',
         transformIndexHtml(html, { bundle }) {
-            const indexJsSource = bundle?.['index.js'].type === 'asset' ? bundle?.['index.js'].source : null;
+            const indexJsSource = bundle?.['index.js'].type === 'chunk' ? bundle?.['index.js'].code : null;
             const indexCssSource = bundle?.['index.css'].type === 'asset' ? bundle?.['index.css'].source : null;
 
             const cssFileName = `${outputName}.${getHash(indexJsSource)}.css`;
@@ -68,7 +68,7 @@ export const compilePlatformApp = async ({ outputName, projectPath = '' }: Compi
         },
         generateBundle(_options, bundle) {
             const indexHtmlSource = bundle?.['index.html'].type === 'asset' ? bundle?.['index.html'].source : null;
-            const indexJsSource = bundle?.['index.js'].type === 'asset' ? bundle?.['index.js'].source : null;
+            const indexJsSource = bundle?.['index.js'].type === 'chunk' ? bundle?.['index.js'].code : null;
             const indexCssSource = bundle?.['index.css'].type === 'asset' ? bundle?.['index.css'].source : null;
 
             bundle['index.html'].fileName = `${outputName}.${getHash(indexHtmlSource)}.html`;


### PR DESCRIPTION
There was a bug inside of the Platform App compiler with a mapping of the generated js files.