### PR TITLE
fix: add retry to subscription

### DIFF
--- a/.changeset/strong-tools-check.md
+++ b/.changeset/strong-tools-check.md
@@ -3,4 +3,4 @@
 "@frontify/guideline-blocks-settings": patch
 ---
 
-Fix/add retry to subscription
+Fix: add retry to subscription

--- a/.changeset/strong-tools-check.md
+++ b/.changeset/strong-tools-check.md
@@ -1,0 +1,6 @@
+---
+"@frontify/app-bridge": patch
+"@frontify/guideline-blocks-settings": patch
+---
+
+Fix/add retry to subscription


### PR DESCRIPTION
- i noticed that sometimes the app couldnt connect to the web-app, as there is a interfering notify object.

{msgId: '17pvzfy', source: 'poa7ru', destination: '1033kkb', name: 'should-intercept-webauthn', type: 'op-window-direct-response', …}

Why that happens i could not figure out and also not what this event is. Now when there is an intercepting event the subscribe will do a retry of X times. 