### PR TITLE
chore: replace deprecated functions in attachments

### DIFF
--- a/.changeset/curly-readers-clean.md
+++ b/.changeset/curly-readers-clean.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+chore(Attachments): replace deprecated functions with hooks

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
@@ -4,7 +4,6 @@ import { AssetDummy, getAppBridgeBlockStub } from '@frontify/app-bridge';
 import { mount } from 'cypress/react18';
 import { Attachments as AttachmentsComponent } from './Attachments';
 import { AttachmentsProps } from './types';
-import type { SinonStub } from 'sinon';
 
 const FlyoutButtonSelector = '[data-test-id="attachments-flyout-button"]';
 const AssetInputSelector = '[data-test-id="asset-input-placeholder"]';

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
@@ -89,7 +89,6 @@ describe('Attachments', () => {
         const appBridge = getAppBridgeBlockStub({
             editorState: true,
         });
-        (appBridge.openAssetChooser as SinonStub) = cy.stub().callsArgWith(0, AssetDummy.with(4));
 
         cy.clock();
         const replaceStub = () =>

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -14,7 +14,7 @@ import {
 } from '@dnd-kit/core';
 import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable';
-import { Asset, useAssetUpload, useEditorState } from '@frontify/app-bridge';
+import { Asset, useAssetChooser, useAssetUpload, useEditorState } from '@frontify/app-bridge';
 import {
     AssetInput,
     AssetInputSize,
@@ -49,6 +49,7 @@ export const Attachments = ({
     const [assetIdsLoading, setAssetIdsLoading] = useState<number[]>([]);
     const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
     const isEditing = useEditorState(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const isControllingStateExternally = isOpen !== undefined;
     const isFlyoutOpen = isControllingStateExternally ? isOpen : isFlyoutOpenInternal;
 
@@ -89,10 +90,10 @@ export const Attachments = ({
 
     const onOpenAssetChooser = () => {
         handleFlyoutOpenChange(false);
-        appBridge.openAssetChooser(
+        openAssetChooser(
             (result: Asset[]) => {
                 onBrowse(result);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
                 handleFlyoutOpenChange(true);
             },
             {
@@ -104,10 +105,10 @@ export const Attachments = ({
 
     const onReplaceItemWithBrowse = (toReplace: Asset) => {
         handleFlyoutOpenChange(false);
-        appBridge.openAssetChooser(
+        openAssetChooser(
             async (result: Asset[]) => {
                 handleFlyoutOpenChange(true);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
                 setAssetIdsLoading([...assetIdsLoading, toReplace.id]);
                 await onReplaceWithBrowse(toReplace, result[0]);
                 setAssetIdsLoading(assetIdsLoading.filter((id) => id !== toReplace.id));


### PR DESCRIPTION
As preparation to move the `@frontify/app-bridge` to the peerDeps we need to replace all deprecated functions.