### PR TITLE
fix: add missing `types` entry in exports list

### DIFF
--- a/.changeset/dull-games-cross.md
+++ b/.changeset/dull-games-cross.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+Add missing path for types in the export list

--- a/.changeset/dull-games-cross.md
+++ b/.changeset/dull-games-cross.md
@@ -2,4 +2,4 @@
 "@frontify/guideline-blocks-settings": patch
 ---
 
-Add missing path for types in the export list
+fix: Add missing path for types in the export list

--- a/packages/guideline-blocks-settings/package.json
+++ b/packages/guideline-blocks-settings/package.json
@@ -16,6 +16,7 @@
     },
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/index.es.js",
             "require": "./dist/index.umd.js"
         },


### PR DESCRIPTION
Else it doesn't works with a tsconfig containing 
```
"module": "ESNext",
"moduleResolution": "bundler",
```