### PR TITLE
fix: typeerror in toolbar 

### DIFF
--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/ToolbarAttachments.tsx
@@ -8,17 +8,17 @@ import { type ToolbarFlyoutState } from './types';
 import { ToolbarAttachmentsTrigger } from './ToolbarAttachmentsTrigger';
 
 export const ToolbarAttachments = ({ isOpen, onOpenChange }: ToolbarFlyoutState) => {
-    const { appBridge, attachments, onAddAttachments, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
+    const { appBridge, attachments, onAttachmentsAdd, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
         useAttachmentsContext();
 
     return (
         <Attachments
-            onUpload={onAddAttachments}
+            onUpload={onAttachmentsAdd}
             onDelete={onAttachmentDelete}
             onReplaceWithBrowse={onAttachmentReplace}
             onReplaceWithUpload={onAttachmentReplace}
             onSorted={onAttachmentsSorted}
-            onBrowse={onAddAttachments}
+            onBrowse={onAttachmentsAdd}
             items={attachments}
             appBridge={appBridge}
             triggerComponent={ToolbarAttachmentsTrigger}


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/Frontify/brand-sdk/pull/672 where the `onAddAttachments` method was renamed `onAttachmentsAdd` but not renamed in the BlockToolbar