### PR TITLE
chore: add typing for package.json

### DIFF
--- a/.changeset/green-dryers-sip.md
+++ b/.changeset/green-dryers-sip.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": patch
+---
+
+Add typing for package.json

--- a/packages/app-bridge/.gitignore
+++ b/packages/app-bridge/.gitignore
@@ -3,3 +3,4 @@ dist
 .idea
 coverage
 .DS_Store
+package.json.d.ts

--- a/packages/app-bridge/package.json
+++ b/packages/app-bridge/package.json
@@ -15,7 +15,8 @@
     "module": "dist/index.es.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist"
+        "dist",
+        "package.json.d.ts"
     ],
     "exports": {
         ".": {
@@ -29,7 +30,7 @@
         "node": ">=16"
     },
     "scripts": {
-        "build": "vite build",
+        "build": "ts-json-as-const ./package.json && vite build",
         "dev": "vite build --watch",
         "lint": "eslint .",
         "lint:fix": "eslint --fix .",
@@ -63,6 +64,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sinon": "^17.0.1",
+        "ts-json-as-const": "^1.0.7",
         "typescript": "^5.3.2",
         "vite": "^4.5.0",
         "vite-plugin-dts": "^3.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       sinon:
         specifier: ^17.0.1
         version: 17.0.1
+      ts-json-as-const:
+        specifier: ^1.0.7
+        version: 1.0.7(typescript@5.3.2)
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
@@ -926,6 +929,10 @@ packages:
       lodash.once: 4.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@dfoverdx/tocamelcase@1.0.7:
+    resolution: {integrity: sha512-QDlMJqwcE4eVCvxxQXp8nh7Nw9m5VQHPCAiyTD+W86Tl89VGhVJRb//RJRZKpn5A/Bq3EQNYDYlepurQ805MOQ==}
     dev: true
 
   /@dnd-kit/accessibility@3.1.0(react@18.2.0):
@@ -8743,6 +8750,10 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  /get-own-enumerable-property-symbols@3.0.2:
+    resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
+    dev: true
+
   /get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
@@ -9309,6 +9320,11 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  /is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
+    dev: true
+
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
@@ -9337,6 +9353,11 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
+    dev: true
+
+  /is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
     dev: true
 
   /is-set@2.0.2:
@@ -9436,6 +9457,11 @@ packages:
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    dev: true
+
+  /isbinaryfile@4.0.10:
+    resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
+    engines: {node: '>= 8.0.0'}
     dev: true
 
   /isexe@2.0.0:
@@ -12096,6 +12122,15 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
+  /stringify-object@4.0.1:
+    resolution: {integrity: sha512-qpV1FBpN0R1gDAhCHIU71SYGZb35Te+gOQbQ6lYRmVJT7pF1NB8mkHeEJvyYNiHXw+fB4KIbeIjQl1rgiIijiA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      get-own-enumerable-property-symbols: 3.0.2
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
+    dev: true
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -12409,6 +12444,19 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  /ts-json-as-const@1.0.7(typescript@5.3.2):
+    resolution: {integrity: sha512-UMM24g4uBevqBuEqeMUNm2yBEd6VrpJt2hhGWSpmr3nGuhQYwYcLpmxUjsAh5qxJbafF+ICrHvOvHn16zh9Ojg==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=3'
+    dependencies:
+      '@dfoverdx/tocamelcase': 1.0.7
+      isbinaryfile: 4.0.10
+      json5: 2.2.3
+      stringify-object: 4.0.1
+      typescript: 5.3.2
+    dev: true
 
   /ts-node@10.9.1(@types/node@18.18.11)(typescript@5.3.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}


### PR DESCRIPTION
Adds a `package.json.d.ts`, useful to compare and infer version in external package.
TypeScript doesn't allow `as const` when importing from a `json` file thus this is the only way to get full inferring of types :/