### PR TITLE
chore: remove unnecessary properties on DocumentSectionApi

### DIFF
--- a/.changeset/fair-foxes-train.md
+++ b/.changeset/fair-foxes-train.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": patch
+---
+
+Remove (internally) unused properties from DocumentSectionApi

--- a/.changeset/fair-foxes-train.md
+++ b/.changeset/fair-foxes-train.md
@@ -2,4 +2,4 @@
 "@frontify/app-bridge": patch
 ---
 
-Remove (internally) unused properties from DocumentSectionApi
+fix: remove unused properties from `DocumentSectionApi`

--- a/packages/app-bridge/src/tests/DocumentSectionApiDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentSectionApiDummy.ts
@@ -12,8 +12,6 @@ export class DocumentSectionApiDummy {
             modified: '2022-04-04T15:36:43.000+00:00',
             document_id: 1,
             page_id: 6,
-            revision: null,
-            valid_from: '2022-04-04T15:36:36.000+00:00',
             valid_to: null,
             title: `Document Section Dummy ${id}`,
             slug: `document-section-dummy-${id}`,

--- a/packages/app-bridge/src/types/DocumentSection.ts
+++ b/packages/app-bridge/src/types/DocumentSection.ts
@@ -4,7 +4,6 @@ export type DocumentSectionApi = {
     id: number;
     document_id: number;
     page_id: number;
-    revision: unknown;
     slug: string;
     sort: number;
     title: string;
@@ -12,7 +11,6 @@ export type DocumentSectionApi = {
     created: string;
     modifier: Nullable<number>;
     modified: Nullable<string>;
-    valid_from: string;
     valid_to: Nullable<string>;
     permanent_link: string;
 };


### PR DESCRIPTION
These properties are not used externally (The `DocumentSection` type should be used externally)