### PR TITLE
chore: changeset remove guideline-blocks-settings

### DIFF
--- a/.changeset/strong-tools-check.md
+++ b/.changeset/strong-tools-check.md
@@ -1,6 +1,5 @@
 ---
 "@frontify/app-bridge": patch
-"@frontify/guideline-blocks-settings": patch
 ---
 
 Fix: add retry to subscription


### PR DESCRIPTION
fixes the changeset so guideline-blocks-settings are not getting released.. 