### PR TITLE
fix(RTE): avoid column breaks when wrapping

### DIFF
--- a/.changeset/curly-lizards-know.md
+++ b/.changeset/curly-lizards-know.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(RTE): avoid column breaks when wrapping

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.spec.ct.tsx
@@ -269,7 +269,7 @@ describe('RichTextEditor', () => {
             />,
         );
         cy.get(RichTextContainerSelector).should('have.class', 'tw-@container');
-        cy.get(RichTextContentSelector).should('have.class', 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-4');
+        cy.get(RichTextContentSelector).should('have.class', 'tw-columns-1 @md:!tw-columns-4');
         cy.get(RichTextContentSelector).should('have.css', 'column-gap', '30px');
     });
 
@@ -288,7 +288,7 @@ describe('RichTextEditor', () => {
         );
 
         cy.get(RichTextContainerSelector).should('have.class', 'tw-@container');
-        cy.get(`${RteHtmlSelector} > div`).should('have.class', 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-4');
+        cy.get(`${RteHtmlSelector} > div`).should('have.class', 'tw-columns-1 @md:!tw-columns-4');
         cy.get(`${RteHtmlSelector} > div`).should('have.css', 'column-gap', '30px');
     });
 });

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/helpers.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ColumnBreakPlugin/helpers.ts
@@ -1,11 +1,21 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+/**
+ * As container queries lack a selector like @max-sm, as a workaround
+ * the class is disabled by default and reenabled on bigger container sizes
+ */
+const columnBreakDisablingClassUnderMd =
+    '[&_.tw-break-after-column]:tw-break-after-auto [&_.tw-break-inside-avoid-column]:tw-break-inside-auto [&_.tw-break-after-column.tw-pb-5]:tw-pb-0 @md:[&_.tw-break-after-column.tw-pb-5]:!tw-pb-5 @md:[&_.tw-break-after-column]:!tw-break-after-column @md:[&_.tw-break-inside-avoid-column]:!tw-break-inside-avoid-column';
+
+const columnBreakDisablingClassUnderSm =
+    '[&_.tw-break-after-column]:tw-break-after-auto [&_.tw-break-inside-avoid-column]:tw-break-inside-auto [&_.tw-break-after-column.tw-pb-5]:tw-pb-0 @sm:[&_.tw-break-after-column.tw-pb-5]:!tw-pb-5 @sm:[&_.tw-break-after-column]:!tw-break-after-column @sm:[&_.tw-break-inside-avoid-column]:!tw-break-inside-avoid-column';
+
 export const columnClassMap = {
     1: 'tw-columns-1',
-    2: 'tw-columns-1 @sm:!tw-columns-2',
-    3: 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-3',
-    4: 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-4',
-    5: 'tw-columns-1 @sm:!tw-columns-2 @md:!tw-columns-5',
+    2: `tw-columns-1 @sm:!tw-columns-2 ${columnBreakDisablingClassUnderSm}`,
+    3: `tw-columns-1 @md:!tw-columns-3 ${columnBreakDisablingClassUnderMd}`,
+    4: `tw-columns-1 @md:!tw-columns-4 ${columnBreakDisablingClassUnderMd}`,
+    5: `tw-columns-1 @md:!tw-columns-5 ${columnBreakDisablingClassUnderMd}`,
 };
 
 export const getResponsiveColumnClasses = (columnCount?: number) => {


### PR DESCRIPTION
Changes made according to [this loom](https://www.loom.com/share/814d70588956404c9f1a82200f768796).

1. Now we always wrap immediately to 1 column, no in-between.
2. When wrapping to 1-column, disable the specified column break if there is any.