### PR TITLE
feat(Templates): add creation form uri to template type

### DIFF
--- a/.changeset/hip-gorillas-explode.md
+++ b/.changeset/hip-gorillas-explode.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": minor
+---
+
+adds creationFormUri type to template type

--- a/.changeset/hip-gorillas-explode.md
+++ b/.changeset/hip-gorillas-explode.md
@@ -2,4 +2,4 @@
 "@frontify/app-bridge": minor
 ---
 
-adds creationFormUri type to template type
+feat(AppBridgeBlock): adds `creationFormUri` to the type `template`

--- a/packages/app-bridge/src/tests/TemplateDummy.ts
+++ b/packages/app-bridge/src/tests/TemplateDummy.ts
@@ -10,7 +10,7 @@ export class TemplateDummy {
             name: 'A template',
             description: 'A description',
             previewUrl: 'https://preview.url',
-            creationFormUri: `/publishing/template/${String(id)}?referer=test.frontify.com`,
+            creationFormUri: `/publishing/template/${id}?referer=test.frontify.com`,
             projectId: 23,
             pages: [
                 convertObjectCase(

--- a/packages/app-bridge/src/tests/TemplateDummy.ts
+++ b/packages/app-bridge/src/tests/TemplateDummy.ts
@@ -10,6 +10,7 @@ export class TemplateDummy {
             name: 'A template',
             description: 'A description',
             previewUrl: 'https://preview.url',
+            creationFormUri: '/publishing/template/1?referer=test.frontify.com',
             projectId: 23,
             pages: [
                 convertObjectCase(

--- a/packages/app-bridge/src/tests/TemplateDummy.ts
+++ b/packages/app-bridge/src/tests/TemplateDummy.ts
@@ -10,7 +10,7 @@ export class TemplateDummy {
             name: 'A template',
             description: 'A description',
             previewUrl: 'https://preview.url',
-            creationFormUri: '/publishing/template/1?referer=test.frontify.com',
+            creationFormUri: `/publishing/template/${String(id)}?referer=test.frontify.com`,
             projectId: 23,
             pages: [
                 convertObjectCase(

--- a/packages/app-bridge/src/tests/TemplateDummy.ts
+++ b/packages/app-bridge/src/tests/TemplateDummy.ts
@@ -10,7 +10,7 @@ export class TemplateDummy {
             name: 'A template',
             description: 'A description',
             previewUrl: 'https://preview.url',
-            creationFormUri: `/publishing/template/${id}?referer=test.frontify.com`,
+            creationFormUri: `/publishing/template/${id}`,
             projectId: 23,
             pages: [
                 convertObjectCase(

--- a/packages/app-bridge/src/types/Template.ts
+++ b/packages/app-bridge/src/types/Template.ts
@@ -8,6 +8,7 @@ export type Template = {
     description: string;
     projectId: number;
     previewUrl: string;
+    creationFormUri: string;
     pages: TemplatePage[];
 };
 


### PR DESCRIPTION
Adds the `creationFromUri` type to the `Templates` type so that it is manageable via the `web-app` and accessible in the `TemplateBlock`.