### PR TITLE
feat: add documentId to GuidelineDocumentCategory event payload

### DIFF
--- a/.changeset/hip-foxes-listen.md
+++ b/.changeset/hip-foxes-listen.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": patch
+---
+
+feat: add documentId to GuidelineDocumentCategory events

--- a/packages/app-bridge/src/react/useDocumentCategories.spec.ts
+++ b/packages/app-bridge/src/react/useDocumentCategories.spec.ts
@@ -339,7 +339,7 @@ describe('useDocumentCategories', () => {
         // Trigger a "document page add" event in the specified document
         window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
             action: 'add',
-            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_2 },
+            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_2, documentId: DOCUMENT_ID },
         });
 
         await waitFor(() => {
@@ -370,7 +370,7 @@ describe('useDocumentCategories', () => {
         // Trigger a "document page add" event in the specified document
         window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
             action: 'add',
-            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_4 },
+            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_4, documentId: DOCUMENT_ID },
         });
 
         await waitFor(() => {
@@ -401,7 +401,7 @@ describe('useDocumentCategories', () => {
         // Trigger a "document page delete" event in the specified document
         window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
             action: 'delete',
-            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_3 },
+            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_3, documentId: DOCUMENT_ID },
         });
 
         await waitFor(() => {
@@ -432,7 +432,7 @@ describe('useDocumentCategories', () => {
         // Trigger a "document page delete" event in the specified document
         window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
             action: 'delete',
-            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_4 },
+            documentPage: { id: DOCUMENT_PAGE_ID, categoryId: DOCUMENT_CATEGORY_ID_4, documentId: DOCUMENT_ID },
         });
 
         await waitFor(() => {

--- a/packages/app-bridge/src/react/useDocumentNavigation.spec.ts
+++ b/packages/app-bridge/src/react/useDocumentNavigation.spec.ts
@@ -86,7 +86,7 @@ describe('useDocumentNavigation', () => {
         testEventHandler(() => {
             window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
                 action: 'add',
-                documentPage: { categoryId: 0, id: 0 },
+                documentPage: { categoryId: 0, id: 0, documentId: 0 },
             });
         }));
 

--- a/packages/app-bridge/src/react/useGuidelineActions.ts
+++ b/packages/app-bridge/src/react/useGuidelineActions.ts
@@ -260,6 +260,7 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
                     documentPage: {
                         id: result.id,
                         categoryId: documentPage.categoryId,
+                        documentId: documentPage.documentId,
                     },
                     action: 'add',
                 });
@@ -310,7 +311,11 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
 
             if (documentPage.categoryId) {
                 window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
-                    documentPage: { ...documentPage, categoryId: documentPage.categoryId },
+                    documentPage: {
+                        ...documentPage,
+                        categoryId: documentPage.categoryId,
+                        documentId: documentPage.documentId,
+                    },
                     action: 'delete',
                 });
             } else {
@@ -334,7 +339,7 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
 
             if (categoryId) {
                 window.emitter.emit('AppBridge:GuidelineDocumentCategory:DocumentPageAction', {
-                    documentPage: { id: duplicatedDocumentPage.id, categoryId },
+                    documentPage: { id: duplicatedDocumentPage.id, categoryId, documentId },
                     action: 'add',
                 });
             }

--- a/packages/app-bridge/src/types/Emitter.ts
+++ b/packages/app-bridge/src/types/Emitter.ts
@@ -142,7 +142,7 @@ export type EmitterEvents = {
           };
 
     'AppBridge:GuidelineDocumentCategory:DocumentPageAction': {
-        documentPage: { id: number; categoryId: number };
+        documentPage: { id: number; categoryId: number; documentId: number };
         action: 'add' | 'delete';
     };
 


### PR DESCRIPTION
`documentId` needs to be included in `GuidelineDocumentCategory` events payload for themes to be aware of changes from the Navigation Manager and update navigation items for the document.

https://app.clickup.com/t/8694xwktr