### PR TITLE
feat(RTE): add custom column break plugin

### DIFF
--- a/.changeset/spotty-papayas-admire.md
+++ b/.changeset/spotty-papayas-admire.md
@@ -3,3 +3,4 @@
 ---
 
 feat(RTE): add custom column break plugin
+Use simply as: `new BreakAfterPlugin({ columns, gap })`, and the plugin will take care of responsivity using container queries. Don't forget to also supply columns and gap to the `RichTextEditor` component.

--- a/.changeset/spotty-papayas-admire.md
+++ b/.changeset/spotty-papayas-admire.md
@@ -1,5 +1,5 @@
 ---
-"@frontify/guideline-blocks-settings": patch
+"@frontify/guideline-blocks-settings": minor
 ---
 
 feat(RTE): add custom column break plugin

--- a/.changeset/spotty-papayas-admire.md
+++ b/.changeset/spotty-papayas-admire.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+feat(RTE): add custom column break plugin

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
@@ -103,7 +103,6 @@ describe('Attachments', () => {
         });
 
         if ((await isPre302Stub(appBridge)) && hasOpenAssetChooser(appBridge)) {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             (appBridge.openAssetChooser as SinonStub) = cy.stub().callsArgWith(0, AssetDummy.with(4));
         }
 

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
@@ -103,6 +103,7 @@ describe('Attachments', () => {
         });
 
         if ((await isPre302Stub(appBridge)) && hasOpenAssetChooser(appBridge)) {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             (appBridge.openAssetChooser as SinonStub) = cy.stub().callsArgWith(0, AssetDummy.with(4));
         }
 

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.tsx
@@ -7,6 +7,7 @@ import { useIsInViewport } from '../../hooks/useIsInViewport';
 
 import { SerializedText } from './SerializedText';
 import { floatingButtonActions, floatingButtonSelectors } from './plugins/ButtonPlugin/components';
+import { getResponsiveColumnClasses } from './plugins/ColumnBreakPlugin/helpers';
 import { type RichTextEditorProps } from './types';
 
 const InternalRichTextEditor = memo(
@@ -21,6 +22,7 @@ const InternalRichTextEditor = memo(
         onTextChange,
         showSerializedText,
     }: Omit<RichTextEditorProps, 'isEditing'> & { isEnabled: boolean }) => {
+        const customClass = getResponsiveColumnClasses(columns);
         const [shouldPreventPageLeave, setShouldPreventPageLeave] = useState(false);
 
         const handleTextChange = useCallback(
@@ -68,7 +70,15 @@ const InternalRichTextEditor = memo(
                 />
             );
         }
-        return <SerializedText value={value} columns={columns} gap={gap} show={showSerializedText} plugins={plugins} />;
+        return (
+            <SerializedText
+                value={value}
+                gap={gap}
+                customClass={customClass}
+                show={showSerializedText}
+                plugins={plugins}
+            />
+        );
     },
 );
 InternalRichTextEditor.displayName = 'InternalRichTextEditor';
@@ -94,7 +104,7 @@ export const RichTextEditor = (props: RichTextEditorProps) => {
     }, [isEditing]);
 
     return (
-        <div className="tw-block tw-w-full" ref={ref}>
+        <div className="tw-block tw-w-full tw-@container" ref={ref}>
             <InternalRichTextEditor {...internalRteProps} isEnabled={isEditing && hasEnteredViewport} />
         </div>
     );

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.tsx
@@ -104,7 +104,7 @@ export const RichTextEditor = (props: RichTextEditorProps) => {
     }, [isEditing]);
 
     return (
-        <div className="tw-block tw-w-full tw-@container" ref={ref}>
+        <div data-test-id="rich-text-editor-container" className="tw-block tw-w-full tw-@container" ref={ref}>
             <InternalRichTextEditor {...internalRteProps} isEnabled={isEditing && hasEnteredViewport} />
         </div>
     );

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/SerializedText.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/SerializedText.tsx
@@ -5,14 +5,14 @@ import { useEffect, useState } from 'react';
 
 import { type SerializedTextProps } from './types';
 
-export const SerializedText = ({ value = '', gap, columns, show = true, plugins }: SerializedTextProps) => {
+export const SerializedText = ({ value = '', gap, customClass, show = true, plugins }: SerializedTextProps) => {
     const [html, setHtml] = useState<string | null>(null);
 
     useEffect(() => {
         (async () => {
-            setHtml(await serializeRawToHtmlAsync(value, plugins, columns, gap));
+            setHtml(await serializeRawToHtmlAsync(value, plugins, undefined, gap, customClass));
         })();
-    }, [value, columns, gap, plugins]);
+    }, [value, gap, plugins, customClass]);
 
     if (!show || html === '<br />') {
         return null;

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/ColumnBreakPlugin.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/ColumnBreakPlugin.ts
@@ -1,0 +1,28 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type PlatePlugin, Plugin, createColumnBreakPlugin, ColumnBreakButton } from '@frontify/fondue';
+import { type CSSProperties } from 'react';
+
+import { getResponsiveColumnClasses } from './helpers';
+
+export const KEY_ELEMENT_BREAK_AFTER_COLUMN = 'breakAfterColumn';
+export const GAP_DEFAULT = 'normal';
+
+export class BreakAfterPlugin extends Plugin {
+    private columns: number;
+    private gap: CSSProperties['gap'];
+    private customClass: string | undefined;
+    constructor(props?: { columns?: number; gap?: string | number }) {
+        super('break-after-plugin', {
+            button: ColumnBreakButton,
+            ...props,
+        });
+        this.columns = props?.columns ?? 1;
+        this.gap = props?.gap ?? GAP_DEFAULT;
+        this.customClass = getResponsiveColumnClasses(this.columns);
+    }
+
+    plugins(): PlatePlugin[] {
+        return [createColumnBreakPlugin(this.columns, this.gap, this.customClass)];
+    }
+}

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/helper.spec.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/helper.spec.ts
@@ -1,0 +1,21 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { describe, expect, it, test } from 'vitest';
+
+import { columnClassMap, getResponsiveColumnClasses } from './helpers';
+
+describe('RichTextEditor helpers', () => {
+    it('should return empty string if no column count is provided', () => {
+        expect(getResponsiveColumnClasses()).toBe('');
+    });
+
+    test.each([
+        [1, columnClassMap[1]],
+        [2, columnClassMap[2]],
+        [3, columnClassMap[3]],
+        [4, columnClassMap[4]],
+        [123, columnClassMap[1]],
+    ])('should return the proper classes for %i column count', (columnCount, expectedClasses) => {
+        expect(getResponsiveColumnClasses(columnCount)).toBe(expectedClasses);
+    });
+});

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/helpers.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/helpers.ts
@@ -1,0 +1,17 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export const columnClassMap = {
+    1: 'tw-columns-1',
+    2: 'tw-columns-1 @sm:!tw-columns-2',
+    3: 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-3',
+    4: 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-4',
+    5: 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-5',
+};
+
+export const getResponsiveColumnClasses = (columnCount?: number) => {
+    if (!columnCount) {
+        return '';
+    }
+
+    return columnClassMap[columnCount as keyof typeof columnClassMap] || columnClassMap[1];
+};

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/index.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/index.ts
@@ -1,0 +1,3 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './ColumnBreakPlugin';

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/index.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/index.ts
@@ -2,5 +2,6 @@
 
 export * from './LinkPlugin';
 export * from './ButtonPlugin';
+export * from './ColumnBreakPlugin';
 export * from './TextStylePlugins';
 export * from './styles';

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/types.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/types.ts
@@ -17,7 +17,7 @@ export type RichTextEditorProps = {
 export type SerializedTextProps = {
     value?: string;
     show?: boolean;
-    columns?: number;
     gap?: string;
+    customClass?: string;
     plugins?: PluginComposer;
 };


### PR DESCRIPTION
Introducing container query responsivity to the rich text editor when it comes to columns.

1. Extending fondue ColumnBreak plugin with some custom logic, so guideline-blocks can stay untouched
2. Extending serialized text with the same logic