### PR TITLE
feat: added useDocumentPage hook

### DIFF
--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -338,6 +338,8 @@ export interface AppBridgeTheme<
 
     getDocumentGroups(): Promise<DocumentGroup[]>;
 
+    getDocumentPageById(documentPageId: number): Promise<DocumentPage>;
+
     getDocumentPagesByDocumentId(documentId: number): Promise<DocumentPage[]>;
 
     getDocumentPagesByDocumentCategoryId(documentCategoryId: number): Promise<DocumentPage[]>;

--- a/packages/app-bridge/src/react/useDocumentPage.ts
+++ b/packages/app-bridge/src/react/useDocumentPage.ts
@@ -1,0 +1,29 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { useEffect, useState } from 'react';
+
+import type { AppBridgeTheme } from '../AppBridgeTheme';
+import { DocumentPageUpdate } from 'src';
+
+export const useDocumentPage = <DocumentPage>(appBridge: AppBridgeTheme, documentPageId: number) => {
+    const [documentPage, setDocumentPage] = useState<DocumentPage | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const updateDocumentPage = async (documentPageUpdate: DocumentPageUpdate) => {
+        setDocumentPage((await appBridge.updateDocumentPage(documentPageUpdate)) as DocumentPage);
+    };
+
+    useEffect(() => {
+        (async () => {
+            setIsLoading(true);
+            setDocumentPage((await appBridge.getDocumentPageById(documentPageId)) as DocumentPage);
+            setIsLoading(false);
+        })();
+    }, [appBridge, documentPageId]);
+
+    return {
+        documentPage,
+        updateDocumentPage,
+        isLoading,
+    };
+};

--- a/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeThemeStub.ts
@@ -143,6 +143,9 @@ export const getAppBridgeThemeStub = ({
             DocumentGroupDummy.with(DOCUMENT_GROUP_ID_2, 0),
             DocumentGroupDummy.with(DOCUMENT_GROUP_ID_3, 2),
         ]),
+        getDocumentPageById: stub<Parameters<AppBridgeTheme['getDocumentPageById']>>().resolves(
+            DocumentPageDummy.with(1),
+        ),
         getDocumentPagesByDocumentId: stub<Parameters<AppBridgeTheme['getDocumentPagesByDocumentId']>>().resolves([
             DocumentPageDummy.with(DOCUMENT_PAGE_ID_1),
             DocumentPageDummy.with(DOCUMENT_PAGE_ID_2),

--- a/packages/app-bridge/src/types/DocumentPage.ts
+++ b/packages/app-bridge/src/types/DocumentPage.ts
@@ -59,13 +59,15 @@ type DocumentPageRequest = {
     linkUrl?: Nullable<string>;
     categoryId?: Nullable<number>;
     visibility?: DocumentPageVisibility;
+    heading?: string;
+    subheading?: string;
 };
 
 export type DocumentPageCreate = Omit<SetRequired<DocumentPageRequest, 'title' | 'documentId'>, 'id'>;
 
 export type DocumentPageUpdate = RequireAtLeastOne<
     DocumentPageRequest,
-    'documentId' | 'categoryId' | 'linkUrl' | 'title' | 'visibility'
+    'documentId' | 'categoryId' | 'linkUrl' | 'title' | 'visibility' | 'heading' | 'subheading'
 >;
 
 export type DocumentPageDelete = Pick<DocumentPageRequest, 'id' | 'documentId' | 'categoryId'>;


### PR DESCRIPTION
This PR adds the hook `useDocumentPage` in order to interact with the DocumentPage heading and subheading.