### PR TITLE
feat(GuidelineBlocksSettings): add support for app-bridge alpha

### DIFF
--- a/.changeset/slimy-bikes-sin.md
+++ b/.changeset/slimy-bikes-sin.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+feat: add support for @frontify/app-bridge 4.0.0-alpha.0

--- a/packages/guideline-blocks-settings/package.json
+++ b/packages/guideline-blocks-settings/package.json
@@ -75,7 +75,7 @@
         "slate-react": "^0.98.3"
     },
     "peerDependencies": {
-        "@frontify/app-bridge": "^3.0.0",
+        "@frontify/app-bridge": "^3.0.0 || ^4.0.0-alpha.0",
         "react": "^18",
         "react-dom": "^18"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge':
-        specifier: ^3.0.0
+        specifier: ^3.0.0 || ^4.0.0-alpha.0
         version: link:../app-bridge
       '@frontify/fondue':
         specifier: 12.0.0-beta.396


### PR DESCRIPTION
There will be a follow up PR to adjust the CI Matrix (as soon 4.0.0 alpha is released)