### PR TITLE
test: improve app-bridge stub for attachments as prep for 4.0.0-alpha

### DIFF
--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
@@ -43,6 +43,12 @@ const isPre302Stub = async (appBridge: AppBridgeBlock): Promise<boolean> => {
     return context === undefined;
 };
 
+const hasOpenAssetChooser = (
+    appBridge: AppBridgeBlock,
+): appBridge is AppBridgeBlock & { openAssetChooser: SinonStub } => {
+    return 'openAssetChooser' in appBridge;
+};
+
 describe('Attachments', () => {
     it('renders attachments flyout if it is in edit mode', () => {
         mount(<Attachments appBridge={getAppBridgeBlockStub({ editorState: true })} />);
@@ -94,8 +100,8 @@ describe('Attachments', () => {
             editorState: true,
         });
 
-        if (await isPre302Stub(appBridge)) {
-            (appBridge.openAssetChooser as SinonStub) = cy.stub().callsArgWith(0, AssetDummy.with(4));
+        if ((await isPre302Stub(appBridge)) && hasOpenAssetChooser(appBridge)) {
+            appBridge.openAssetChooser = cy.stub().callsArgWith(0, AssetDummy.with(4));
         }
 
         cy.clock();


### PR DESCRIPTION
Improves the openAssetChooser stub so the typecheck will also work if the function is removed, see them fail: https://github.com/Frontify/brand-sdk/pull/705

No changeset needed as it just adjusts the tests.

How to test it locally:
1. build branch this pr: https://github.com/Frontify/brand-sdk/pull/705
2. change branch to this one
3. run `pnpm add @frontify/app-bridge@workspace:^ --filter {packages/guideline-blocks-settings}`
4. run `pnpm typecheck`