### PR TITLE
feat(templates): add zustand as peerdependency

### DIFF
--- a/.changeset/big-maps-marry.md
+++ b/.changeset/big-maps-marry.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+feat(templates): add zustand as peerdependency

--- a/packages/cli/templates/content-block-css-modules/package.json
+++ b/packages/cli/templates/content-block-css-modules/package.json
@@ -10,6 +10,9 @@
         "lint:fix": "eslint . --fix",
         "typecheck": "tsc --noEmit"
     },
+    "peerDependencies": {
+        "zustand": "4.5.5"
+    },
     "dependencies": {
         "@frontify/app-bridge": "^3.5.5",
         "react": "^18.2.0",

--- a/packages/cli/templates/content-block-css/package.json
+++ b/packages/cli/templates/content-block-css/package.json
@@ -10,6 +10,9 @@
         "lint:fix": "eslint . --fix",
         "typecheck": "tsc --noEmit"
     },
+    "peerDependencies": {
+        "zustand": "4.5.5"
+    },
     "dependencies": {
         "@frontify/app-bridge": "^3.5.5",
         "react": "^18.2.0",

--- a/packages/cli/templates/content-block-tailwind/package.json
+++ b/packages/cli/templates/content-block-tailwind/package.json
@@ -10,6 +10,9 @@
         "lint:fix": "eslint . --fix",
         "typecheck": "tsc --noEmit"
     },
+    "peerDependencies": {
+        "zustand": "4.5.5"
+    },
     "dependencies": {
         "@frontify/app-bridge": "^3.5.5",
         "react": "^18.2.0",

--- a/packages/cli/templates/platform-app-css-modules/package.json
+++ b/packages/cli/templates/platform-app-css-modules/package.json
@@ -10,6 +10,9 @@
         "lint:fix": "eslint . --fix",
         "typecheck": "tsc --noEmit"
     },
+    "peerDependencies": {
+        "zustand": "4.5.5"
+    },
     "dependencies": {
         "@frontify/app-bridge-app": "^0.0.16",
         "@frontify/fondue": "^12.2.11",

--- a/packages/cli/templates/platform-app-css/package.json
+++ b/packages/cli/templates/platform-app-css/package.json
@@ -10,6 +10,9 @@
         "lint:fix": "eslint . --fix",
         "typecheck": "tsc --noEmit"
     },
+    "peerDependencies": {
+        "zustand": "4.5.5"
+    },
     "dependencies": {
         "@frontify/app-bridge-app": "^0.0.16",
         "@frontify/fondue": "^12.2.11",

--- a/packages/cli/templates/platform-app-tailwind/package.json
+++ b/packages/cli/templates/platform-app-tailwind/package.json
@@ -10,6 +10,9 @@
         "lint:fix": "eslint . --fix",
         "typecheck": "tsc --noEmit"
     },
+    "peerDependencies": {
+        "zustand": "4.5.5"
+    },
     "dependencies": {
         "@frontify/app-bridge-app": "^0.0.16",
         "@frontify/fondue": "^12.2.11",


### PR DESCRIPTION
Otherwise `npm i` bumps it up to 5.0.0 which is breaking when served