### PR TITLE
fix: add forced line height to button

### DIFF
--- a/.changeset/modern-turtles-cheat.md
+++ b/.changeset/modern-turtles-cheat.md
@@ -2,4 +2,4 @@
 "@frontify/guideline-blocks-settings": patch
 ---
 
-Add line-height class to `AttachmentsButtonTrigger`.
+fix(Attachments): Add line-height class to `AttachmentsButtonTrigger`.

--- a/.changeset/modern-turtles-cheat.md
+++ b/.changeset/modern-turtles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+Add line-height class to `AttachmentsButtonTrigger`.

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
@@ -9,7 +9,7 @@ import { type AttachmentsTriggerProps } from './types';
 export const AttachmentsButtonTrigger = ({ children, isFlyoutOpen }: AttachmentsTriggerProps) => (
     <div
         className={joinClassNames([
-            'tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-outline tw-outline-1 tw-outline-offset-1 tw-p-1.5 tw-outline-line',
+            'tw-flex tw-text-xs tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-outline tw-outline-1 tw-outline-offset-1 tw-p-1.5 tw-outline-line',
             isFlyoutOpen
                 ? 'tw-bg-box-neutral-pressed tw-text-box-neutral-inverse-pressed'
                 : 'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-text-box-neutral-inverse hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',


### PR DESCRIPTION
Prevent Attachments standalone button from being affected by line height changes in global design settings, so that it matches download button height 