### PR TITLE
feat: Add Block name and Marketplace App ID to AppBridgeBlock

### DIFF
--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -69,6 +69,8 @@ export type BlockContext = {
     portalId: number;
     blockId: number;
     sectionId?: number;
+    blockName?: string;
+    marketplaceServiceAppId?: string;
 };
 
 export type BlockEvent = EventNameValidator<


### PR DESCRIPTION
- Adds [optional] the following optional parameters:
    - `blockName`
    - `marketplaceServiceAppId`
 - The fields will be fetched via context to be sent for event tracking payload ([Implementation PR](https://github.com/Frontify/web-app/pull/2074))