### PR TITLE
fix: properly handle paths on windows

### DIFF
--- a/.changeset/five-apples-impress.md
+++ b/.changeset/five-apples-impress.md
@@ -2,4 +2,4 @@
 "@frontify/frontify-cli": patch
 ---
 
-Fix: Path handling on windows
+fix: Path handling on windows

--- a/.changeset/five-apples-impress.md
+++ b/.changeset/five-apples-impress.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+Fix: Path handling on windows


### PR DESCRIPTION
On windows, paths contain `\\` and are interpreted as [escape characters](https://github.com/mrmlnc/fast-glob#advanced-syntax) by `fastGlob`, which causes it to ignore all files. This fix replaces the `join` function with `fastGlob`s `convertPathToPattern` [method](https://github.com/mrmlnc/fast-glob#convertpathtopatternpath) where applicable.