### PR TITLE
feat(app-bridge-app): New command `executeSecureRequest`

### DIFF
--- a/packages/app-bridge-app/src/AppBridgePlatformApp.ts
+++ b/packages/app-bridge-app/src/AppBridgePlatformApp.ts
@@ -36,6 +36,7 @@ export type PlatformAppApiMethod = PlatformAppApiMethodNameValidator<
         | 'getSecureRequest'
         | 'getAccountId'
         | 'executeGraphQl'
+        | 'executeSecureRequest'
     >
 >;
 

--- a/packages/app-bridge-app/src/registries/api/ApiMethodRegistry.ts
+++ b/packages/app-bridge-app/src/registries/api/ApiMethodRegistry.ts
@@ -4,6 +4,7 @@ import { type PlatformAppApiMethodNameValidator } from '../../types/Api.ts';
 
 import { type CreateAssetPayload, type CreateAssetResponse } from './CreateAsset';
 import { type ExecuteGraphQlPayload, type ExecuteGraphQlResponse } from './ExecuteGraphQl.ts';
+import { type ExecuteSecureRequestPayload, type ExecuteSecureRequestResponse } from './ExecuteSecureRequest.ts';
 import { type GetAccountIdPayload, type GetAccountIdResponse } from './GetAccountId.ts';
 import {
     type GetAssetResourceInformationPayload,
@@ -22,4 +23,5 @@ export type ApiMethodRegistry = PlatformAppApiMethodNameValidator<{
     getSecureRequest: { payload: GetSecureRequestPayload; response: GetSecureRequestResponse };
     getAccountId: { payload: GetAccountIdPayload; response: GetAccountIdResponse };
     executeGraphQl: { payload: ExecuteGraphQlPayload; response: ExecuteGraphQlResponse };
+    executeSecureRequest: { payload: ExecuteSecureRequestPayload; response: ExecuteSecureRequestResponse };
 }>;

--- a/packages/app-bridge-app/src/registries/api/ExecuteSecureRequest.spec.ts
+++ b/packages/app-bridge-app/src/registries/api/ExecuteSecureRequest.spec.ts
@@ -1,0 +1,17 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { describe, expect, it } from 'vitest';
+
+import { exeucteSecureRequest } from './ExecuteSecureRequest.ts';
+
+describe('ExecuteSecureRequest', () => {
+    it('should return correct method name', () => {
+        const TEST_ID = 'user-api';
+        const secureRequest = exeucteSecureRequest({ endpoint: TEST_ID, requestParams: 'data' });
+        expect(secureRequest.name).toBe('executeSecureRequest');
+        expect(secureRequest.payload).toStrictEqual({
+            endpoint: TEST_ID,
+            requestParams: 'data',
+        });
+    });
+});

--- a/packages/app-bridge-app/src/registries/api/ExecuteSecureRequest.ts
+++ b/packages/app-bridge-app/src/registries/api/ExecuteSecureRequest.ts
@@ -1,0 +1,13 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export type ExecuteSecureRequestPayload = {
+    endpoint: string;
+    requestParams: unknown;
+};
+
+export type ExecuteSecureRequestResponse = Response;
+
+export const exeucteSecureRequest = (payload: ExecuteSecureRequestPayload) => ({
+    name: 'executeSecureRequest',
+    payload,
+});

--- a/packages/app-bridge-app/src/registries/api/index.ts
+++ b/packages/app-bridge-app/src/registries/api/index.ts
@@ -6,3 +6,4 @@ export * from './GetAssetResourceInformation';
 export * from './GetCurrentUser';
 export * from './GetSecureRequest';
 export * from './ExecuteGraphQl';
+export * from './ExecuteSecureRequest';


### PR DESCRIPTION
This PR creates a new `executeSecureRequest` command that returns a [fetch response](https://developer.mozilla.org/en-US/docs/Web/API/Response). 
The client benefits from being able to decide what to do with the data. For example, deciding whether it's an image or not.

Since it's not possible to send complex objects with methods via `MessagePort:postMessage()`, we have to disassemble the message before sending it through the port and reassemble it on the other side.
