### PR TITLE
fix(RTE): floating modals are hidden behind higher z index siblings

### DIFF
--- a/.changeset/stale-lizards-watch.md
+++ b/.changeset/stale-lizards-watch.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(RTE): floating modals are hidden behind higher z index siblings

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.spec.ct.tsx
@@ -82,7 +82,7 @@ describe('RichTextEditor', () => {
         cy.get(RteHtmlSelector).should('not.exist');
     });
 
-    it('select internal link', () => {
+    it('should be able to select internal link', () => {
         (appBridge.getDocumentGroups as SinonStub) = cy.stub().returns([]);
         (appBridge.getAllDocuments as SinonStub) = cy.stub().returns(Promise.resolve(apiDocuments));
 

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.spec.ct.tsx
@@ -82,7 +82,7 @@ describe('RichTextEditor', () => {
         cy.get(RteHtmlSelector).should('not.exist');
     });
 
-    it('should be able to select internal link', () => {
+    it('select internal link', () => {
         (appBridge.getDocumentGroups as SinonStub) = cy.stub().returns([]);
         (appBridge.getAllDocuments as SinonStub) = cy.stub().returns(Promise.resolve(apiDocuments));
 
@@ -98,7 +98,7 @@ describe('RichTextEditor', () => {
         cy.get(ToolbarButtonSelector).click();
         cy.get(ButtonSelector).first().click();
         cy.get(InternalDocumentLinkSelector).click();
-        cy.get(ButtonSelector).last().click();
+        cy.get(ButtonSelector).eq(1).click();
         cy.get(FloatingLinkModalSelector).find(ButtonSelector).last().click();
         const linkTag = cy.get(RichTextSelector).find('a[href="/r/document"]');
         linkTag.should('exist');
@@ -121,7 +121,7 @@ describe('RichTextEditor', () => {
         cy.get(ToolbarButtonSelector).click();
         cy.get(ButtonSelector).first().click();
         cy.get(InternalDocumentLinkSelector).click();
-        cy.get(ButtonSelector).last().click();
+        cy.get(ButtonSelector).eq(1).click();
         cy.get(CheckboxSelector).click();
         cy.get(FloatingLinkModalSelector).find(ButtonSelector).last().click();
         const linkTag = cy.get(RichTextSelector).find('a[href="/r/document"]');
@@ -252,7 +252,7 @@ describe('RichTextEditor', () => {
         cy.get(ToolbarButtonSelector).click();
         cy.get(ButtonSelector).first().click();
         cy.get(InternalDocumentLinkSelector).click();
-        cy.get(ButtonSelector).last().click();
+        cy.get(ButtonSelector).eq(1).click();
         cy.get(FloatingButtonModalSelector).find(ButtonSelector).last().click();
         cy.get(RichTextSelector).find('a[href="/r/document"]').should('exist');
     });

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/CustomFloatingButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/CustomFloatingButton.tsx
@@ -42,7 +42,7 @@ export const CustomFloatingButton = () => {
                         data-is-underlay
                         ref={insertRef}
                         {...insertProps}
-                        style={{ ...insertProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                        style={{ ...insertProps.style, ...BlockStyles[TextStyles.p] }}
                     >
                         {input}
                     </div>,
@@ -56,7 +56,7 @@ export const CustomFloatingButton = () => {
                         data-is-underlay
                         ref={editRef}
                         {...editProps}
-                        style={{ ...editProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                        style={{ ...editProps.style, ...BlockStyles[TextStyles.p] }}
                     >
                         {editContent}
                     </div>,

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/CustomFloatingButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/CustomFloatingButton.tsx
@@ -1,7 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type UseVirtualFloatingOptions, flip, offset, useEditorRef } from '@frontify/fondue';
+import { TextStyles, type UseVirtualFloatingOptions, flip, offset, useEditorRef } from '@frontify/fondue';
+import { createPortal } from 'react-dom';
 
+import { BlockStyles } from '../../../../../RichTextEditor/plugins/styles';
 import { useFloatingButtonEdit, useFloatingButtonInsert, useFloatingButtonSelectors } from '../FloatingButton';
 
 import { EditModal } from './EditButtonModal/EditModal';
@@ -33,17 +35,33 @@ export const CustomFloatingButton = () => {
 
     return (
         <>
-            {isOpen && mode === 'insert' && (
-                <div ref={insertRef} {...insertProps}>
-                    {input}
-                </div>
-            )}
+            {isOpen &&
+                mode === 'insert' &&
+                createPortal(
+                    <div
+                        data-is-underlay
+                        ref={insertRef}
+                        {...insertProps}
+                        style={{ ...insertProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                    >
+                        {input}
+                    </div>,
+                    document.body,
+                )}
 
-            {isOpen && mode === 'edit' && (
-                <div ref={editRef} {...editProps}>
-                    {editContent}
-                </div>
-            )}
+            {isOpen &&
+                mode === 'edit' &&
+                createPortal(
+                    <div
+                        data-is-underlay
+                        ref={editRef}
+                        {...editProps}
+                        style={{ ...editProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                    >
+                        {editContent}
+                    </div>,
+                    document.body,
+                )}
         </>
     );
 };

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/EditButtonModal/EditModal.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/ButtonPlugin/components/FloatingButton/EditButtonModal/EditModal.tsx
@@ -10,7 +10,7 @@ export const EditModal = () => {
     const editor = useEditorRef();
     return (
         <FloatingModalWrapper padding="16px" minWidth="400px" data-test-id="floating-button-edit">
-            <span data-test-id="preview-button-flyout" className="tw-flex tw-justify-between tw-items-center">
+            <span data-test-id="preview-button-flyout" className="tw-flex tw-justify-between tw-items-center tw-gap-2">
                 <span className="tw-pointer-events-none">{floatingButtonSelectors.url()}</span>
                 <span className="tw-flex tw-gap-2">
                     <button

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/CustomFloatingLink.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/CustomFloatingLink.tsx
@@ -65,7 +65,7 @@ export const CustomFloatingLink = () => {
                         data-is-underlay
                         ref={insertRef}
                         {...insertProps}
-                        style={{ ...insertProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                        style={{ ...insertProps.style, ...BlockStyles[TextStyles.p] }}
                     >
                         {input}
                     </div>,
@@ -78,7 +78,7 @@ export const CustomFloatingLink = () => {
                         data-is-underlay
                         ref={editRef}
                         {...editProps}
-                        style={{ ...editProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                        style={{ ...editProps.style, ...BlockStyles[TextStyles.p] }}
                     >
                         {editContent}
                     </div>,

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/CustomFloatingLink.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/CustomFloatingLink.tsx
@@ -10,6 +10,9 @@ import {
     useFloatingLinkInsert,
     useFloatingLinkInsertState,
 } from '@frontify/fondue';
+import { createPortal } from 'react-dom';
+
+import { BlockStyles, TextStyles } from '../../../../RichTextEditor/plugins/styles';
 
 import { EditModal } from './EditLinkModal';
 import { InsertLinkModal } from './InsertLinkModal/InsertLinkModal';
@@ -55,17 +58,32 @@ export const CustomFloatingLink = () => {
 
     return (
         <>
-            {insertState.isOpen && !editState.isOpen && (
-                <div ref={insertRef} {...insertProps} style={{ ...insertProps.style, zIndex: 1000 }}>
-                    {input}
-                </div>
-            )}
+            {insertState.isOpen &&
+                !editState.isOpen &&
+                createPortal(
+                    <div
+                        data-is-underlay
+                        ref={insertRef}
+                        {...insertProps}
+                        style={{ ...insertProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                    >
+                        {input}
+                    </div>,
+                    document.body,
+                )}
 
-            {editState.isOpen && (
-                <div ref={editRef} {...editProps} style={{ ...editProps.style, zIndex: 1000 }}>
-                    {editContent}
-                </div>
-            )}
+            {editState.isOpen &&
+                createPortal(
+                    <div
+                        data-is-underlay
+                        ref={editRef}
+                        {...editProps}
+                        style={{ ...editProps.style, zIndex: 1000, ...BlockStyles[TextStyles.p] }}
+                    >
+                        {editContent}
+                    </div>,
+                    document.body,
+                )}
         </>
     );
 };

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/plugins/LinkPlugin/FloatingLink/EditLinkModal/EditModal.tsx
@@ -21,7 +21,7 @@ export const EditModal = ({ editButtonProps, unlinkButtonProps }: EditModalProps
 
     return (
         <FloatingModalWrapper data-test-id="floating-link-edit" padding="16px" minWidth="400px">
-            <span data-test-id="preview-link-flyout" className="tw-flex tw-justify-between tw-items-center">
+            <span data-test-id="preview-link-flyout" className="tw-flex tw-justify-between tw-items-center tw-gap-2">
                 <span className="tw-pointer-events-none">{url}</span>
                 <span className="tw-flex tw-gap-2">
                     <button


### PR DESCRIPTION
1. Use portals to render the floating modals
2. Add little gap in edit modal so it is not cluttered anymore

https://app.clickup.com/t/86952var1