### PR TITLE
fix(RTE): on safari the first click is not recognized

### DIFF
--- a/.changeset/sour-pumpkins-suffer.md
+++ b/.changeset/sour-pumpkins-suffer.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(RTE): on safari the first click is not recognized

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/ButtonToolbarButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/ButtonToolbarButton.tsx
@@ -15,7 +15,8 @@ export const ButtonToolbarButton = forwardRef<
         <ToolbarButton
             ref={ref}
             {...rootProps}
-            onMouseDown={() => {
+            onMouseDown={(event) => {
+                event.preventDefault();
                 focusEditor(editor, editor.selection ?? editor.prevSelection ?? undefined);
             }}
             onClick={() => {

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/LinkToolbarButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/LinkToolbarButton.tsx
@@ -18,7 +18,8 @@ export const LinkToolbarButton = forwardRef<HTMLButtonElement, { disabled: boole
         const { props } = useLinkToolbarButton(state);
         return (
             <ToolbarButton
-                onMouseDown={() => {
+                onMouseDown={(event) => {
+                    event.preventDefault();
                     focusEditor(editor, editor.selection ?? editor.prevSelection ?? undefined);
                 }}
                 ref={ref}


### PR DESCRIPTION
This prevents some anomalies that caused Safari to not open link toolbar on first click