### PR TITLE
feat: use new page duplication endpoint

### DIFF
--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -41,8 +41,8 @@ import type {
     DocumentLinkCreate,
     DocumentLinkUpdate,
     DocumentPage,
+    DocumentPageApi,
     DocumentPageCreate,
-    DocumentPageDuplicate,
     DocumentPageTargets,
     DocumentPageUpdate,
     DocumentSection,
@@ -256,7 +256,7 @@ export interface AppBridgeTheme<
         documentCategoryId?: number,
     ): Promise<DocumentPage>;
 
-    duplicateDocumentPage(documentPageId: number): Promise<DocumentPageDuplicate>;
+    duplicateDocumentPage(documentPageId: number): Promise<DocumentPageApi>;
 
     createCoverPage(coverPage: CoverPageCreate): Promise<CoverPage>;
 

--- a/packages/app-bridge/src/react/useGuidelineActions.spec.ts
+++ b/packages/app-bridge/src/react/useGuidelineActions.spec.ts
@@ -11,7 +11,6 @@ import {
     DocumentDummy,
     DocumentGroupDummy,
     DocumentPageDummy,
-    DocumentPageDuplicateDummy,
     getAppBridgeThemeStub,
 } from '../tests';
 
@@ -734,14 +733,13 @@ describe('useGuidelineActions hook', () => {
             useGuidelineActionsStub.duplicateDocumentPage(page);
         });
 
-        const documentPageDuplicateDummy = DocumentPageDuplicateDummy.with(2341);
+        const documentPageDuplicateDummy = DocumentPageDummy.with(2341);
 
         await waitFor(() => {
             expect(duplicateDocumentPage).toHaveBeenCalledWith(page);
             expect(emitSpy).toHaveBeenCalledWith('AppBridge:GuidelineDocumentPage:Action', {
                 documentPage: {
                     ...documentPageDuplicateDummy,
-                    title: documentPageDuplicateDummy.name,
                     documentId: page.documentId,
                 },
                 action: 'add',

--- a/packages/app-bridge/src/react/useGuidelineActions.spec.ts
+++ b/packages/app-bridge/src/react/useGuidelineActions.spec.ts
@@ -724,23 +724,23 @@ describe('useGuidelineActions hook', () => {
     it('should duplicate a page and emit an event', async () => {
         const duplicateDocumentPage = vi.spyOn(useGuidelineActionsStub, 'duplicateDocumentPage');
 
-        const page = {
+        const originalDocumentPage = {
             id: 2341,
             documentId: 10,
+            categoryId: 1138,
         };
 
         act(() => {
-            useGuidelineActionsStub.duplicateDocumentPage(page);
+            useGuidelineActionsStub.duplicateDocumentPage(originalDocumentPage);
         });
 
-        const documentPageDuplicateDummy = DocumentPageDummy.with(2341);
-
         await waitFor(() => {
-            expect(duplicateDocumentPage).toHaveBeenCalledWith(page);
+            expect(duplicateDocumentPage).toHaveBeenCalledWith(originalDocumentPage);
             expect(emitSpy).toHaveBeenCalledWith('AppBridge:GuidelineDocumentPage:Action', {
                 documentPage: {
-                    ...documentPageDuplicateDummy,
-                    documentId: page.documentId,
+                    ...DocumentPageDummy.with(originalDocumentPage.id),
+                    documentId: originalDocumentPage.documentId,
+                    categoryId: originalDocumentPage.categoryId,
                 },
                 action: 'add',
             });

--- a/packages/app-bridge/src/react/useGuidelineActions.ts
+++ b/packages/app-bridge/src/react/useGuidelineActions.ts
@@ -325,21 +325,21 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
 
     const duplicateDocumentPage = useCallback(
         async ({ id, documentId, categoryId }: { id: number; documentId: number; categoryId?: number }) => {
-            const result = await appBridge.duplicateDocumentPage(id);
+            const duplicatedDocumentPage = await appBridge.duplicateDocumentPage(id);
 
             window.emitter.emit('AppBridge:GuidelineDocumentPage:Action', {
-                documentPage: { ...result, documentId, categoryId } as unknown as DocumentPage,
+                documentPage: { ...duplicatedDocumentPage, documentId, categoryId } as unknown as DocumentPage,
                 action: 'add',
             });
 
             if (categoryId) {
                 window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
-                    documentPage: { id: result.id, categoryId },
+                    documentPage: { id: duplicatedDocumentPage.id, categoryId },
                     action: 'add',
                 });
             }
 
-            return result;
+            return duplicatedDocumentPage;
         },
         [appBridge],
     );

--- a/packages/app-bridge/src/react/useGuidelineActions.ts
+++ b/packages/app-bridge/src/react/useGuidelineActions.ts
@@ -328,7 +328,7 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
             const result = await appBridge.duplicateDocumentPage(id);
 
             window.emitter.emit('AppBridge:GuidelineDocumentPage:Action', {
-                documentPage: { ...result, title: result.name, documentId, categoryId } as unknown as DocumentPage,
+                documentPage: { ...result, documentId, categoryId } as unknown as DocumentPage,
                 action: 'add',
             });
 

--- a/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
@@ -17,7 +17,6 @@ import {
     DocumentDummy,
     DocumentGroupDummy,
     DocumentPageDummy,
-    DocumentPageDuplicateDummy,
     DocumentPageTargetsDummy,
     DocumentSectionDummy,
     DocumentTargetsDummy,
@@ -214,7 +213,7 @@ export const getAppBridgeThemeStub = ({
             ColorDummy.yellow(9314),
         ]),
         duplicateDocumentPage: stub<Parameters<AppBridgeTheme['duplicateDocumentPage']>>().resolves(
-            DocumentPageDuplicateDummy.with(DOCUMENT_PAGE_DUPLICATE_ID_1),
+            DocumentPageDummy.with(DOCUMENT_PAGE_DUPLICATE_ID_1),
         ),
         getDocumentTargets: stub<Parameters<AppBridgeTheme['getDocumentTargets']>>().resolves(
             DocumentTargetsDummy.with(DOCUMENT_ID_1),

--- a/packages/app-bridge/src/tests/DocumentPageDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentPageDummy.ts
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import type { DocumentPage, DocumentPageDuplicate, DocumentPageDuplicateApi } from '../types';
+import type { DocumentPage } from '../types';
 import { convertObjectCase } from '../utilities';
 
-import { DocumentPageApiDummy, DocumentPageDuplicateApiDummy } from './DocumentPageApiDummy';
+import { DocumentPageApiDummy } from './DocumentPageApiDummy';
 
 export class DocumentPageDummy {
     static with(id: number): DocumentPage {
@@ -15,11 +15,5 @@ export class DocumentPageDummy {
             ...DocumentPageDummy.with(fields.id),
             ...fields,
         } as DocumentPage;
-    }
-}
-
-export class DocumentPageDuplicateDummy {
-    static with(id: number): DocumentPageDuplicate {
-        return convertObjectCase((DocumentPageDuplicateApiDummy.with(id) as DocumentPageDuplicateApi).page, 'camel');
     }
 }

--- a/packages/app-bridge/src/types/DocumentPage.ts
+++ b/packages/app-bridge/src/types/DocumentPage.ts
@@ -2,7 +2,6 @@
 
 import type { CamelCasedPropertiesDeep, RequireAtLeastOne, SetRequired } from 'type-fest';
 
-import { LinkType } from './Document';
 import { SingleTargetApi } from './Targets';
 
 export enum DocumentPageVisibility {
@@ -70,16 +69,3 @@ export type DocumentPageUpdate = RequireAtLeastOne<
 >;
 
 export type DocumentPageDelete = Pick<DocumentPageRequest, 'id' | 'documentId' | 'categoryId'>;
-
-export type DocumentPageDuplicateApi = {
-    page: {
-        id: number;
-        link_type: LinkType;
-        name: string;
-        sections: unknown[];
-        url: string;
-        visibility: DocumentPageVisibility;
-    };
-};
-
-export type DocumentPageDuplicate = CamelCasedPropertiesDeep<DocumentPageDuplicateApi['page']>;


### PR DESCRIPTION
This PR uses the new page duplication endpoint and drops the usage of the legacy endpoint.

Follow-up of: https://github.com/Frontify/app-server/pull/18390
Pre-requisite of: https://github.com/Frontify/web-app/pull/2916