### PR TITLE
fix: gitignore file on every folder level

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,11 +1,39 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { resolve } from 'node:path';
+import path, { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import pc from 'picocolors';
 
 import { Logger, copyFolder, updatePackageJsonProjectName } from '../utils/index';
+import { writeFileSync } from 'node:fs';
+
+const GITIGNORE_TEMPLATE = `
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.localdist
+.idea
+.vscode
+
+# Editor directories and files
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+.secret.json
+`;
 
 export const createNewApp = (appName: string, template: string, type: string): void => {
     Logger.info(`Creating the ${type}...`);
@@ -15,6 +43,9 @@ export const createNewApp = (appName: string, template: string, type: string): v
 
     const templateDir = resolve(fileURLToPath(import.meta.url), `../../templates/${type}-${template}`);
     copyFolder(templateDir, appName, { exclude: ['node_modules'] });
+
+    const gitignorePath = path.join(templateDir, '.gitignore');
+    writeFileSync(gitignorePath, GITIGNORE_TEMPLATE);
 
     updatePackageJsonProjectName(appName);
 

--- a/packages/cli/src/utils/file.ts
+++ b/packages/cli/src/utils/file.ts
@@ -1,38 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { copyFileSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import path, { resolve } from 'node:path';
+import { copyFileSync, mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import globToRegExp from 'glob-to-regexp';
 
 import FileNotFoundError from '../errors/FileNotFoundError';
-
-const GITIGNORE_TEMPLATE = `
-# Logs
-logs
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-lerna-debug.log*
-
-node_modules
-dist
-dist-ssr
-*.localdist
-.idea
-.vscode
-
-# Editor directories and files
-.DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
-.secret.json
-`;
 
 export const isDirectoryEmpty = (folderPath: string): boolean => {
     try {
@@ -49,9 +22,6 @@ export const copyFolder = (
 ) => {
     mkdirSync(destinationFolderPath, { recursive: true });
     const excludePatterns = options?.exclude.map((glob) => globToRegExp(glob));
-
-    const gitignorePath = path.join(destinationFolderPath, '.gitignore');
-    writeFileSync(gitignorePath, GITIGNORE_TEMPLATE);
 
     for (const file of readdirSync(sourceFolderPath)) {
         if (excludePatterns !== undefined && excludePatterns.some((re) => re.test(file))) {


### PR DESCRIPTION
I made the mistake to add that gitignore file on the copyFolder function which is reused.

It should be done only once in the createNewApp and at the root template directory level.

Following up and fixing bug from this PR: https://github.com/Frontify/brand-sdk/pull/1137