### PR TITLE
ci: add alpha (first and latest) to the matrix

### DIFF
--- a/.github/workflows/guideline-blocks-continuous-integration.yml
+++ b/.github/workflows/guideline-blocks-continuous-integration.yml
@@ -20,9 +20,9 @@ jobs:
         timeout-minutes: 10
 
         strategy:
-            fail-fast: false
             matrix:
-                app-bridge-version: ["3.0.0", "workspace:^"]
+                app-bridge-version:
+                    ["3.0.0", "workspace:^", "4.0.0-alpha.0", "^4.0.0-alpha.0"]
 
         steps:
             - name: Checkout default branch
@@ -65,9 +65,9 @@ jobs:
         timeout-minutes: 10
 
         strategy:
-            fail-fast: false
             matrix:
-                app-bridge-version: ["3.0.0", "workspace:^"]
+                app-bridge-version:
+                    ["3.0.0", "workspace:^", "4.0.0-alpha.0", "^4.0.0-alpha.0"]
 
         steps:
             - name: Checkout current commit
@@ -117,9 +117,9 @@ jobs:
         timeout-minutes: 10
 
         strategy:
-            fail-fast: false
             matrix:
-                app-bridge-version: ["3.0.0", "workspace:^"]
+                app-bridge-version:
+                    ["3.0.0", "workspace:^", "4.0.0-alpha.0", "^4.0.0-alpha.0"]
 
         steps:
             - name: Checkout current commit

--- a/.github/workflows/guideline-blocks-continuous-integration.yml
+++ b/.github/workflows/guideline-blocks-continuous-integration.yml
@@ -20,6 +20,7 @@ jobs:
         timeout-minutes: 10
 
         strategy:
+            fail-fast: false
             matrix:
                 app-bridge-version:
                     ["3.0.0", "workspace:^", "4.0.0-alpha.0", "^4.0.0-alpha.0"]
@@ -65,6 +66,7 @@ jobs:
         timeout-minutes: 10
 
         strategy:
+            fail-fast: false
             matrix:
                 app-bridge-version:
                     ["3.0.0", "workspace:^", "4.0.0-alpha.0", "^4.0.0-alpha.0"]
@@ -117,6 +119,7 @@ jobs:
         timeout-minutes: 10
 
         strategy:
+            fail-fast: false
             matrix:
                 app-bridge-version:
                     ["3.0.0", "workspace:^", "4.0.0-alpha.0", "^4.0.0-alpha.0"]

--- a/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
@@ -3,6 +3,7 @@
 import { DownloadButtonProps } from './types';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE, IconArrowCircleDown16, LegacyTooltip as Tooltip, TooltipPosition } from '@frontify/fondue';
+
 import { joinClassNames } from '../../utilities';
 
 export const DownloadButton = ({ onDownload }: DownloadButtonProps) => {

--- a/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
@@ -3,7 +3,6 @@
 import { DownloadButtonProps } from './types';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE, IconArrowCircleDown16, LegacyTooltip as Tooltip, TooltipPosition } from '@frontify/fondue';
-
 import { joinClassNames } from '../../utilities';
 
 export const DownloadButton = ({ onDownload }: DownloadButtonProps) => {


### PR DESCRIPTION
- adds first 4.0.0-alpha and also the last one

All tests are running see: https://github.com/Frontify/brand-sdk/actions/runs/7656116703?pr=717