### PR TITLE
feat(*): add fondue component style css

### DIFF
--- a/.changeset/fast-eagles-notice.md
+++ b/.changeset/fast-eagles-notice.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+feat(*): add fondue component style css

--- a/packages/guideline-blocks-settings/src/styles.css
+++ b/packages/guideline-blocks-settings/src/styles.css
@@ -1,3 +1,5 @@
+@import '../node_modules/@frontify/fondue/dist/packages/components/style.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/guideline-blocks-settings/src/styles.css
+++ b/packages/guideline-blocks-settings/src/styles.css
@@ -1,4 +1,4 @@
-@import '../node_modules/@frontify/fondue/dist/packages/components/style.css';
+@import '@frontify/fondue/components/styles';
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
Otherwise it's possible that `web-app` fondue is on a newer version and does not have the appropriate CSS module styles anymore because the hash changed.