### PR TITLE
feat(AppBridgeTheme): added commands to open/close AIBrandAssistant dialog

### DIFF
--- a/packages/app-bridge-theme/src/registries/CommandRegistry.ts
+++ b/packages/app-bridge-theme/src/registries/CommandRegistry.ts
@@ -7,6 +7,8 @@ import { type ObjectNameValidator } from '../types';
 export type CommandRegistry = CommandNameValidator<{
     openSearchDialog: void;
     closeSearchDialog: void;
+    openAiBrandAssistantDialog: void;
+    closeAiBrandAssistantDialog: void;
     navigate: string;
     navigateToDocumentSection: number | string;
     hydrateContextDocumentNavigation: number;

--- a/packages/app-bridge-theme/src/registries/commands/AiBrandAssistantDialog.ts
+++ b/packages/app-bridge-theme/src/registries/commands/AiBrandAssistantDialog.ts
@@ -1,0 +1,14 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type DispatchHandlerParameter } from '../../types';
+import { type CommandRegistry } from '../CommandRegistry';
+
+export const openAiBrandAssistantDialog = (): DispatchHandlerParameter<
+    'openAiBrandAssistantDialog',
+    CommandRegistry
+> => ({ name: 'openAiBrandAssistantDialog' });
+
+export const closeAiBrandAssistantDialog = (): DispatchHandlerParameter<
+    'closeAiBrandAssistantDialog',
+    CommandRegistry
+> => ({ name: 'closeAiBrandAssistantDialog' });

--- a/packages/app-bridge-theme/src/registries/commands/index.ts
+++ b/packages/app-bridge-theme/src/registries/commands/index.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+export * from './AiBrandAssistantDialog';
 export * from './SearchDialog';
 export * from './Navigate';
 export * from './NavigateToDocumentSection';

--- a/packages/app-bridge-theme/src/types/Context.ts
+++ b/packages/app-bridge-theme/src/types/Context.ts
@@ -33,6 +33,7 @@ export type Context = {
     isEditing: boolean;
     isPublicLink: boolean;
     isAuthenticated: boolean;
+    isAiBrandAssistantDialogOpen: boolean;
     isSearchDialogOpen: boolean;
     languages: Language[];
     template: TemplateContext | null;


### PR DESCRIPTION
This PR adds 2 commands to the AppBridgeTheme:

- `openAiBrandAssistantDialog`
- `closeAiBrandAssistantDialog`