### PR TITLE
ci: add latest 3 to matrix

### DIFF
--- a/.github/workflows/guideline-blocks-continuous-integration.yml
+++ b/.github/workflows/guideline-blocks-continuous-integration.yml
@@ -20,6 +20,7 @@ jobs:
         timeout-minutes: 10
 
         strategy:
+            fail-fast: false
             matrix:
                 app-bridge-version:
                     ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
@@ -65,6 +66,7 @@ jobs:
         timeout-minutes: 10
 
         strategy:
+            fail-fast: false
             matrix:
                 app-bridge-version:
                     ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
@@ -117,6 +119,7 @@ jobs:
         timeout-minutes: 10
 
         strategy:
+            fail-fast: false
             matrix:
                 app-bridge-version:
                     ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]

--- a/.github/workflows/guideline-blocks-continuous-integration.yml
+++ b/.github/workflows/guideline-blocks-continuous-integration.yml
@@ -20,9 +20,9 @@ jobs:
         timeout-minutes: 10
 
         strategy:
-            fail-fast: false
             matrix:
-                app-bridge-version: ["3.0.0", "workspace:^"]
+                app-bridge-version:
+                    ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
 
         steps:
             - name: Checkout default branch
@@ -65,9 +65,9 @@ jobs:
         timeout-minutes: 10
 
         strategy:
-            fail-fast: false
             matrix:
-                app-bridge-version: ["3.0.0", "workspace:^"]
+                app-bridge-version:
+                    ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
 
         steps:
             - name: Checkout current commit
@@ -117,9 +117,9 @@ jobs:
         timeout-minutes: 10
 
         strategy:
-            fail-fast: false
             matrix:
-                app-bridge-version: ["3.0.0", "workspace:^"]
+                app-bridge-version:
+                    ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
 
         steps:
             - name: Checkout current commit

--- a/.github/workflows/guideline-blocks-continuous-integration.yml
+++ b/.github/workflows/guideline-blocks-continuous-integration.yml
@@ -22,8 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                app-bridge-version:
-                    ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
+                app-bridge-version: ["3.0.0", "^3.0.0", "workspace:^"]
 
         steps:
             - name: Checkout default branch
@@ -68,8 +67,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                app-bridge-version:
-                    ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
+                app-bridge-version: ["3.0.0", "^3.0.0", "workspace:^"]
 
         steps:
             - name: Checkout current commit
@@ -121,8 +119,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                app-bridge-version:
-                    ["3.0.0", "^3.0.0", "4.0.0-alpha.0", "workspace:^"]
+                app-bridge-version: ["3.0.0", "^3.0.0", "workspace:^"]
 
         steps:
             - name: Checkout current commit

--- a/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
@@ -3,6 +3,7 @@
 import { DownloadButtonProps } from './types';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE, IconArrowCircleDown16, LegacyTooltip as Tooltip, TooltipPosition } from '@frontify/fondue';
+
 import { joinClassNames } from '../../utilities';
 
 export const DownloadButton = ({ onDownload }: DownloadButtonProps) => {

--- a/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/DownloadButton/DownloadButton.tsx
@@ -3,7 +3,6 @@
 import { DownloadButtonProps } from './types';
 import { useFocusRing } from '@react-aria/focus';
 import { FOCUS_STYLE, IconArrowCircleDown16, LegacyTooltip as Tooltip, TooltipPosition } from '@frontify/fondue';
-
 import { joinClassNames } from '../../utilities';
 
 export const DownloadButton = ({ onDownload }: DownloadButtonProps) => {


### PR DESCRIPTION
- adds latest 3 to test matrix


first alpha 4 needs to be added after we have released `app-bridge: 4.0.0-alpha.1`

See them run: https://github.com/Frontify/brand-sdk/actions/runs/7656508195?pr=718