### PR TITLE
feat(AppBridgeTheme): added GuidelineBrandPortalLink interface

### DIFF
--- a/packages/app-bridge-theme/src/types/Guideline.ts
+++ b/packages/app-bridge-theme/src/types/Guideline.ts
@@ -88,6 +88,12 @@ export interface GuidelineDocumentPageHeading {
     type: 'document-page-heading';
 }
 
+export interface GuidelineBrandPortalLink {
+    isEnabled(): boolean;
+    title(language?: string): string;
+    url(language?: string): string;
+}
+
 export type PortalNavigationItem =
     | GuidelineCoverPage
     | GuidelineDocumentGroup


### PR DESCRIPTION
This PR adds the `GuidelineBrandPortalLink` interface that later can be used by Themes.