### PR TITLE
fix: flaky useUngroupedDocuments and useGroupedDocuments tests

### DIFF
--- a/.changeset/pretty-items-marry.md
+++ b/.changeset/pretty-items-marry.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": patch
+---
+
+fix: useGroupedDocuments and useUngroupedDocuments flaky tests

--- a/packages/app-bridge/src/react/useGroupedDocuments.spec.ts
+++ b/packages/app-bridge/src/react/useGroupedDocuments.spec.ts
@@ -29,18 +29,18 @@ describe('useGroupedDocument', () => {
         const { result } = renderHook(() => useGroupedDocuments(appBridge, DOCUMENT_GROUP_ID_1));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-
-            expect(result.current.documents).toEqual([
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_4, DOCUMENT_GROUP_ID_1),
-            ]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_4, DOCUMENT_GROUP_ID_1),
+        ]);
     });
 
     it('should not fetch grouped documents on mount if not enabled', () => {
@@ -71,18 +71,18 @@ describe('useGroupedDocument', () => {
         rerender();
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-
-            expect(result.current.documents).toEqual([
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_4, DOCUMENT_GROUP_ID_1),
-            ]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_4, DOCUMENT_GROUP_ID_1),
+        ]);
     });
 
     it('should update document if a page is added', async () => {
@@ -101,17 +101,17 @@ describe('useGroupedDocument', () => {
         const { result } = renderHook(() => useGroupedDocuments(appBridge, DOCUMENT_GROUP_ID_1, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
-
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-            expect(result.current.documents).toEqual([
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
-                OLD_DOCUMENT,
-            ]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
+            OLD_DOCUMENT,
+        ]);
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -168,9 +168,11 @@ describe('useGroupedDocument', () => {
         const { result } = renderHook(() => useGroupedDocuments(appBridge, DOCUMENT_GROUP_ID_1, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+            expect(spy).toHaveBeenCalledOnce();
+        });
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -217,17 +219,18 @@ describe('useGroupedDocument', () => {
         const { result } = renderHook(() => useGroupedDocuments(appBridge, DOCUMENT_GROUP_ID_1, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-            expect(result.current.documents).toEqual([
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
-                DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
-                OLD_DOCUMENT,
-            ]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_1, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_2, DOCUMENT_GROUP_ID_1),
+            DocumentDummy.withDocumentGroupId(GROUPED_DOCUMENT_ID_3, DOCUMENT_GROUP_ID_1),
+            OLD_DOCUMENT,
+        ]);
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -284,9 +287,11 @@ describe('useGroupedDocument', () => {
         const { result } = renderHook(() => useGroupedDocuments(appBridge, DOCUMENT_GROUP_ID_1, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+            expect(spy).toHaveBeenCalledOnce();
+        });
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -347,12 +352,13 @@ describe('useGroupedDocument', () => {
         const { result } = renderHook(() => useGroupedDocuments(appBridge, DOCUMENT_GROUP_ID_1, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-            expect(result.current.documents).toEqual([DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4]);
 
         // Trigger a "document category added" event in the specified document
         window.emitter.emit('AppBridge:GuidelineDocument:MoveEvent', {

--- a/packages/app-bridge/src/react/useUngroupedDocuments.spec.ts
+++ b/packages/app-bridge/src/react/useUngroupedDocuments.spec.ts
@@ -73,18 +73,19 @@ describe('useUngroupedDocuments', () => {
         rerender();
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-            expect(result.current.documents).toEqual([
-                DocumentDummy.with(DOCUMENT_ID_1),
-                DocumentDummy.with(DOCUMENT_ID_2),
-                DocumentDummy.with(DOCUMENT_ID_3),
-                DocumentDummy.with(DOCUMENT_ID_4),
-                DocumentDummy.with(DOCUMENT_ID_5),
-            ]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([
+            DocumentDummy.with(DOCUMENT_ID_1),
+            DocumentDummy.with(DOCUMENT_ID_2),
+            DocumentDummy.with(DOCUMENT_ID_3),
+            DocumentDummy.with(DOCUMENT_ID_4),
+            DocumentDummy.with(DOCUMENT_ID_5),
+        ]);
     });
 
     it('should update document if a page is added', async () => {
@@ -113,17 +114,17 @@ describe('useUngroupedDocuments', () => {
         const { result } = renderHook(() => useUngroupedDocuments(appBridge, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
-
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-            expect(result.current.documents).toEqual([
-                DocumentDummy.with(DOCUMENT_ID_1),
-                DocumentDummy.with(DOCUMENT_ID_2),
-                DocumentDummy.with(DOCUMENT_ID_3),
-                OLD_DOCUMENT,
-            ]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([
+            DocumentDummy.with(DOCUMENT_ID_1),
+            DocumentDummy.with(DOCUMENT_ID_2),
+            DocumentDummy.with(DOCUMENT_ID_3),
+            OLD_DOCUMENT,
+        ]);
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -180,9 +181,11 @@ describe('useUngroupedDocuments', () => {
         const { result } = renderHook(() => useUngroupedDocuments(appBridge, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+            expect(spy).toHaveBeenCalledOnce();
+        });
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -239,17 +242,18 @@ describe('useUngroupedDocuments', () => {
         const { result } = renderHook(() => useUngroupedDocuments(appBridge, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
         await waitFor(() => {
             expect(result.current.isLoading).toBe(false);
-            expect(result.current.documents).toEqual([
-                DocumentDummy.with(DOCUMENT_ID_1),
-                DocumentDummy.with(DOCUMENT_ID_2),
-                DocumentDummy.with(DOCUMENT_ID_3),
-                OLD_DOCUMENT,
-            ]);
+            expect(spy).toHaveBeenCalledOnce();
         });
+
+        expect(result.current.documents).toEqual([
+            DocumentDummy.with(DOCUMENT_ID_1),
+            DocumentDummy.with(DOCUMENT_ID_2),
+            DocumentDummy.with(DOCUMENT_ID_3),
+            OLD_DOCUMENT,
+        ]);
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -306,9 +310,11 @@ describe('useUngroupedDocuments', () => {
         const { result } = renderHook(() => useUngroupedDocuments(appBridge, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+            expect(spy).toHaveBeenCalledOnce();
+        });
 
         // Mock the response of the second call
         spy.mockImplementationOnce(() =>
@@ -378,9 +384,11 @@ describe('useUngroupedDocuments', () => {
         const { result } = renderHook(() => useUngroupedDocuments(appBridge, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+            expect(spy).toHaveBeenCalledOnce();
+        });
 
         // Trigger a "document category added" event in the specified document
         window.emitter.emit('AppBridge:GuidelineDocument:MoveEvent', {
@@ -436,9 +444,11 @@ describe('useUngroupedDocuments', () => {
         const { result } = renderHook(() => useUngroupedDocuments(appBridge, { enabled: true }));
 
         expect(result.current.isLoading).toBe(true);
-        expect(spy).toHaveBeenCalledOnce();
 
-        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+            expect(spy).toHaveBeenCalledOnce();
+        });
 
         // Trigger a "document category added" event in the specified document
         window.emitter.emit('AppBridge:GuidelineDocumentGroup:MoveEvent', {


### PR DESCRIPTION
try to fix these flaky tests: `useGroupedDocuments` and `useUngroupedDocuments`





CU-8693wzzx6


