### PR TITLE
fix: export menu component and type

### DIFF
--- a/.changeset/khaki-wasps-learn.md
+++ b/.changeset/khaki-wasps-learn.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(Toolbar): export `ToolbarFlyoutMenu` component and `ToolbarFlyoutMenuItem` type

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/MenuToolbarButton/index.ts
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/MenuToolbarButton/index.ts
@@ -1,3 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export * from './MenuToolbarButton';
+export * from './ToolbarFlyoutMenu';


### PR DESCRIPTION
Export missing type to make it cleaner to create menu item arrays outside of the package