### PR TITLE
chore: replace deprecated functions from attachments

### DIFF
--- a/.changeset/dull-spiders-fetch.md
+++ b/.changeset/dull-spiders-fetch.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+chore(Attachments): replace deprecated functions with hooks

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
@@ -4,7 +4,6 @@ import { AssetDummy, getAppBridgeBlockStub } from '@frontify/app-bridge';
 import { mount } from 'cypress/react18';
 import { Attachments as AttachmentsComponent } from './Attachments';
 import { AttachmentsProps } from './types';
-import type { SinonStub } from 'sinon';
 
 const FlyoutButtonSelector = '[data-test-id="attachments-flyout-button"]';
 const AssetInputSelector = '[data-test-id="asset-input-placeholder"]';
@@ -89,7 +88,6 @@ describe('Attachments', () => {
         const appBridge = getAppBridgeBlockStub({
             editorState: true,
         });
-        (appBridge.openAssetChooser as SinonStub) = cy.stub().callsArgWith(0, AssetDummy.with(4));
 
         cy.clock();
         const replaceStub = () =>

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -13,7 +13,7 @@ import {
     useSensors,
 } from '@dnd-kit/core';
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable';
-import { Asset, useAssetUpload, useEditorState } from '@frontify/app-bridge';
+import { Asset, useAssetChooser, useAssetUpload, useEditorState } from '@frontify/app-bridge';
 import {
     AssetInput,
     AssetInputSize,
@@ -46,6 +46,7 @@ export const Attachments = ({
     const [assetIdsLoading, setAssetIdsLoading] = useState<number[]>([]);
     const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
     const isEditing = useEditorState(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
 
     const draggedItem = internalItems?.find((item) => item.id === draggedAssetId);
 
@@ -78,10 +79,10 @@ export const Attachments = ({
 
     const onOpenAssetChooser = () => {
         setIsFlyoutOpen(false);
-        appBridge.openAssetChooser(
+        openAssetChooser(
             (result: Asset[]) => {
                 onBrowse(result);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
                 setIsFlyoutOpen(true);
             },
             {
@@ -93,10 +94,10 @@ export const Attachments = ({
 
     const onReplaceItemWithBrowse = (toReplace: Asset) => {
         setIsFlyoutOpen(false);
-        appBridge.openAssetChooser(
+        openAssetChooser(
             async (result: Asset[]) => {
                 setIsFlyoutOpen(true);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
                 setAssetIdsLoading([...assetIdsLoading, toReplace.id]);
                 await onReplaceWithBrowse(toReplace, result[0]);
                 setAssetIdsLoading(assetIdsLoading.filter((id) => id !== toReplace.id));


### PR DESCRIPTION
As preparation to move the `@frontify/app-bridge` to the peerDeps we need to replace all deprecated functions.

PS: one component test (`renders loading circle for attachment item`) will fail as it needs the stub from https://github.com/Frontify/brand-sdk/pull/680