### PR TITLE
fix(guideline-themes): export types ungroupped

### DIFF
--- a/.changeset/four-ravens-try.md
+++ b/.changeset/four-ravens-try.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-themes": patch
+---
+
+fix(guideline-themes): export types ungroupped

--- a/packages/guideline-themes/package.json
+++ b/packages/guideline-themes/package.json
@@ -27,6 +27,7 @@
     ],
     "scripts": {
         "build": "vite build",
+        "dev": "vite build --watch",
         "lint": "eslint .",
         "lint:fix": "eslint --fix .",
         "prettier": "prettier --check .",

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -56,23 +56,19 @@ export type TextareaBlock = TextareaBlockSidebarSettings<AppBridgeTheme>;
 export type ValueOrPromisedValue<T> = ValueOrPromisedValueSidebarSettings<AppBridgeTheme, T>;
 
 export type ContentAreaWidthChoice = `${number}${'px' | '%' | 'vw'}`;
-type ContentAreaWidthTemplateSettings = {
+export type ContentAreaWidthTemplateSettings = {
     contentAreaWidthChoice?: ContentAreaWidthChoice;
     contentAreaWidthCustom?: `${number}${string}`;
     contentAreaWidthCustomEnabled?: boolean;
 };
 export type ContentAreaPaddingChoice = `${number}${'px' | '%' | 'vw'}`;
-type ContentAreaPaddingTemplateSettings = {
+export type ContentAreaPaddingTemplateSettings = {
     contentAreaPaddingChoice?: ContentAreaPaddingChoice;
     contentAreaPaddingCustom?: `${number}${string}`;
     contentAreaPaddingCustomEnabled?: boolean;
 };
 export type ContentAreaAlignmentChoice = 'left' | 'center' | 'right';
-type ContentAreaAlignmentSetting = { contentAreaAlignmentChoice?: ContentAreaAlignmentChoice };
-
-export type ContentAreaSettings = ContentAreaWidthTemplateSettings &
-    ContentAreaPaddingTemplateSettings &
-    ContentAreaAlignmentSetting;
+export type ContentAreaAlignmentSetting = { contentAreaAlignmentChoice?: ContentAreaAlignmentChoice };
 
 export type ThemeSettingsStructureExport = { [customSectionName: string]: SettingBlock[] };
 export type ThemeSettingsStructure = Record<ThemeTemplate, ThemeSettingsStructureExport>;


### PR DESCRIPTION
Partially reverts changes in https://github.com/Frontify/brand-sdk/pull/1103
Intersected type `ContentAreaSettings` complicates typing for devs


https://app.clickup.com/t/8695hb071