### PR TITLE
feat: usePageTemplateSettings to return templateThemeSettings

### DIFF
--- a/.changeset/giant-dodos-work.md
+++ b/.changeset/giant-dodos-work.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": patch
+---
+
+feat(usePageTemplateSettings): returns also templateThemeSettings

--- a/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.spec.ts
@@ -217,6 +217,7 @@ describe('usePageTemplateSettings', () => {
                     ...PAGE_SETTINGS_WITH_OVERRIDES,
                 });
                 expect(result.current.customizedPageTemplateSettingsKeys).toEqual(['customThemeSetting']);
+                expect(result.current.templateThemeSettings).toEqual(THEME_SETTINGS.documentPage);
             });
         });
 

--- a/packages/app-bridge/src/react/usePageTemplateSettings.ts
+++ b/packages/app-bridge/src/react/usePageTemplateSettings.ts
@@ -110,6 +110,7 @@ export const usePageTemplateSettings = <TPageTemplateSettings = Record<string, u
 
     return {
         pageTemplateSettings: mergedThemeAndPageTemplateSettings,
+        templateThemeSettings,
         customizedPageTemplateSettingsKeys,
         updatePageTemplateSettings,
         isLoading,


### PR DESCRIPTION
This is needed so we can know settings not belonging to ThemeSettings but only to pageTemplateSettings