### PR TITLE
feat: assetInput allowDelete prop

### DIFF
--- a/.changeset/fair-seahorses-look.md
+++ b/.changeset/fair-seahorses-look.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": patch
+---
+
+feat: add assetInput 'allowDelete' optional prop

--- a/packages/sidebar-settings/src/blocks/assetInput.ts
+++ b/packages/sidebar-settings/src/blocks/assetInput.ts
@@ -49,6 +49,11 @@ export type AssetInputBlock<AppBridge> = {
     mode?: AssetInputMode;
 
     /**
+     * Whether the Delete option is present in the options dropdown
+     */
+    allowDelete?: boolean;
+
+    /**
      * The size of the input.
      */
     size?: 'small' | 'large' | AssetInputSize;


### PR DESCRIPTION
Adds prop to assetInput to allow showing the `Delete/Remove` option in the assetInputBlock