### PR TITLE
fix: gitignore file missing when creating an app

### DIFF
--- a/.changeset/two-dolls-joke.md
+++ b/.changeset/two-dolls-joke.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+Add .gitignore file while creating an extension

--- a/packages/cli/src/utils/file.ts
+++ b/packages/cli/src/utils/file.ts
@@ -1,11 +1,38 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { copyFileSync, mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { copyFileSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path, { resolve } from 'node:path';
 
 import globToRegExp from 'glob-to-regexp';
 
 import FileNotFoundError from '../errors/FileNotFoundError';
+
+const GITIGNORE_TEMPLATE = `
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.localdist
+.idea
+.vscode
+
+# Editor directories and files
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+.secret.json
+`;
 
 export const isDirectoryEmpty = (folderPath: string): boolean => {
     try {
@@ -22,6 +49,9 @@ export const copyFolder = (
 ) => {
     mkdirSync(destinationFolderPath, { recursive: true });
     const excludePatterns = options?.exclude.map((glob) => globToRegExp(glob));
+
+    const gitignorePath = path.join(destinationFolderPath, '.gitignore');
+    writeFileSync(gitignorePath, GITIGNORE_TEMPLATE);
 
     for (const file of readdirSync(sourceFolderPath)) {
         if (excludePatterns !== undefined && excludePatterns.some((re) => re.test(file))) {


### PR DESCRIPTION
Issue:
When creating an app with the frontify-cli, the .gitignore file is missing. The missing file makes deployment to the marketplace fail. Although it can be easily added manually, it should be added by default for a better DX.

Why it's missing even if it exist in the templates files:
`.gitignore` files are ignored by default when a package is published to `npm`. [See docs for reference.](https://docs.npmjs.com/cli/v9/using-npm/developers#keeping-files-out-of-your-package) 

Possible Solution:
Manually write a .gitignore file (generic template) when the files are copied from source to destination folder.