### PR TITLE
ci: pin pnpm to 8

### DIFF
--- a/.github/workflows/app-bridge-continuous-integration.yml
+++ b/.github/workflows/app-bridge-continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -65,7 +65,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/cli-continuous-integration.yml
+++ b/.github/workflows/cli-continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -52,7 +52,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -87,7 +87,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -122,7 +122,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -162,7 +162,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
                   run_install: false
 
             - name: Get pnpm store directory
@@ -210,7 +210,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/guideline-blocks-continuous-integration.yml
+++ b/.github/workflows/guideline-blocks-continuous-integration.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4
@@ -79,7 +79,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
                   run_install: false
 
             - name: Get pnpm store directory
@@ -132,7 +132,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
                   run_install: false
 
             - name: Get pnpm store directory

--- a/.github/workflows/typing-continuous-integration.yml
+++ b/.github/workflows/typing-continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Use pnpm
               uses: pnpm/action-setup@v3
               with:
-                  version: latest
+                  version: 8
 
             - name: Use Node.js
               uses: actions/setup-node@v4


### PR DESCRIPTION
As `pnpm` 9 got released the CI breaks now as it was defined as latest, will pin it down till we update it 

To unblock: https://github.com/Frontify/brand-sdk/pull/860