### PR TITLE
feat: add deploy token

### DIFF
--- a/.changeset/thin-bears-press.md
+++ b/.changeset/thin-bears-press.md
@@ -3,3 +3,5 @@
 ---
 
 feat: add the option to deploy with token
+- `-i, --instance <instanceUrl>`: url of the Frontify instance
+- `-t, --token <accessToken>`: the access token to authenticate with the Frontify instance

--- a/.changeset/thin-bears-press.md
+++ b/.changeset/thin-bears-press.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": minor
+---
+
+feat: add the option to deploy with token

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -116,8 +116,6 @@ export const createDeployment = async (
 
                 const httpClient = new HttpClient(instanceUrl);
 
-                const accessToken = token ? token : Configuration.get('tokens.access_token');
-
                 try {
                     await httpClient.put(`/api/marketplace/app/${appId}`, request, {
                         headers: { Authorization: `Bearer ${accessToken}` },

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -52,15 +52,13 @@ const SOURCE_FILE_BLOCK_LIST = ['.git', 'node_modules', 'dist', '.vscode', '.ide
 export const createDeployment = async (
     entryFile: string,
     distPath: string,
-    { dryRun = false, noVerify = false, openInBrowser = false, token = '', instance = '' }: Options,
+    { dryRun = false, noVerify = false, openInBrowser = false, token, instance }: Options,
     compile: ({ projectPath, entryFile, outputName }: CompilerOptions) => Promise<unknown>,
 ): Promise<void> => {
     try {
         let user: UserInfo | undefined;
-        const instanceUrl = Configuration.get('instanceUrl')
-            ? (Configuration.get('instanceUrl') as string)
-            : (instance as string | undefined);
-        const accessToken = token ? token : Configuration.get('tokens.access_token');
+        const instanceUrl = instance || Configuration.get('instanceUrl');
+        const accessToken = token || Configuration.get('tokens.access_token');
 
         if (!accessToken || !instanceUrl) {
             Logger.error(

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -63,7 +63,11 @@ export const createDeployment = async (
         const accessToken = token ? token : Configuration.get('tokens.access_token');
 
         if (!accessToken || !instanceUrl) {
-            Logger.error(`You are not logged in, you can use the command ${pc.bold('frontify-cli login')}.`);
+            Logger.error(
+                `You are currently not logged in. You can use the command ${pc.bold(
+                    'frontify-cli login',
+                )} to log in, or pass --token=<token> --instance=<instance> to the deploy command.`,
+            );
             process.exit(-1);
         }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,8 +19,8 @@ import pkg from '../package.json';
 
 const cli = cac(pkg.name.split('/')[1]);
 
-cli.command('login [instanceUrl]', 'log in to a Frontify instance')
-    .option('-i, --instance [instanceUrl]', '[string] url of the Frontify instance')
+cli.command('login <instanceUrl>', 'log in to a Frontify instance')
+    .option('-i, --instance <instanceUrl>', '[string] url of the Frontify instance')
     .option('-p, --port <port>', '[number] port for the oauth service', {
         default: process.env.PORT || 5600,
     })
@@ -80,7 +80,7 @@ cli.command('serve', 'serve the app locally')
     .option('--allowExternal, --allow-external', '[boolean] allow external IPs to access the server', {
         default: false,
     })
-    .option('--appType [appType], --app-type', '[string] specify app type. Overrides manifest values')
+    .option('--appType <appType>, --app-type', '[string] specify app type. Overrides manifest values')
     .action(async (options) => {
         const manifest = reactiveJson<AppManifest>(join(process.cwd(), 'manifest.json'));
         const appType = options.appType || manifest.appType;
@@ -122,9 +122,9 @@ cli.command('deploy', 'deploy the app to the marketplace')
     .option('--dryRun, --dry-run', '[boolean] enable the dry run mode', { default: false })
     .option('--noVerify, --no-verify', '[boolean] disable the linting and typechecking', { default: false })
     .option('--open', '[boolean] open the marketplace app page', { default: false })
-    .option('--appType [appType], --app-type', '[string] specify app type. Overrides manifest values')
-    .option('-i, --instance [instanceUrl]', '[string] url of the Frontify instance')
-    .option('-t, --token [accessToken]', '[string] the access token')
+    .option('--appType <appType>, --app-type', '[string] specify app type. Overrides manifest values')
+    .option('-i, --instance <instanceUrl>', '[string] url of the Frontify instance')
+    .option('-t, --token <accessToken>', '[string] the access token')
     .action(async (options) => {
         const manifest = reactiveJson<AppManifest>(join(process.cwd(), 'manifest.json'));
         const appType = options.appType || manifest.appType;
@@ -158,7 +158,7 @@ cli.command('deploy', 'deploy the app to the marketplace')
         }
     });
 
-cli.command('create [appName]', 'create a new marketplace app')
+cli.command('create <appName>', 'create a new marketplace app')
     .option('-e, --experimental', 'set experimental flag')
     .action(async (appName: string, options) => {
         if (options.experimental) {
@@ -241,7 +241,7 @@ cli.command('create [appName]', 'create a new marketplace app')
  */
 for (const appType of ['block', 'theme']) {
     cli.command(
-        `${appType} create [appName]`,
+        `${appType} create <appName>`,
         `[deprecated: use 'create' instead] create a ${appType} app locally`,
     ).action((appName: string) => createNewApp(appName, 'css-modules', 'content-block'));
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -123,6 +123,8 @@ cli.command('deploy', 'deploy the app to the marketplace')
     .option('--noVerify, --no-verify', '[boolean] disable the linting and typechecking', { default: false })
     .option('--open', '[boolean] open the marketplace app page', { default: false })
     .option('--appType [appType], --app-type', '[string] specify app type. Overrides manifest values')
+    .option('-i, --instance [instanceUrl]', '[string] url of the Frontify instance')
+    .option('-t, --token [accessToken]', '[string] the access token')
     .action(async (options) => {
         const manifest = reactiveJson<AppManifest>(join(process.cwd(), 'manifest.json'));
         const appType = options.appType || manifest.appType;
@@ -135,6 +137,8 @@ cli.command('deploy', 'deploy the app to the marketplace')
                     dryRun: options.dryRun,
                     noVerify: options.noVerify,
                     openInBrowser: options.open,
+                    instance: options.instance,
+                    token: options.token,
                 },
                 compilePlatformApp,
             );
@@ -146,6 +150,8 @@ cli.command('deploy', 'deploy the app to the marketplace')
                     dryRun: options.dryRun,
                     noVerify: options.noVerify,
                     openInBrowser: options.open,
+                    instance: options.instance,
+                    token: options.token,
                 },
                 compileBlock,
             );

--- a/packages/cli/src/utils/user.ts
+++ b/packages/cli/src/utils/user.ts
@@ -23,7 +23,9 @@ export const getUser = async (instanceUrl: string, token?: string): Promise<User
         );
         return user.data.currentUser;
     } catch {
-        Logger.error(`You are not logged in, you can use the command ${pc.bold('frontify-cli login')}.`);
+        Logger.error(
+            `You are currently not logged in. You can use the command ${pc.bold('frontify-cli login')} to log in.`,
+        );
         return undefined;
     }
 };

--- a/packages/cli/src/utils/user.ts
+++ b/packages/cli/src/utils/user.ts
@@ -12,8 +12,7 @@ export interface UserInfo {
 
 export const getUser = async (instanceUrl: string, token?: string): Promise<UserInfo | undefined> => {
     const httpClient = new HttpClient(instanceUrl);
-
-    const accessToken = token ? token : Configuration.get('tokens.access_token');
+    const accessToken = token || Configuration.get('tokens.access_token');
 
     try {
         const user = await httpClient.post<{ data: { currentUser: UserInfo } }>(

--- a/packages/cli/src/utils/user.ts
+++ b/packages/cli/src/utils/user.ts
@@ -10,7 +10,7 @@ export interface UserInfo {
     email: string;
 }
 
-export const getUser = async (instanceUrl: string, token: string): Promise<UserInfo | undefined> => {
+export const getUser = async (instanceUrl: string, token?: string): Promise<UserInfo | undefined> => {
     const httpClient = new HttpClient(instanceUrl);
 
     const accessToken = token ? token : Configuration.get('tokens.access_token');

--- a/packages/cli/src/utils/user.ts
+++ b/packages/cli/src/utils/user.ts
@@ -10,10 +10,10 @@ export interface UserInfo {
     email: string;
 }
 
-export const getUser = async (instanceUrl: string): Promise<UserInfo | undefined> => {
+export const getUser = async (instanceUrl: string, token: string): Promise<UserInfo | undefined> => {
     const httpClient = new HttpClient(instanceUrl);
 
-    const accessToken = Configuration.get('tokens.access_token');
+    const accessToken = token ? token : Configuration.get('tokens.access_token');
 
     try {
         const user = await httpClient.post<{ data: { currentUser: UserInfo } }>(

--- a/packages/cli/tests/utils/user.spec.ts
+++ b/packages/cli/tests/utils/user.spec.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { beforeAll, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 import nock from 'nock';
 
 import { Configuration } from '../../src/utils/configuration.js';
@@ -24,7 +24,7 @@ const GET_USER_API_RESPONSE = {
 const TEST_BASE_URL = 'testing.frontify.test';
 
 describe('User utils', () => {
-    beforeAll(() => {
+    beforeEach(() => {
         const testMockApi = nock(`https://${TEST_BASE_URL}`);
         testMockApi.post('/graphql', { query: '{ currentUser { email name } }' }).reply(200, GET_USER_API_RESPONSE);
     });
@@ -36,6 +36,10 @@ describe('User utils', () => {
             Configuration.set('tokens', DUMMY_TOKENS.tokens);
             expect(await getUser(TEST_BASE_URL)).toEqual(DUMMY_TOKENS);
             Configuration.set('tokens', oldTokens);
+        });
+
+        test('should get user object with token', async () => {
+            expect(await getUser(TEST_BASE_URL, 'some_access_token')).toEqual(DUMMY_TOKENS);
         });
     });
 });


### PR DESCRIPTION
This change makes it possible to deploy without the need to run `login` first. You can pass `--instance` and `--token` to the `deploy` command, and it will use those values instead of relying on the stored config.