### PR TITLE
feat: update block toolbar to include attachments flyout

### DIFF
--- a/.changeset/thick-lizards-visit.md
+++ b/.changeset/thick-lizards-visit.md
@@ -1,0 +1,10 @@
+---
+"@frontify/guideline-blocks-settings": minor
+---
+
+-   Toolbar design updated
+-   Add Attachments to the Toolbar component. `isFlyoutOpen`, `setIsFlyoutOpen` and `flyoutItems` props have been removed from the Toolbar and replaced
+    with a `flyoutMenu` object (`{ items: FlyoutItem[]; isOpen: boolean; onOpenChange: (isOpen: boolean)=>void }`).
+    `isFlyoutDisabled` prop has been removed.
+    `attachments` prop has been added (`{ isEnabled: boolean; isOpen: boolean; onOpenChange: (isOpen: boolean)=>void }`).
+    To enable block attachments in the Toolbar from the `BlockWrapper` component, set `showAttachments` to `true` and wrap the block in the `withAttachments` HOC or alternatively, wrap the `BlockWrapper` in an `AttachmentsProvider`.

--- a/.changeset/thick-lizards-visit.md
+++ b/.changeset/thick-lizards-visit.md
@@ -7,4 +7,4 @@
     with a `flyoutMenu` object (`{ items: FlyoutItem[]; isOpen: boolean; onOpenChange: (isOpen: boolean)=>void }`).
     `isFlyoutDisabled` prop has been removed.
     `attachments` prop has been added (`{ isEnabled: boolean; isOpen: boolean; onOpenChange: (isOpen: boolean)=>void }`).
-    To enable block attachments in the Toolbar from the `BlockWrapper` component, set `showAttachments` to `true` and wrap the block in the `withAttachments` HOC or alternatively, wrap the `BlockWrapper` in an `AttachmentsProvider`.
+    To enable block attachments in the Toolbar from the `BlockWrapper` component, set `showAttachments` to `true` and wrap the block in the `withAttachmentsProvider` HOC or alternatively, wrap the `BlockWrapper` in an `AttachmentsProvider`.

--- a/.changeset/thick-lizards-visit.md
+++ b/.changeset/thick-lizards-visit.md
@@ -8,3 +8,4 @@
     `isFlyoutDisabled` prop has been removed.
     `attachments` prop has been added (`{ isEnabled: boolean; isOpen: boolean; onOpenChange: (isOpen: boolean)=>void }`).
     To enable block attachments in the Toolbar from the `BlockWrapper` component, set `showAttachments` to `true` and wrap the block in the `withAttachmentsProvider` HOC or alternatively, wrap the `BlockWrapper` in an `AttachmentsProvider`.
+-   `onAddAttachments` has been replaced with `onAttachmentsAdd` in the object returned from `useAttachments` hook.

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -12,6 +12,7 @@ import {
     useSensor,
     useSensors,
 } from '@dnd-kit/core';
+import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable';
 import { Asset, useAssetUpload, useEditorState } from '@frontify/app-bridge';
 import {
@@ -24,15 +25,10 @@ import {
     LegacyTooltip as Tooltip,
     TooltipPosition,
 } from '@frontify/fondue';
-import { AttachmentItem, SortableAttachmentItem } from './AttachmentItem';
-import { AttachmentsProps, AttachmentsTriggerComponentProps } from './types';
-import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 
-const AttachmentsButtonTrigger = ({ children }: AttachmentsTriggerComponentProps) => (
-    <div className="tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line">
-        {children}
-    </div>
-);
+import { AttachmentItem, SortableAttachmentItem } from './AttachmentItem';
+import { type AttachmentsProps } from './types';
+import { AttachmentsButtonTrigger } from './AttachmentsButtonTrigger';
 
 export const Attachments = ({
     items = [],

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -165,7 +165,7 @@ export const Attachments = ({
                         fitContent
                         legacyFooter={false}
                         trigger={
-                            <TriggerComponent>
+                            <TriggerComponent isFlyoutOpen={isFlyoutOpen}>
                                 <IconPaperclip16 />
                                 <div>{items.length > 0 ? items.length : 'Add'}</div>
                                 <IconCaretDown12 />

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -20,8 +20,6 @@ import {
     AssetInputSize,
     Flyout,
     FlyoutPlacement,
-    IconCaretDown12,
-    IconPaperclip16,
     LegacyTooltip as Tooltip,
     TooltipPosition,
 } from '@frontify/fondue';
@@ -162,13 +160,11 @@ export const Attachments = ({
                         legacyFooter={false}
                         trigger={
                             <TriggerComponent isFlyoutOpen={isFlyoutOpen}>
-                                <IconPaperclip16 />
                                 <div>{items.length > 0 ? items.length : 'Add'}</div>
-                                <IconCaretDown12 />
                             </TriggerComponent>
                         }
                     >
-                        <div className="tw-w-[300px]">
+                        <div className="tw-w-[300px]" data-test-id="attachments-flyout-content">
                             {internalItems.length > 0 && (
                                 <DndContext
                                     sensors={sensors}

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -59,9 +59,9 @@ export const Attachments = ({
     });
 
     const handleFlyoutOpenChange = (isOpen: boolean) => {
-        const stateSetter = isControllingStateExternally ? onOpenChange! : setIsFlyoutOpenInternal;
+        const stateSetter = isControllingStateExternally ? onOpenChange : setIsFlyoutOpenInternal;
 
-        stateSetter(isOpen);
+        stateSetter?.(isOpen);
     };
 
     useEffect(() => {

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
@@ -1,5 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { IconCaretDown12, IconPaperclip16 } from '@frontify/fondue';
+
 import { joinClassNames } from '../../utilities';
 
 import { type AttachmentsTriggerProps } from './types';
@@ -13,6 +15,8 @@ export const AttachmentsButtonTrigger = ({ children, isFlyoutOpen }: Attachments
                 : 'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-text-box-neutral-inverse hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
         ])}
     >
+        <IconPaperclip16 />
         {children}
+        <IconCaretDown12 />
     </div>
 );

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
@@ -9,7 +9,7 @@ import { type AttachmentsTriggerProps } from './types';
 export const AttachmentsButtonTrigger = ({ children, isFlyoutOpen }: AttachmentsTriggerProps) => (
     <div
         className={joinClassNames([
-            'tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line',
+            'tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-outline tw-outline-1 tw-outline-offset-1 tw-p-1.5 tw-outline-line',
             isFlyoutOpen
                 ? 'tw-bg-box-neutral-pressed tw-text-box-neutral-inverse-pressed'
                 : 'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-text-box-neutral-inverse hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
@@ -1,9 +1,18 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { joinClassNames } from '../../utilities';
+
 import { type AttachmentsTriggerProps } from './types';
 
-export const AttachmentsButtonTrigger = ({ children }: AttachmentsTriggerProps) => (
-    <div className="tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line">
+export const AttachmentsButtonTrigger = ({ children, isFlyoutOpen }: AttachmentsTriggerProps) => (
+    <div
+        className={joinClassNames([
+            'tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line',
+            isFlyoutOpen
+                ? 'tw-bg-box-neutral-pressed tw-text-box-neutral-inverse-pressed'
+                : 'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-text-box-neutral-inverse hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
+        ])}
+    >
         {children}
     </div>
 );

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
@@ -1,0 +1,9 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type AttachmentsTriggerProps } from './types';
+
+export const AttachmentsButtonTrigger = ({ children }: AttachmentsTriggerProps) => (
+    <div className="tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line">
+        {children}
+    </div>
+);

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -3,6 +3,11 @@
 import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
 import { ReactNode } from 'react';
 
+export type AttachmentsTriggerProps = {
+    children: ReactNode;
+    isFlyoutOpen: boolean;
+};
+
 export type AttachmentsProps = {
     items?: Asset[];
     appBridge: AppBridgeBlock;
@@ -12,7 +17,7 @@ export type AttachmentsProps = {
     onUpload: (uploadedAttachments: Asset[]) => Promise<void>;
     onBrowse: (browserAttachments: Asset[]) => void;
     onSorted: (sortedAttachments: Asset[]) => void;
-    triggerComponent?: ({ children }: AttachmentsTriggerComponentProps) => JSX.Element;
+    triggerComponent?: ({ children }: AttachmentsTriggerProps) => JSX.Element;
 } & ({ isOpen?: never; onOpenChange?: never } | { isOpen: boolean; onOpenChange: (isOpen: boolean) => void });
 
 export type AttachmentItemProps = SortableAttachmentItemProps & {
@@ -29,9 +34,4 @@ export type SortableAttachmentItemProps = {
     isLoading?: boolean;
     onReplaceWithBrowse: () => void;
     onReplaceWithUpload: (uploadedAsset: Asset) => void;
-};
-
-export type AttachmentsTriggerComponentProps = {
-    children: ReactNode;
-    isFlyoutOpen: boolean;
 };

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
-import { ReactNode } from 'react';
+import { type AppBridgeBlock, type Asset } from '@frontify/app-bridge';
+import { type ReactNode } from 'react';
 
 export type AttachmentsTriggerProps = {
     children: ReactNode;

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -17,7 +17,7 @@ export type AttachmentsProps = {
     onUpload: (uploadedAttachments: Asset[]) => Promise<void>;
     onBrowse: (browserAttachments: Asset[]) => void;
     onSorted: (sortedAttachments: Asset[]) => void;
-    triggerComponent?: ({ children }: AttachmentsTriggerProps) => JSX.Element;
+    triggerComponent?: (props: AttachmentsTriggerProps) => JSX.Element;
 } & ({ isOpen?: never; onOpenChange?: never } | { isOpen: boolean; onOpenChange: (isOpen: boolean) => void });
 
 export type AttachmentItemProps = SortableAttachmentItemProps & {

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
+import { ReactNode } from 'react';
 
 export type AttachmentsProps = {
     items?: Asset[];
@@ -11,7 +12,8 @@ export type AttachmentsProps = {
     onUpload: (uploadedAttachments: Asset[]) => Promise<void>;
     onBrowse: (browserAttachments: Asset[]) => void;
     onSorted: (sortedAttachments: Asset[]) => void;
-};
+    triggerComponent?: ({ children }: AttachmentsTriggerComponentProps) => JSX.Element;
+} & ({ isOpen?: never; onOpenChange?: never } | { isOpen: boolean; onOpenChange: (isOpen: boolean) => void });
 
 export type AttachmentItemProps = SortableAttachmentItemProps & {
     isDragging?: boolean;
@@ -27,4 +29,8 @@ export type SortableAttachmentItemProps = {
     isLoading?: boolean;
     onReplaceWithBrowse: () => void;
     onReplaceWithUpload: (uploadedAsset: Asset) => void;
+};
+
+export type AttachmentsTriggerComponentProps = {
+    children: ReactNode;
 };

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -33,4 +33,5 @@ export type SortableAttachmentItemProps = {
 
 export type AttachmentsTriggerComponentProps = {
     children: ReactNode;
+    isFlyoutOpen: boolean;
 };

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ReactElement, useEffect, useRef, useState } from 'react';
+import { ReactElement, useRef, useState } from 'react';
 import { joinClassNames } from '../../utilities';
 import { Toolbar } from './Toolbar';
 import { BlockItemWrapperProps, ToolbarItem } from './types';
@@ -15,17 +15,11 @@ export const BlockItemWrapper = ({
     shouldFillContainer,
     outlineOffset = 2,
     shouldBeShown = false,
+    showAttachments,
 }: BlockItemWrapperProps): ReactElement => {
-    const [isFlyoutOpen, setIsFlyoutOpen] = useState(shouldBeShown);
-    const [isFlyoutDisabled, setIsFlyoutDisabled] = useState(false);
+    const [isMenuFlyoutOpen, setIsMenuFlyoutOpen] = useState(shouldBeShown);
+    const [isAttachmentFlyoutOpen, setIsAttachmentFlyoutOpen] = useState(false);
     const wrapperRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (!isFlyoutOpen) {
-            // This prevents automatic refocusing of the trigger element
-            setIsFlyoutDisabled(true);
-        }
-    }, [isFlyoutOpen]);
 
     if (shouldHideWrapper) {
         // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -34,11 +28,11 @@ export const BlockItemWrapper = ({
 
     const items = toolbarItems?.filter((item): item is ToolbarItem => item !== undefined);
 
+    const shouldToolbarBeVisible = isMenuFlyoutOpen || isAttachmentFlyoutOpen || shouldBeShown;
+
     return (
         <div
             ref={wrapperRef}
-            onFocus={() => setIsFlyoutDisabled(false)}
-            onPointerEnter={() => setIsFlyoutDisabled(false)}
             data-test-id="block-item-wrapper"
             style={{
                 outlineOffset,
@@ -47,7 +41,7 @@ export const BlockItemWrapper = ({
                 'tw-relative tw-group tw-outline-1 tw-outline-box-selected-inverse',
                 shouldFillContainer && 'tw-flex-1 tw-h-full tw-w-full',
                 'hover:tw-outline focus-within:tw-outline',
-                (isFlyoutOpen || shouldBeShown) && 'tw-outline',
+                shouldToolbarBeVisible && 'tw-outline',
                 shouldHideComponent && 'tw-opacity-0',
             ])}
         >
@@ -59,14 +53,21 @@ export const BlockItemWrapper = ({
                 className={joinClassNames([
                     'tw-pointer-events-none tw-absolute tw-bottom-[calc(100%-4px)] tw-right-[-3px] tw-w-full tw-opacity-0 tw-z-[60]',
                     'group-hover:tw-opacity-100 group-focus:tw-opacity-100 focus-within:tw-opacity-100',
-                    (isFlyoutOpen || shouldBeShown) && 'tw-opacity-100',
+                    'tw-flex tw-justify-end',
+                    shouldToolbarBeVisible && 'tw-opacity-100',
                 ])}
             >
                 <Toolbar
-                    isFlyoutOpen={isFlyoutOpen}
-                    isFlyoutDisabled={isFlyoutDisabled}
-                    setIsFlyoutOpen={setIsFlyoutOpen}
-                    flyoutItems={toolbarFlyoutItems}
+                    flyoutMenu={{
+                        items: toolbarFlyoutItems,
+                        isOpen: isMenuFlyoutOpen,
+                        onOpenChange: setIsMenuFlyoutOpen,
+                    }}
+                    attachments={{
+                        enabled: showAttachments,
+                        isOpen: isAttachmentFlyoutOpen,
+                        onOpenChange: setIsAttachmentFlyoutOpen,
+                    }}
                     items={items}
                     isDragging={isDragging}
                 />

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ReactElement, useRef, useState } from 'react';
+import { type ReactElement, useRef, useState } from 'react';
+
 import { joinClassNames } from '../../utilities';
-import { Toolbar } from './Toolbar';
-import { BlockItemWrapperProps, ToolbarItem } from './types';
+
+import { Toolbar, type ToolbarItem } from './Toolbar';
+import { type BlockItemWrapperProps } from './types';
 
 export const BlockItemWrapper = ({
     children,

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -17,7 +17,7 @@ export const BlockItemWrapper = ({
     shouldFillContainer,
     outlineOffset = 2,
     shouldBeShown = false,
-    showAttachments,
+    showAttachments = false,
 }: BlockItemWrapperProps): ReactElement => {
     const [isMenuFlyoutOpen, setIsMenuFlyoutOpen] = useState(shouldBeShown);
     const [isAttachmentFlyoutOpen, setIsAttachmentFlyoutOpen] = useState(false);

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -64,7 +64,7 @@ export const BlockItemWrapper = ({
                         onOpenChange: setIsMenuFlyoutOpen,
                     }}
                     attachments={{
-                        enabled: showAttachments,
+                        isEnabled: showAttachments,
                         isOpen: isAttachmentFlyoutOpen,
                         onOpenChange: setIsAttachmentFlyoutOpen,
                     }}

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
@@ -63,7 +63,7 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
             data-test-id="block-item-wrapper-toolbar"
             className="tw-rounded-md tw-border tw-border-line-strong tw-divide-x tw-divide-line-strong tw-shadow-lg tw-flex tw-flex-none tw-items-center tw-bg-base tw-text-box-neutral-strong tw-isolate"
         >
-            {attachments.enabled && (
+            {attachments.isEnabled && (
                 <ToolbarButtonSegment>
                     <ToolbarAttachments
                         isOpen={attachments.isOpen && !isDragging}

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
@@ -13,24 +13,42 @@ import { ReactNode } from 'react';
 import { FlyoutState, ToolbarProps } from './types';
 import { joinClassNames } from '../../utilities';
 import { DEFAULT_DRAGGING_TOOLTIP, DEFAULT_DRAG_TOOLTIP } from './constants';
-import { Attachments } from '..';
+import { Attachments, AttachmentsTriggerComponentProps } from '..';
 import { useAttachmentsContext } from '../../hooks/useAttachments';
 
-export const SHARED_TOOLBAR_BUTTON_CLASSES =
-    'tw-bg-base tw-relative tw-inline-flex tw-items-center tw-justify-center tw-min-w-[24px] tw-h-6 tw-rounded focus-visible:tw-z-10';
+const getToolbarButtonClassNames = (cursor: 'grab' | 'pointer', forceActiveStyle?: boolean) => {
+    const classNames = [
+        FOCUS_VISIBLE_STYLE,
+        'tw-relative tw-inline-flex tw-items-center tw-justify-center',
+        'tw-h-6 tw-p-1',
+        'tw-rounded',
+        'tw-text-xs tw-font-medium',
+        'tw-gap-0.5',
+        'focus-visible:tw-z-10',
+    ];
 
-const AttachmentsToolbarTrigger = ({ children }: { children: ReactNode }) => (
-    <div
-        className={joinClassNames([
-            'tw-flex tw-text-xs tw-font-medium tw-gap-0.5 hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-p-1',
-            SHARED_TOOLBAR_BUTTON_CLASSES,
-        ])}
-    >
-        {children}
-    </div>
+    if (forceActiveStyle) {
+        classNames.push(
+            'tw-bg-box-neutral-pressed',
+            'tw-text-box-neutral-inverse-pressed',
+            cursor === 'grab' ? 'tw-cursor-grabbing' : 'tw-cursor-pointer',
+        );
+    } else {
+        classNames.push(
+            'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed',
+            'tw-text-text-weak hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
+            cursor === 'grab' ? 'tw-cursor-grab active:tw-cursor-grabbing' : 'tw-cursor-pointer',
+        );
+    }
+
+    return joinClassNames(classNames);
+};
+
+const AttachmentsToolbarTrigger = ({ children, isFlyoutOpen }: AttachmentsTriggerComponentProps) => (
+    <div className={getToolbarButtonClassNames('pointer', isFlyoutOpen)}>{children}</div>
 );
 
-const ToolbarButtonSegment = ({ children }: { children: ReactNode }) => (
+const ToolbarSegment = ({ children }: { children: ReactNode }) => (
     <div className="tw-pointer-events-auto tw-flex tw-flex-shrink-0 tw-gap-px tw-px-px tw-h-[26px] tw-items-center tw-self-start">
         {children}
     </div>
@@ -61,17 +79,17 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
     return (
         <div
             data-test-id="block-item-wrapper-toolbar"
-            className="tw-rounded-md tw-border tw-border-line-strong tw-divide-x tw-divide-line-strong tw-shadow-lg tw-flex tw-flex-none tw-items-center tw-bg-base tw-text-box-neutral-strong tw-isolate"
+            className="tw-rounded-md tw-border tw-border-line-strong tw-divide-x tw-divide-line-strong tw-shadow-lg tw-flex tw-flex-none tw-items-center tw-bg-base tw-isolate"
         >
             {attachments.isEnabled && (
-                <ToolbarButtonSegment>
+                <ToolbarSegment>
                     <ToolbarAttachments
                         isOpen={attachments.isOpen && !isDragging}
                         onOpenChange={attachments.onOpenChange}
                     />
-                </ToolbarButtonSegment>
+                </ToolbarSegment>
             )}
-            <ToolbarButtonSegment>
+            <ToolbarSegment>
                 {items.map((item, i) =>
                     'draggableProps' in item ? (
                         <Tooltip
@@ -91,14 +109,7 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
                                     ref={item.setActivatorNodeRef}
                                     data-test-id="block-item-wrapper-toolbar-btn"
                                     {...item.draggableProps}
-                                    className={joinClassNames([
-                                        FOCUS_VISIBLE_STYLE,
-                                        SHARED_TOOLBAR_BUTTON_CLASSES,
-                                        'focus-visible:tw-z-10',
-                                        isDragging
-                                            ? 'tw-cursor-grabbing tw-bg-box-neutral-pressed'
-                                            : 'tw-cursor-grab hover:tw-bg-box-neutral-hover',
-                                    ])}
+                                    className={getToolbarButtonClassNames('grab', isDragging)}
                                 >
                                     {item.icon}
                                 </button>
@@ -117,11 +128,7 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
                                 <button
                                     data-test-id="block-item-wrapper-toolbar-btn"
                                     onClick={item.onClick}
-                                    className={joinClassNames([
-                                        'hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-cursor-pointer',
-                                        FOCUS_VISIBLE_STYLE,
-                                        SHARED_TOOLBAR_BUTTON_CLASSES,
-                                    ])}
+                                    className={getToolbarButtonClassNames('pointer')}
                                 >
                                     {item.icon}
                                 </button>
@@ -148,10 +155,7 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
                                     trigger={
                                         <div
                                             data-test-id="block-item-wrapper-toolbar-flyout"
-                                            className={joinClassNames([
-                                                'hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-cursor-pointer',
-                                                SHARED_TOOLBAR_BUTTON_CLASSES,
-                                            ])}
+                                            className={getToolbarButtonClassNames('pointer', flyoutMenu.isOpen)}
                                         >
                                             <IconDotsHorizontal16 />
                                         </div>
@@ -179,7 +183,7 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
                         }
                     />
                 )}
-            </ToolbarButtonSegment>
+            </ToolbarSegment>
         </div>
     );
 };

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar.tsx
@@ -9,21 +9,69 @@ import {
     LegacyTooltip as Tooltip,
     TooltipPosition,
 } from '@frontify/fondue';
-import { ToolbarProps } from './types';
+import { ReactNode } from 'react';
+import { FlyoutState, ToolbarProps } from './types';
 import { joinClassNames } from '../../utilities';
 import { DEFAULT_DRAGGING_TOOLTIP, DEFAULT_DRAG_TOOLTIP } from './constants';
+import { Attachments } from '..';
+import { useAttachmentsContext } from '../../hooks/useAttachments';
 
-export const Toolbar = ({
-    items,
-    flyoutItems,
-    isFlyoutOpen,
-    setIsFlyoutOpen,
-    isDragging,
-    isFlyoutDisabled,
-}: ToolbarProps) => {
+export const SHARED_TOOLBAR_BUTTON_CLASSES =
+    'tw-bg-base tw-relative tw-inline-flex tw-items-center tw-justify-center tw-min-w-[24px] tw-h-6 tw-rounded focus-visible:tw-z-10';
+
+const AttachmentsToolbarTrigger = ({ children }: { children: ReactNode }) => (
+    <div
+        className={joinClassNames([
+            'tw-flex tw-text-xs tw-font-medium tw-gap-0.5 hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-p-1',
+            SHARED_TOOLBAR_BUTTON_CLASSES,
+        ])}
+    >
+        {children}
+    </div>
+);
+
+const ToolbarButtonSegment = ({ children }: { children: ReactNode }) => (
+    <div className="tw-pointer-events-auto tw-flex tw-flex-shrink-0 tw-gap-px tw-px-px tw-h-[26px] tw-items-center tw-self-start">
+        {children}
+    </div>
+);
+
+const ToolbarAttachments = ({ isOpen, onOpenChange }: FlyoutState) => {
+    const { appBridge, attachments, onAddAttachments, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
+        useAttachmentsContext();
+
     return (
-        <div data-test-id="block-item-wrapper-toolbar" className="tw-flex tw-justify-end">
-            <div className="tw-bg-white tw-isolate tw-text-box-selected-inverse tw-pointer-events-auto tw-flex tw-flex-shrink-0 tw-gap-[2px] tw-px-[1px] tw-spacing tw-items-center tw-h-7 tw-self-start tw-border tw-border-box-selected-inverse tw-rounded">
+        <Attachments
+            onUpload={onAddAttachments}
+            onDelete={onAttachmentDelete}
+            onReplaceWithBrowse={onAttachmentReplace}
+            onReplaceWithUpload={onAttachmentReplace}
+            onSorted={onAttachmentsSorted}
+            onBrowse={onAddAttachments}
+            items={attachments}
+            appBridge={appBridge}
+            triggerComponent={AttachmentsToolbarTrigger}
+            isOpen={isOpen}
+            onOpenChange={onOpenChange}
+        />
+    );
+};
+
+export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarProps) => {
+    return (
+        <div
+            data-test-id="block-item-wrapper-toolbar"
+            className="tw-rounded-md tw-border tw-border-line-strong tw-divide-x tw-divide-line-strong tw-shadow-lg tw-flex tw-flex-none tw-items-center tw-bg-base tw-text-box-neutral-strong tw-isolate"
+        >
+            {attachments.enabled && (
+                <ToolbarButtonSegment>
+                    <ToolbarAttachments
+                        isOpen={attachments.isOpen && !isDragging}
+                        onOpenChange={attachments.onOpenChange}
+                    />
+                </ToolbarButtonSegment>
+            )}
+            <ToolbarButtonSegment>
                 {items.map((item, i) =>
                     'draggableProps' in item ? (
                         <Tooltip
@@ -45,10 +93,11 @@ export const Toolbar = ({
                                     {...item.draggableProps}
                                     className={joinClassNames([
                                         FOCUS_VISIBLE_STYLE,
-                                        'tw-bg-base tw-relative tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm focus-visible:tw-z-10',
+                                        SHARED_TOOLBAR_BUTTON_CLASSES,
+                                        'focus-visible:tw-z-10',
                                         isDragging
-                                            ? 'tw-cursor-grabbing tw-bg-box-selected-pressed'
-                                            : 'tw-cursor-grab hover:tw-bg-box-selected-hover',
+                                            ? 'tw-cursor-grabbing tw-bg-box-neutral-pressed'
+                                            : 'tw-cursor-grab hover:tw-bg-box-neutral-hover',
                                     ])}
                                 >
                                     {item.icon}
@@ -69,8 +118,9 @@ export const Toolbar = ({
                                     data-test-id="block-item-wrapper-toolbar-btn"
                                     onClick={item.onClick}
                                     className={joinClassNames([
-                                        'tw-bg-base tw-relative hover:tw-bg-box-selected-hover active:tw-bg-box-selected-pressed tw-cursor-pointer tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm focus-visible:tw-z-10',
+                                        'hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-cursor-pointer',
                                         FOCUS_VISIBLE_STYLE,
+                                        SHARED_TOOLBAR_BUTTON_CLASSES,
                                     ])}
                                 >
                                     {item.icon}
@@ -79,55 +129,57 @@ export const Toolbar = ({
                         />
                     ),
                 )}
-                {flyoutItems.length > 0 && (
-                    <div className="tw-flex tw-flex-shrink-0 tw-flex-1 tw-h-6 tw-relative">
-                        <Flyout
-                            isOpen={isFlyoutOpen && !isDragging}
-                            isTriggerDisabled={isFlyoutDisabled}
-                            legacyFooter={false}
-                            fitContent
-                            hug={false}
-                            onOpenChange={setIsFlyoutOpen}
-                            trigger={
-                                <Tooltip
-                                    withArrow
-                                    hoverDelay={0}
-                                    enterDelay={300}
-                                    disabled={isDragging}
-                                    position={TooltipPosition.Top}
-                                    content={<div>Options</div>}
-                                    triggerElement={
+                {flyoutMenu.items.length > 0 && (
+                    <Tooltip
+                        withArrow
+                        hoverDelay={0}
+                        enterDelay={300}
+                        disabled={isDragging || flyoutMenu.isOpen}
+                        position={TooltipPosition.Top}
+                        content={<div>Options</div>}
+                        triggerElement={
+                            <div className="tw-flex tw-flex-shrink-0 tw-flex-1 tw-h-6 tw-relative">
+                                <Flyout
+                                    isOpen={flyoutMenu.isOpen && !isDragging}
+                                    legacyFooter={false}
+                                    fitContent
+                                    hug={false}
+                                    onOpenChange={flyoutMenu.onOpenChange}
+                                    trigger={
                                         <div
                                             data-test-id="block-item-wrapper-toolbar-flyout"
-                                            className="tw-bg-base hover:tw-bg-box-selected-hover active:tw-bg-box-selected-pressed tw-cursor-pointer tw-inline-flex tw-items-center tw-justify-center tw-w-6 tw-h-6 tw-rounded-sm tw-relative"
+                                            className={joinClassNames([
+                                                'hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-cursor-pointer',
+                                                SHARED_TOOLBAR_BUTTON_CLASSES,
+                                            ])}
                                         >
                                             <IconDotsHorizontal16 />
                                         </div>
                                     }
-                                />
-                            }
-                        >
-                            <ActionMenu
-                                menuBlocks={flyoutItems.map((block, blockIndex) => ({
-                                    id: blockIndex.toString(),
-                                    menuItems: block.map((item, itemIndex) => ({
-                                        id: blockIndex.toString() + itemIndex.toString(),
-                                        size: MenuItemContentSize.XSmall,
-                                        title: item.title,
-                                        style: item.style,
-                                        onClick: () => {
-                                            setIsFlyoutOpen(false);
-                                            item.onClick();
-                                        },
-                                        initialValue: true,
-                                        decorator: <div className="tw-mr-2">{item.icon}</div>,
-                                    })),
-                                }))}
-                            />
-                        </Flyout>
-                    </div>
+                                >
+                                    <ActionMenu
+                                        menuBlocks={flyoutMenu.items.map((block, blockIndex) => ({
+                                            id: blockIndex.toString(),
+                                            menuItems: block.map((item, itemIndex) => ({
+                                                id: blockIndex.toString() + itemIndex.toString(),
+                                                size: MenuItemContentSize.XSmall,
+                                                title: item.title,
+                                                style: item.style,
+                                                onClick: () => {
+                                                    flyoutMenu.onOpenChange(false);
+                                                    item.onClick();
+                                                },
+                                                initialValue: true,
+                                                decorator: <div className="tw-mr-2">{item.icon}</div>,
+                                            })),
+                                        }))}
+                                    />
+                                </Flyout>
+                            </div>
+                        }
+                    />
                 )}
-            </div>
+            </ToolbarButtonSegment>
         </div>
     );
 };

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.spec.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.spec.tsx
@@ -53,18 +53,6 @@ describe('Toolbar', () => {
         ).toThrowError();
     });
 
-    it('should throw error if toolbar does have attachments enabled without provider', () => {
-        expect(() =>
-            render(
-                <Toolbar
-                    items={[]}
-                    flyoutMenu={{ items: [], isOpen: false, onOpenChange: vi.fn() }}
-                    attachments={{ isEnabled: true, isOpen: false, onOpenChange: vi.fn() }}
-                />,
-            ),
-        ).toThrowError();
-    });
-
     it('should open flyouts if not dragging', async () => {
         const STUB_WITH_NO_ASSETS = getAppBridgeBlockStub({
             blockId: 1,

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.spec.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.spec.tsx
@@ -1,0 +1,139 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { getAppBridgeBlockStub } from '@frontify/app-bridge';
+import { render } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { AttachmentsProvider } from '../../../hooks/useAttachments';
+
+import { Toolbar } from './Toolbar';
+
+/**
+ * @vitest-environment happy-dom
+ */
+
+const ATTACHMENTS_FLYOUT_ID = 'attachments-flyout-content';
+const MENU_FLYOUT_ID = 'menu-item';
+
+const MOCK_ASSET_FIELD_ID = 'attachment';
+
+describe('Toolbar', () => {
+    beforeAll(() => {
+        vi.stubGlobal(
+            'Worker',
+            class Worker {
+                constructor() {}
+                addEventListener() {}
+                terminate() {}
+            },
+        );
+    });
+
+    it('should not throw error if toolbar does not have attachments enabled', () => {
+        expect(() =>
+            render(
+                <Toolbar
+                    items={[]}
+                    flyoutMenu={{ items: [], isOpen: false, onOpenChange: vi.fn() }}
+                    attachments={{ isEnabled: false, isOpen: false, onOpenChange: vi.fn() }}
+                />,
+            ),
+        ).not.toThrowError();
+    });
+
+    it('should throw error if toolbar does have attachments enabled without provider', () => {
+        expect(() =>
+            render(
+                <Toolbar
+                    items={[]}
+                    flyoutMenu={{ items: [], isOpen: false, onOpenChange: vi.fn() }}
+                    attachments={{ isEnabled: true, isOpen: false, onOpenChange: vi.fn() }}
+                />,
+            ),
+        ).toThrowError();
+    });
+
+    it('should throw error if toolbar does have attachments enabled without provider', () => {
+        expect(() =>
+            render(
+                <Toolbar
+                    items={[]}
+                    flyoutMenu={{ items: [], isOpen: false, onOpenChange: vi.fn() }}
+                    attachments={{ isEnabled: true, isOpen: false, onOpenChange: vi.fn() }}
+                />,
+            ),
+        ).toThrowError();
+    });
+
+    it('should open flyouts if not dragging', async () => {
+        const STUB_WITH_NO_ASSETS = getAppBridgeBlockStub({
+            blockId: 1,
+            blockAssets: { [MOCK_ASSET_FIELD_ID]: [] },
+            editorState: true,
+        });
+
+        const ToolbarWithAttachments = () => (
+            <AttachmentsProvider appBridge={STUB_WITH_NO_ASSETS} assetId={MOCK_ASSET_FIELD_ID}>
+                <Toolbar
+                    items={[]}
+                    flyoutMenu={{
+                        items: [
+                            [
+                                {
+                                    title: 'Replace with upload',
+                                    icon: <div></div>,
+                                    onClick: vi.fn(),
+                                },
+                            ],
+                        ],
+                        isOpen: true,
+                        onOpenChange: vi.fn(),
+                    }}
+                    attachments={{ isEnabled: true, isOpen: true, onOpenChange: vi.fn() }}
+                    isDragging={false}
+                />
+            </AttachmentsProvider>
+        );
+
+        const { baseElement } = render(<ToolbarWithAttachments />, { container: document.body });
+
+        expect(baseElement.querySelector(`[data-test-id=${ATTACHMENTS_FLYOUT_ID}]`)).not.toBeNull();
+        expect(baseElement.querySelector(`[data-test-id=${MENU_FLYOUT_ID}]`)).not.toBeNull();
+    });
+
+    it('should keep flyouts closed if dragging', async () => {
+        const MOCK_ASSET_FIELD_ID = 'attachment';
+        const STUB_WITH_NO_ASSETS = getAppBridgeBlockStub({
+            blockId: 1,
+            blockAssets: { [MOCK_ASSET_FIELD_ID]: [] },
+            editorState: true,
+        });
+
+        const ToolbarWithAttachments = () => (
+            <AttachmentsProvider appBridge={STUB_WITH_NO_ASSETS} assetId={MOCK_ASSET_FIELD_ID}>
+                <Toolbar
+                    items={[]}
+                    flyoutMenu={{
+                        items: [
+                            [
+                                {
+                                    title: 'Replace with upload',
+                                    icon: <div></div>,
+                                    onClick: vi.fn(),
+                                },
+                            ],
+                        ],
+                        isOpen: true,
+                        onOpenChange: vi.fn(),
+                    }}
+                    attachments={{ isEnabled: true, isOpen: true, onOpenChange: vi.fn() }}
+                    isDragging
+                />
+            </AttachmentsProvider>
+        );
+
+        const { baseElement } = render(<ToolbarWithAttachments />, { container: document.body });
+        expect(baseElement.querySelector(`[data-test-id=${ATTACHMENTS_FLYOUT_ID}]`)).toBeNull();
+        expect(baseElement.querySelector(`[data-test-id=${MENU_FLYOUT_ID}]`)).toBeNull();
+    });
+});

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.tsx
@@ -2,78 +2,19 @@
 
 import {
     ActionMenu,
-    FOCUS_VISIBLE_STYLE,
     Flyout,
     IconDotsHorizontal16,
     MenuItemContentSize,
     LegacyTooltip as Tooltip,
     TooltipPosition,
 } from '@frontify/fondue';
-import { ReactNode } from 'react';
-import { FlyoutState, ToolbarProps } from './types';
-import { joinClassNames } from '../../utilities';
-import { DEFAULT_DRAGGING_TOOLTIP, DEFAULT_DRAG_TOOLTIP } from './constants';
-import { Attachments, AttachmentsTriggerComponentProps } from '..';
-import { useAttachmentsContext } from '../../hooks/useAttachments';
 
-const getToolbarButtonClassNames = (cursor: 'grab' | 'pointer', forceActiveStyle?: boolean) => {
-    const classNames = [
-        FOCUS_VISIBLE_STYLE,
-        'tw-relative tw-inline-flex tw-items-center tw-justify-center',
-        'tw-h-6 tw-p-1',
-        'tw-rounded',
-        'tw-text-xs tw-font-medium',
-        'tw-gap-0.5',
-        'focus-visible:tw-z-10',
-    ];
+import { DEFAULT_DRAGGING_TOOLTIP, DEFAULT_DRAG_TOOLTIP } from '../constants';
 
-    if (forceActiveStyle) {
-        classNames.push(
-            'tw-bg-box-neutral-pressed',
-            'tw-text-box-neutral-inverse-pressed',
-            cursor === 'grab' ? 'tw-cursor-grabbing' : 'tw-cursor-pointer',
-        );
-    } else {
-        classNames.push(
-            'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed',
-            'tw-text-text-weak hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
-            cursor === 'grab' ? 'tw-cursor-grab active:tw-cursor-grabbing' : 'tw-cursor-pointer',
-        );
-    }
-
-    return joinClassNames(classNames);
-};
-
-const AttachmentsToolbarTrigger = ({ children, isFlyoutOpen }: AttachmentsTriggerComponentProps) => (
-    <div className={getToolbarButtonClassNames('pointer', isFlyoutOpen)}>{children}</div>
-);
-
-const ToolbarSegment = ({ children }: { children: ReactNode }) => (
-    <div className="tw-pointer-events-auto tw-flex tw-flex-shrink-0 tw-gap-px tw-px-px tw-h-[26px] tw-items-center tw-self-start">
-        {children}
-    </div>
-);
-
-const ToolbarAttachments = ({ isOpen, onOpenChange }: FlyoutState) => {
-    const { appBridge, attachments, onAddAttachments, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
-        useAttachmentsContext();
-
-    return (
-        <Attachments
-            onUpload={onAddAttachments}
-            onDelete={onAttachmentDelete}
-            onReplaceWithBrowse={onAttachmentReplace}
-            onReplaceWithUpload={onAttachmentReplace}
-            onSorted={onAttachmentsSorted}
-            onBrowse={onAddAttachments}
-            items={attachments}
-            appBridge={appBridge}
-            triggerComponent={AttachmentsToolbarTrigger}
-            isOpen={isOpen}
-            onOpenChange={onOpenChange}
-        />
-    );
-};
+import { ToolbarSegment } from './ToolbarSegment';
+import { ToolbarAttachments } from './ToolbarAttachments';
+import { getToolbarButtonClassNames } from './helpers';
+import { type ToolbarProps } from './types';
 
 export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarProps) => {
     return (

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.tsx
@@ -96,7 +96,10 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
                                     trigger={
                                         <div
                                             data-test-id="block-item-wrapper-toolbar-flyout"
-                                            className={getToolbarButtonClassNames('pointer', flyoutMenu.isOpen)}
+                                            className={getToolbarButtonClassNames(
+                                                'pointer',
+                                                flyoutMenu.isOpen && !isDragging,
+                                            )}
                                         >
                                             <IconDotsHorizontal16 />
                                         </div>

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/Toolbar.tsx
@@ -20,7 +20,7 @@ export const Toolbar = ({ items, flyoutMenu, attachments, isDragging }: ToolbarP
     return (
         <div
             data-test-id="block-item-wrapper-toolbar"
-            className="tw-rounded-md tw-border tw-border-line-strong tw-divide-x tw-divide-line-strong tw-shadow-lg tw-flex tw-flex-none tw-items-center tw-bg-base tw-isolate"
+            className="tw-rounded-md tw-bg-base tw-border tw-border-line-strong tw-divide-x tw-divide-line-strong tw-shadow-lg tw-flex tw-flex-none tw-items-center tw-isolate"
         >
             {attachments.isEnabled && (
                 <ToolbarSegment>

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachments.tsx
@@ -1,0 +1,29 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { Attachments } from '../../Attachments';
+import { useAttachmentsContext } from '../../../hooks';
+
+import { type ToolbarFlyoutState } from './types';
+
+import { ToolbarAttachmentsTrigger } from './ToolbarAttachmentsTrigger';
+
+export const ToolbarAttachments = ({ isOpen, onOpenChange }: ToolbarFlyoutState) => {
+    const { appBridge, attachments, onAddAttachments, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
+        useAttachmentsContext();
+
+    return (
+        <Attachments
+            onUpload={onAddAttachments}
+            onDelete={onAttachmentDelete}
+            onReplaceWithBrowse={onAttachmentReplace}
+            onReplaceWithUpload={onAttachmentReplace}
+            onSorted={onAttachmentsSorted}
+            onBrowse={onAddAttachments}
+            items={attachments}
+            appBridge={appBridge}
+            triggerComponent={ToolbarAttachmentsTrigger}
+            isOpen={isOpen}
+            onOpenChange={onOpenChange}
+        />
+    );
+};

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachmentsTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachmentsTrigger.tsx
@@ -1,9 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { IconCaretDown12, IconPaperclip16 } from '@frontify/fondue';
 import { type AttachmentsTriggerProps } from '../../Attachments/types';
 
 import { getToolbarButtonClassNames } from './helpers';
 
 export const ToolbarAttachmentsTrigger = ({ children, isFlyoutOpen }: AttachmentsTriggerProps) => (
-    <div className={getToolbarButtonClassNames('pointer', isFlyoutOpen)}>{children}</div>
+    <div className={getToolbarButtonClassNames('pointer', isFlyoutOpen)}>
+        <IconPaperclip16 />
+        {children}
+        <IconCaretDown12 />
+    </div>
 );

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachmentsTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachmentsTrigger.tsx
@@ -1,0 +1,9 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type AttachmentsTriggerProps } from '../../Attachments/types';
+
+import { getToolbarButtonClassNames } from './helpers';
+
+export const ToolbarAttachmentsTrigger = ({ children, isFlyoutOpen }: AttachmentsTriggerProps) => (
+    <div className={getToolbarButtonClassNames('pointer', isFlyoutOpen)}>{children}</div>
+);

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarSegment.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarSegment.tsx
@@ -1,0 +1,9 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type ReactNode } from 'react';
+
+export const ToolbarSegment = ({ children }: { children: ReactNode }) => (
+    <div className="tw-pointer-events-auto tw-flex tw-flex-shrink-0 tw-gap-px tw-px-px tw-h-[26px] tw-items-center tw-self-start">
+        {children}
+    </div>
+);

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/helpers.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/helpers.ts
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { FOCUS_VISIBLE_STYLE } from '@frontify/fondue';
+
 import { joinClassNames } from '../../../utilities';
 
 export const getToolbarButtonClassNames = (cursor: 'grab' | 'pointer', forceActiveStyle?: boolean) => {

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/helpers.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/helpers.ts
@@ -22,7 +22,7 @@ export const getToolbarButtonClassNames = (cursor: 'grab' | 'pointer', forceActi
         );
     } else {
         classNames.push(
-            'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed',
+            'hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed',
             'tw-text-text-weak hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
             cursor === 'grab' ? 'tw-cursor-grab active:tw-cursor-grabbing' : 'tw-cursor-pointer',
         );

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/helpers.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/helpers.ts
@@ -1,0 +1,32 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { FOCUS_VISIBLE_STYLE } from '@frontify/fondue';
+import { joinClassNames } from '../../../utilities';
+
+export const getToolbarButtonClassNames = (cursor: 'grab' | 'pointer', forceActiveStyle?: boolean) => {
+    const classNames = [
+        FOCUS_VISIBLE_STYLE,
+        'tw-relative tw-inline-flex tw-items-center tw-justify-center',
+        'tw-h-6 tw-p-1',
+        'tw-rounded',
+        'tw-text-xs tw-font-medium',
+        'tw-gap-0.5',
+        'focus-visible:tw-z-10',
+    ];
+
+    if (forceActiveStyle) {
+        classNames.push(
+            'tw-bg-box-neutral-pressed',
+            'tw-text-box-neutral-inverse-pressed',
+            cursor === 'grab' ? 'tw-cursor-grabbing' : 'tw-cursor-pointer',
+        );
+    } else {
+        classNames.push(
+            'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed',
+            'tw-text-text-weak hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
+            cursor === 'grab' ? 'tw-cursor-grab active:tw-cursor-grabbing' : 'tw-cursor-pointer',
+        );
+    }
+
+    return joinClassNames(classNames);
+};

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/index.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/index.ts
@@ -1,0 +1,4 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './Toolbar';
+export * from './types';

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/types.ts
@@ -1,0 +1,38 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type MenuItemStyle } from '@frontify/fondue';
+
+export type ToolbarProps = {
+    items: ToolbarItem[];
+    flyoutMenu: ToolbarFlyoutState & { items: FlyoutToolbarItem[][] };
+    attachments: ToolbarFlyoutState & { isEnabled: boolean };
+    isDragging?: boolean;
+};
+
+export type ToolbarFlyoutState = {
+    isOpen: boolean;
+    onOpenChange: (isOpen: boolean) => void;
+};
+
+type BaseToolbarItem = {
+    icon: JSX.Element;
+    tooltip?: string;
+};
+
+type DraghandleToolbarItem = BaseToolbarItem & {
+    draggableProps: Record<string, unknown>;
+    setActivatorNodeRef?: (node: HTMLElement | null) => void;
+};
+
+type ButtonToolbarItem = BaseToolbarItem & {
+    onClick: () => void;
+};
+
+export type ToolbarItem = DraghandleToolbarItem | ButtonToolbarItem;
+
+export type FlyoutToolbarItem = {
+    title: string;
+    onClick: () => void;
+    icon: JSX.Element;
+    style?: MenuItemStyle;
+};

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { MenuItemStyle } from '@frontify/fondue';
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
+
+import { type FlyoutToolbarItem, type ToolbarItem } from './Toolbar';
 
 export type BlockItemWrapperProps = {
     children: ReactNode;
@@ -14,39 +15,4 @@ export type BlockItemWrapperProps = {
     outlineOffset?: number;
     shouldBeShown?: boolean;
     showAttachments: boolean;
-};
-
-export type ToolbarProps = {
-    items: ToolbarItem[];
-    flyoutMenu: FlyoutState & { items: FlyoutToolbarItem[][] };
-    attachments: FlyoutState & { isEnabled: boolean };
-    isDragging?: boolean;
-};
-
-export type FlyoutState = {
-    isOpen: boolean;
-    onOpenChange: (isOpen: boolean) => void;
-};
-
-type BaseToolbarItem = {
-    icon: JSX.Element;
-    tooltip?: string;
-};
-
-type DraghandleToolbarItem = BaseToolbarItem & {
-    draggableProps: Record<string, unknown>;
-    setActivatorNodeRef?: (node: HTMLElement | null) => void;
-};
-
-type ButtonToolbarItem = BaseToolbarItem & {
-    onClick: () => void;
-};
-
-export type ToolbarItem = DraghandleToolbarItem | ButtonToolbarItem;
-
-export type FlyoutToolbarItem = {
-    title: string;
-    onClick: () => void;
-    icon: JSX.Element;
-    style?: MenuItemStyle;
 };

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
@@ -2,6 +2,8 @@
 
 import { type ReactNode } from 'react';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { type AttachmentsProvider, type withAttachmentsProvider } from '../../hooks/useAttachments';
 import { type FlyoutToolbarItem, type ToolbarItem } from './Toolbar';
 
 export type BlockItemWrapperProps = {
@@ -15,8 +17,8 @@ export type BlockItemWrapperProps = {
     outlineOffset?: number;
     shouldBeShown?: boolean;
     /**
-     * When set to true the BlockItemWrapper must be a child of a 'AttachmentsProvider' component,
-     *  or the block must be wrapper with a 'withAttachments' HOC.
+     * When set to true the BlockItemWrapper must be a child of a {@link AttachmentsProvider} component,
+     *  or the block must be wrapped with a {@link withAttachmentsProvider} HOC.
      * @default false
      */
     showAttachments?: boolean;

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
@@ -19,7 +19,7 @@ export type BlockItemWrapperProps = {
 export type ToolbarProps = {
     items: ToolbarItem[];
     flyoutMenu: FlyoutState & { items: FlyoutToolbarItem[][] };
-    attachments: FlyoutState & { enabled: boolean };
+    attachments: FlyoutState & { isEnabled: boolean };
     isDragging?: boolean;
 };
 

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
@@ -14,5 +14,10 @@ export type BlockItemWrapperProps = {
     shouldFillContainer?: boolean;
     outlineOffset?: number;
     shouldBeShown?: boolean;
-    showAttachments: boolean;
+    /**
+     * When set to true the BlockItemWrapper must be a child of a 'AttachmentsProvider' component,
+     *  or the block must be wrapper with a 'withAttachments' HOC.
+     * @default false
+     */
+    showAttachments?: boolean;
 };

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/types.ts
@@ -13,15 +13,19 @@ export type BlockItemWrapperProps = {
     shouldFillContainer?: boolean;
     outlineOffset?: number;
     shouldBeShown?: boolean;
+    showAttachments: boolean;
 };
 
 export type ToolbarProps = {
     items: ToolbarItem[];
-    flyoutItems: FlyoutToolbarItem[][];
-    isFlyoutOpen: boolean;
-    setIsFlyoutOpen: (isOpen: boolean) => void;
+    flyoutMenu: FlyoutState & { items: FlyoutToolbarItem[][] };
+    attachments: FlyoutState & { enabled: boolean };
     isDragging?: boolean;
-    isFlyoutDisabled?: boolean;
+};
+
+export type FlyoutState = {
+    isOpen: boolean;
+    onOpenChange: (isOpen: boolean) => void;
 };
 
 type BaseToolbarItem = {

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
@@ -20,7 +20,7 @@ describe('useAttachments', () => {
         });
         const { result } = renderHook(() => useAttachments(STUB_WITH_NO_ASSETS, MOCK_SETTINGS_ID));
 
-        await result.current.onAddAttachments([AssetDummy.with(1)]);
+        await result.current.onAttachmentsAdd([AssetDummy.with(1)]);
         await waitFor(() => {
             expect(result.current.attachments).toHaveLength(1);
         });

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { AssetDummy, getAppBridgeBlockStub } from '@frontify/app-bridge';
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { AttachmentsProvider, useAttachments, useAttachmentsContext } from './useAttachments';
+import { AttachmentsProvider, useAttachments, useAttachmentsContext, withAttachments } from './useAttachments';
 
 const MOCK_SETTINGS_ID = 'attachments';
 
@@ -100,5 +100,31 @@ describe('useAttachmentsContext', () => {
         await waitFor(() => {
             expect(result.current.attachments).toHaveLength(1);
         });
+    });
+});
+
+describe('withAttachments', () => {
+    it('should provide correct info to context consumer', async () => {
+        const STUB_WITH_THREE_ASSETS = getAppBridgeBlockStub({
+            blockId: 2,
+            blockAssets: { [MOCK_SETTINGS_ID]: [AssetDummy.with(1), AssetDummy.with(2), AssetDummy.with(3)] },
+        });
+
+        const Component = withAttachments(() => {
+            const context = useAttachmentsContext();
+            return (
+                <ul>
+                    {context.attachments.map((attachment) => (
+                        <li key={attachment.id} role="list">
+                            {attachment.id}
+                        </li>
+                    ))}
+                </ul>
+            );
+        }, MOCK_SETTINGS_ID);
+
+        const { getAllByRole } = render(<Component appBridge={STUB_WITH_THREE_ASSETS} />);
+
+        await waitFor(() => expect(getAllByRole('list')).toHaveLength(3));
     });
 });

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
@@ -4,7 +4,7 @@ import { AssetDummy, getAppBridgeBlockStub } from '@frontify/app-bridge';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { describe, expect, it } from 'vitest';
-import { useAttachments } from './useAttachments';
+import { AttachmentsProvider, useAttachments, useAttachmentsContext } from './useAttachments';
 
 const MOCK_SETTINGS_ID = 'attachments';
 
@@ -74,6 +74,31 @@ describe('useAttachments', () => {
             expect(result.current.attachments[0].id).toBe(3);
             expect(result.current.attachments[1].id).toBe(2);
             expect(result.current.attachments[2].id).toBe(1);
+        });
+    });
+});
+
+describe('useAttachmentsContext', () => {
+    it('should throw an error when not a child of a provider', async () => {
+        expect(() => renderHook(() => useAttachmentsContext())).toThrowError();
+    });
+
+    it('should return correct info', async () => {
+        const STUB_WITH_NO_ASSETS = getAppBridgeBlockStub({
+            blockId: 1,
+            blockAssets: { [MOCK_SETTINGS_ID]: [AssetDummy.with(1)] },
+        });
+        const { result } = renderHook(useAttachmentsContext, {
+            wrapper: ({ children }) => (
+                <AttachmentsProvider appBridge={STUB_WITH_NO_ASSETS} assetId={MOCK_SETTINGS_ID}>
+                    {children}
+                </AttachmentsProvider>
+            ),
+        });
+
+        expect(result.current.appBridge).toEqual(STUB_WITH_NO_ASSETS);
+        await waitFor(() => {
+            expect(result.current.attachments).toHaveLength(1);
         });
     });
 });

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
@@ -2,8 +2,8 @@
 
 import { AssetDummy, getAppBridgeBlockStub } from '@frontify/app-bridge';
 import { renderHook, waitFor } from '@testing-library/react';
-
 import { describe, expect, it } from 'vitest';
+
 import { AttachmentsProvider, useAttachments, useAttachmentsContext } from './useAttachments';
 
 const MOCK_SETTINGS_ID = 'attachments';

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.spec.tsx
@@ -4,7 +4,7 @@ import { AssetDummy, getAppBridgeBlockStub } from '@frontify/app-bridge';
 import { render, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { AttachmentsProvider, useAttachments, useAttachmentsContext, withAttachments } from './useAttachments';
+import { AttachmentsProvider, useAttachments, useAttachmentsContext, withAttachmentsProvider } from './useAttachments';
 
 const MOCK_SETTINGS_ID = 'attachments';
 
@@ -103,14 +103,14 @@ describe('useAttachmentsContext', () => {
     });
 });
 
-describe('withAttachments', () => {
+describe('withAttachmentsProvider', () => {
     it('should provide correct info to context consumer', async () => {
         const STUB_WITH_THREE_ASSETS = getAppBridgeBlockStub({
             blockId: 2,
             blockAssets: { [MOCK_SETTINGS_ID]: [AssetDummy.with(1), AssetDummy.with(2), AssetDummy.with(3)] },
         });
 
-        const Component = withAttachments(() => {
+        const Component = withAttachmentsProvider(() => {
             const context = useAttachmentsContext();
             return (
                 <ul>

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -70,7 +70,7 @@ export const useAttachmentsContext = () => {
 
     if (!context) {
         throw new Error(
-            "No AttachmentsContext Provided. Component must be wrapped in an 'AttachmentsProvider' or the 'withAttachments' HOC",
+            "No AttachmentsContext Provided. Component must be wrapped in an 'AttachmentsProvider' or the 'withAttachmentsProvider' HOC",
         );
     }
 

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -77,6 +77,11 @@ export const useAttachmentsContext = () => {
     return context;
 };
 
+/**
+ * Block-level HOC for cases when there is only one attachment asset field related to the block.
+ * Recommended for most cases.
+ * If finer control is required over attachments, use AttachmentsProvider component.
+ */
 export const withAttachments = <T extends BlockProps>(Component: FC<T>, assetId: string) => {
     const wrappedComponent = (props: T) => (
         <AttachmentsProvider appBridge={props.appBridge} assetId={assetId}>

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -82,14 +82,14 @@ export const useAttachmentsContext = () => {
  * Recommended for most cases.
  * If finer control is required over attachments, use AttachmentsProvider component.
  */
-export const withAttachments = <T extends BlockProps>(Component: (props: T) => ReactNode, assetId: string) => {
+export const withAttachmentsProvider = <T extends BlockProps>(Component: (props: T) => ReactNode, assetId: string) => {
     const wrappedComponent = (props: T) => (
         <AttachmentsProvider appBridge={props.appBridge} assetId={assetId}>
             <Component {...props} />
         </AttachmentsProvider>
     );
 
-    wrappedComponent.displayName = 'withAttachments';
+    wrappedComponent.displayName = 'withAttachmentsProvider';
 
     return wrappedComponent;
 };

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { AppBridgeBlock, Asset, useBlockAssets } from '@frontify/app-bridge';
-import { type FC, type ReactNode, createContext, useContext } from 'react';
+import { type ReactNode, createContext, useContext } from 'react';
 
 import { type BlockProps } from 'src';
 
@@ -82,7 +82,7 @@ export const useAttachmentsContext = () => {
  * Recommended for most cases.
  * If finer control is required over attachments, use AttachmentsProvider component.
  */
-export const withAttachments = <T extends BlockProps>(Component: FC<T>, assetId: string) => {
+export const withAttachments = <T extends BlockProps>(Component: (props: T) => ReactNode, assetId: string) => {
     const wrappedComponent = (props: T) => (
         <AttachmentsProvider appBridge={props.appBridge} assetId={assetId}>
             <Component {...props} />

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -3,7 +3,7 @@
 import { AppBridgeBlock, Asset, useBlockAssets } from '@frontify/app-bridge';
 import { type ReactNode, createContext, useContext } from 'react';
 
-import { type BlockProps } from '../';
+import { type BlockProps } from '../index';
 
 export const useAttachments = (appBridge: AppBridgeBlock, assetId: string) => {
     const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);
@@ -80,7 +80,7 @@ export const useAttachmentsContext = () => {
 /**
  * Block-level HOC for cases when there is only one attachment asset field related to the block.
  * Recommended for most cases.
- * If finer control is required over attachments, use AttachmentsProvider component.
+ * If finer control is required over attachments, use {@link AttachmentsProvider} component.
  */
 export const withAttachmentsProvider = <T extends BlockProps>(Component: (props: T) => ReactNode, assetId: string) => {
     const wrappedComponent = (props: T) => (

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -3,7 +3,7 @@
 import { AppBridgeBlock, Asset, useBlockAssets } from '@frontify/app-bridge';
 import { type ReactNode, createContext, useContext } from 'react';
 
-import { type BlockProps } from '../../';
+import { type BlockProps } from '../';
 
 export const useAttachments = (appBridge: AppBridgeBlock, assetId: string) => {
     const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -9,7 +9,7 @@ export const useAttachments = (appBridge: AppBridgeBlock, assetId: string) => {
     const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);
     const attachments = blockAssets?.[assetId] || [];
 
-    const onAddAttachments = async (newAssets: Asset[]) => {
+    const onAttachmentsAdd = async (newAssets: Asset[]) => {
         const newAssetIds = attachments.map((attachment) => attachment.id);
         for (const asset of newAssets) {
             newAssetIds.push(asset.id);
@@ -40,7 +40,7 @@ export const useAttachments = (appBridge: AppBridgeBlock, assetId: string) => {
     };
 
     return {
-        onAddAttachments,
+        onAttachmentsAdd,
         onAttachmentDelete,
         onAttachmentReplace,
         onAttachmentsSorted,

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -3,7 +3,7 @@
 import { AppBridgeBlock, Asset, useBlockAssets } from '@frontify/app-bridge';
 import { type ReactNode, createContext, useContext } from 'react';
 
-import { type BlockProps } from 'src';
+import { type BlockProps } from '../../';
 
 export const useAttachments = (appBridge: AppBridgeBlock, assetId: string) => {
     const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);

--- a/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/hooks/useAttachments.tsx
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { AppBridgeBlock, Asset, useBlockAssets } from '@frontify/app-bridge';
-import { FC, ReactNode, createContext, useContext } from 'react';
-import { BlockProps } from 'src';
+import { type FC, type ReactNode, createContext, useContext } from 'react';
+
+import { type BlockProps } from 'src';
 
 export const useAttachments = (appBridge: AppBridgeBlock, assetId: string) => {
     const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);


### PR DESCRIPTION
To Test: 
- `pnpm build`
- `cd packages/guideline-blocks-settings`
- `pnpm link --global`

(In guideline-blocks/packages/audio)
- checkout https://github.com/Frontify/guideline-blocks/pull/702 branch (fix/audio-block-update)
- `pnpm link --global @fronfify/guideline-blocks-settings`
- `pnpm serve`