### PR TITLE
chore: add new type

### DIFF
--- a/packages/app-bridge/src/AppBridge.ts
+++ b/packages/app-bridge/src/AppBridge.ts
@@ -167,7 +167,7 @@ export type EventUnsubscribeFunction = () => void;
 export interface AppBridge<
     ApiMethod extends ApiMethodNamePattern,
     Command extends CommandNamePattern,
-    State extends Record<string, Record<string, unknown>>,
+    State extends Record<string, unknown> | Record<string, Record<string, unknown>>,
     Context extends Record<string, unknown>,
     Event extends EventNamePattern,
 > {

--- a/packages/app-bridge/src/AppBridgePlatformApp.ts
+++ b/packages/app-bridge/src/AppBridgePlatformApp.ts
@@ -34,9 +34,7 @@ export type PlatformAppCommandRegistry = CommandNameValidator<{
 
 export type PlatformAppCommand = CommandNameValidator<Pick<PlatformAppCommandRegistry, 'openConnection'>>;
 
-export type PlatformAppState = {
-    settings: Record<string, unknown>;
-};
+export type PlatformAppState = Record<string, unknown>;
 
 type InitializeEvent = {
     apiPort: MessagePort;


### PR DESCRIPTION
@SamuelAlev hey i would like to adjust the state type. What do you think if we change it to <Record<string, unknown>> This has the advantage that when we do 
`appBridge.state().get()`

instead of
`appBridge.state('settings').get()`

wdyt?