### PR TITLE
fix(*): scroll events are hijacked by dnd-kit

### DIFF
--- a/.changeset/friendly-olives-shake.md
+++ b/.changeset/friendly-olives-shake.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(*): scroll events are hijacked by dnd-kit

--- a/packages/guideline-blocks-settings/src/hooks/useDndSensors.ts
+++ b/packages/guideline-blocks-settings/src/hooks/useDndSensors.ts
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { useMemo } from 'react';
 
 import { customCoordinatesGetterFactory } from '../helpers/customCoordinatesGetterFactory';
 
@@ -11,14 +12,15 @@ const keyboardCodes = {
 };
 
 export const useDndSensors = (columnGap = 0, rowGap = 0) => {
-    const customCoordinatesGetter = customCoordinatesGetterFactory(columnGap, rowGap);
-    const sensors = useSensors(
-        useSensor(PointerSensor),
-        useSensor(KeyboardSensor, {
+    const keyboardSensorOptions = useMemo(() => {
+        const customCoordinatesGetter = customCoordinatesGetterFactory(columnGap, rowGap);
+        return {
             coordinateGetter: customCoordinatesGetter,
             keyboardCodes,
-        }),
-    );
+        };
+    }, [columnGap, rowGap]);
+
+    const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor, keyboardSensorOptions));
 
     return sensors;
 };


### PR DESCRIPTION
Through painful trial and errors I found that the `useDndSensor` is causing the scroll to stop midway. Possibly due to the dnd-kit using some internal scroll listener, and the `useSensor` hook was recreated on every render since the second parameter was not memoised.

https://app.clickup.com/t/2523021/TASK-12175