### PR TITLE
feat(app-bridge-theme): add a navigate command

### DIFF
--- a/.changeset/dry-mangos-fix.md
+++ b/.changeset/dry-mangos-fix.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge-theme": patch
+---
+
+feat: add a navigate command

--- a/packages/app-bridge-theme/src/AppBridgeTheme.ts
+++ b/packages/app-bridge-theme/src/AppBridgeTheme.ts
@@ -2,7 +2,6 @@
 
 import {
     type AppBridgeThemeEvent,
-    type Command,
     type Context,
     type ContextReturn,
     type DispatchHandlerParameter,
@@ -11,10 +10,11 @@ import {
     type EventUnsubscribeFunction,
     type GuidelineSearchResult,
 } from './types';
+import {CommandRegistry} from "./registries";
 
 export interface AppBridgeTheme {
-    dispatch<CommandName extends keyof Command>(
-        dispatchHandler: DispatchHandlerParameter<CommandName, Command>,
+    dispatch<CommandName extends keyof CommandRegistry>(
+        dispatchHandler: DispatchHandlerParameter<CommandName, CommandRegistry>,
     ): Promise<void>;
 
     context(): ContextReturn<Context, void>;

--- a/packages/app-bridge-theme/src/AppBridgeTheme.ts
+++ b/packages/app-bridge-theme/src/AppBridgeTheme.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type CommandRegistry } from './registries';
 import {
     type AppBridgeThemeEvent,
     type Context,
@@ -10,7 +11,6 @@ import {
     type EventUnsubscribeFunction,
     type GuidelineSearchResult,
 } from './types';
-import {CommandRegistry} from "./registries";
 
 export interface AppBridgeTheme {
     dispatch<CommandName extends keyof CommandRegistry>(

--- a/packages/app-bridge-theme/src/registries/CommandRegistry.ts
+++ b/packages/app-bridge-theme/src/registries/CommandRegistry.ts
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type CommandNameValidator } from '../types';
+import {ObjectNameValidator} from '../types';
+import {Simplify} from "type-fest";
 
 export type CommandRegistry = CommandNameValidator<{
     openSearchDialog: string[];
@@ -8,3 +9,11 @@ export type CommandRegistry = CommandNameValidator<{
     navigate: string;
     navigateToDocumentSection: number | string;
 }>;
+
+type CommandNameValidator<CommandNameObject> = Simplify<
+    ObjectNameValidator<CommandNameObject, CommandNamePattern, 'Command'>
+>;
+
+type CommandNamePattern = { [commandName: `${CommandVerb}${string}`]: unknown };
+
+type CommandVerb = 'open' | 'close' | 'navigate' | 'download';

--- a/packages/app-bridge-theme/src/registries/CommandRegistry.ts
+++ b/packages/app-bridge-theme/src/registries/CommandRegistry.ts
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import {ObjectNameValidator} from '../types';
-import {Simplify} from "type-fest";
+import { type Simplify } from 'type-fest';
+
+import { type ObjectNameValidator } from '../types';
 
 export type CommandRegistry = CommandNameValidator<{
     openSearchDialog: string[];

--- a/packages/app-bridge-theme/src/registries/CommandRegistry.ts
+++ b/packages/app-bridge-theme/src/registries/CommandRegistry.ts
@@ -2,12 +2,9 @@
 
 import { type CommandNameValidator } from '../types';
 
-type OpenSearchDialog = void;
-type CloseSearchDialog = void;
-type NavigateToDocumentSection = number | string;
-
 export type CommandRegistry = CommandNameValidator<{
-    openSearchDialog: OpenSearchDialog;
-    closeSearchDialog: CloseSearchDialog;
-    navigateToDocumentSection: NavigateToDocumentSection;
+    openSearchDialog: string[];
+    closeSearchDialog: void;
+    navigate: string;
+    navigateToDocumentSection: number | string;
 }>;

--- a/packages/app-bridge-theme/src/types/Command.ts
+++ b/packages/app-bridge-theme/src/types/Command.ts
@@ -1,18 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type Simplify } from 'type-fest';
-
 import { type CommandRegistry } from '../registries';
 
-import { type ObjectNameValidator, type WrongNamePattern } from './Common';
-
-type CommandVerb = 'open' | 'close' | 'navigate' | 'download';
-
-type CommandNamePattern = { [commandName: `${CommandVerb}${string}`]: unknown };
-
-export type CommandNameValidator<CommandNameObject> = Simplify<
-    ObjectNameValidator<CommandNameObject, CommandNamePattern, 'Command'>
->;
+import { type WrongNamePattern } from './Common';
 
 type DispatchHandler<
     CommandName extends keyof CommandRegistry,

--- a/packages/app-bridge-theme/src/types/Command.ts
+++ b/packages/app-bridge-theme/src/types/Command.ts
@@ -14,18 +14,14 @@ export type CommandNameValidator<CommandNameObject> = Simplify<
     ObjectNameValidator<CommandNameObject, CommandNamePattern, 'Command'>
 >;
 
-export type Command = CommandNameValidator<
-    Pick<CommandRegistry, 'openSearchDialog' | 'closeSearchDialog' | 'navigateToDocumentSection'>
->;
-
 type DispatchHandler<
-    CommandName extends keyof CommandNamePattern,
-    Command extends CommandNamePattern,
-> = Command[CommandName] extends void ? { name: CommandName } : { name: CommandName; payload: Command[CommandName] };
+    CommandName extends keyof CommandRegistry,
+    TCommand extends CommandRegistry,
+> = TCommand[CommandName] extends void ? { name: CommandName } : { name: CommandName; payload: TCommand[CommandName] };
 
 export type DispatchHandlerParameter<
     CommandName,
-    Command extends CommandNamePattern,
-> = CommandName extends keyof CommandNamePattern
-    ? DispatchHandler<CommandName, Command>
+    TCommand extends CommandRegistry,
+> = CommandName extends keyof CommandRegistry
+    ? DispatchHandler<CommandName, TCommand>
     : WrongNamePattern<CommandName, 'Command'>;


### PR DESCRIPTION
 - Added a `command` property in CommandRegistry.
 - Removed obsolete `Command` type. It was used to strip away non-AppBridgeTheme commands, but that is no longer necessary with a separate package. Will also enable us to bring more clarity into the implementation, where we often mix `Command` and `CommandRegistry`, despite being identical
 - Removed aliases for payload types. Without aliases the actually required type is more transparent, instead of being hidden by an alias
 - Moved `CommandNameValidator` type to internal only