### PR TITLE
feat: update useTemplateAssets to return also themeAssets

### DIFF
--- a/packages/app-bridge/src/react/useTemplateAssets.ts
+++ b/packages/app-bridge/src/react/useTemplateAssets.ts
@@ -198,6 +198,7 @@ export const useTemplateAssets = (
 
     return {
         templateAssets: mergedThemeAndTemplateAssets,
+        themeAssets,
         customizedTemplateAssetsKeys,
         addAssetIdsToKey,
         deleteAssetIdsFromKey,


### PR DESCRIPTION
`useTemplateAssets` needs to return also themeAssets so the consumer can know if the assets used are from theme or by template.

There is no way to know between these 2 cases with the current data returned, this PR helps to solve that:
- template has no asset set but there is a theme asset
- template has an asset set but there is no theme asset overriden
