### PR TITLE
feat: deprecate dropdownBlock size prop

### DIFF
--- a/.changeset/itchy-months-teach.md
+++ b/.changeset/itchy-months-teach.md
@@ -2,4 +2,4 @@
 "@frontify/sidebar-settings": patch
 ---
 
-feat: deprecate dropdownBlock size prop
+refactor(dropdown): deprecate the size prop

--- a/.changeset/itchy-months-teach.md
+++ b/.changeset/itchy-months-teach.md
@@ -1,0 +1,5 @@
+---
+"@frontify/sidebar-settings": patch
+---
+
+feat: deprecate dropdownBlock size prop

--- a/packages/sidebar-settings/src/blocks/dropdown.ts
+++ b/packages/sidebar-settings/src/blocks/dropdown.ts
@@ -22,7 +22,7 @@ export type DropdownBlock<AppBridge> = {
 
     /**
      * The size of the dropdown.
-     * @deprecated
+     * @deprecated `size` has no effect anymore, will be removed 13.09.2025 
      */
     size?: 'small' | 'large' | DropdownSize;
 

--- a/packages/sidebar-settings/src/blocks/dropdown.ts
+++ b/packages/sidebar-settings/src/blocks/dropdown.ts
@@ -22,6 +22,7 @@ export type DropdownBlock<AppBridge> = {
 
     /**
      * The size of the dropdown.
+     * @deprecated
      */
     size?: 'small' | 'large' | DropdownSize;
 

--- a/packages/sidebar-settings/src/blocks/dropdown.ts
+++ b/packages/sidebar-settings/src/blocks/dropdown.ts
@@ -22,7 +22,7 @@ export type DropdownBlock<AppBridge> = {
 
     /**
      * The size of the dropdown.
-     * @deprecated `size` has no effect anymore, will be removed 13.09.2025
+     * @deprecated `size` has no effect anymore, will be removed 13.10.2024
      */
     size?: 'small' | 'large' | DropdownSize;
 

--- a/packages/sidebar-settings/src/blocks/dropdown.ts
+++ b/packages/sidebar-settings/src/blocks/dropdown.ts
@@ -22,7 +22,7 @@ export type DropdownBlock<AppBridge> = {
 
     /**
      * The size of the dropdown.
-     * @deprecated `size` has no effect anymore, will be removed 13.09.2025 
+     * @deprecated `size` has no effect anymore, will be removed 13.09.2025
      */
     size?: 'small' | 'large' | DropdownSize;
 


### PR DESCRIPTION
New implementation of the dropdownBlock doesn't use `size` prop anymore