### PR TITLE
refactor(guideline-themes): removes themeConfigExport.settings

### DIFF
--- a/.changeset/empty-jobs-add.md
+++ b/.changeset/empty-jobs-add.md
@@ -2,4 +2,4 @@
 "@frontify/guideline-themes": patch
 ---
 
-refactor(guideline-themes):removes themeConfigExport.settings
+refactor(guideline-themes): removes themeConfigExport.settings

--- a/.changeset/empty-jobs-add.md
+++ b/.changeset/empty-jobs-add.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-themes": patch
+---
+
+refactor(guideline-themes):removes themeConfigExport.settings

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -90,8 +90,6 @@ export type ThemeConfigExport = {
         documentPage: { default: ThemeTemplateExport } & Record<string, ThemeTemplateExport>;
         library: { default: ThemeTemplateExport } & Record<string, ThemeTemplateExport>;
     };
-    /** @deprecated to be removed in fave of templates */
-    settings?: ThemeSettingsStructure;
 };
 
 /**

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -90,7 +90,8 @@ export type ThemeConfigExport = {
         documentPage: { default: ThemeTemplateExport } & Record<string, ThemeTemplateExport>;
         library: { default: ThemeTemplateExport } & Record<string, ThemeTemplateExport>;
     };
-    settings: ThemeSettingsStructure;
+    /** @deprecated to be removed in fave of templates */
+    settings?: ThemeSettingsStructure;
 };
 
 /**


### PR DESCRIPTION
[CU-86966vzkv Change the settings structure type in BrandSDK](https://app.clickup.com/t/86966vzkv)