### PR TITLE
fix(templates): prevent delete on update without existing template ids

### DIFF
--- a/.changeset/brave-comics-guess.md
+++ b/.changeset/brave-comics-guess.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge": patch
+---
+
+fix(templates): prevent delete on update without existing template ids

--- a/packages/app-bridge/src/react/useBlockTemplates.spec.ts
+++ b/packages/app-bridge/src/react/useBlockTemplates.spec.ts
@@ -53,7 +53,7 @@ describe('useBlockTemplates hook', () => {
         const deleteCall = appBridgeStub.deleteTemplateIdsFromBlockTemplateKey.getCall(0);
         const addCall = appBridgeStub.addTemplateIdsToBlockTemplateKey.getCall(0);
 
-        await waitFor(async () => {
+        await waitFor(() => {
             expect(deleteCall.firstArg).toEqual('key');
             expect(deleteCall.lastArg).toEqual([1, 2]);
             expect(addCall.firstArg).toEqual('key');
@@ -73,11 +73,29 @@ describe('useBlockTemplates hook', () => {
             await result.current.updateTemplateIdsFromKey('key', [2, 1]);
         });
 
-        await waitFor(async () => {
+        await waitFor(() => {
             expect(result.current.blockTemplates.key.map((template) => template.id)).toEqual([1, 2]);
         });
 
         expect(result.current.error).toEqual(errorMessage);
+    });
+
+    it('should not delete templates if no old keys', async () => {
+        const { result, appBridgeStub } = await loadUseBlockTemplates([]);
+
+        await act(async () => {
+            await result.current.updateTemplateIdsFromKey('key', [2, 1]);
+        });
+
+        const deleteCall = appBridgeStub.deleteTemplateIdsFromBlockTemplateKey.getCall(0);
+        const addCall = appBridgeStub.addTemplateIdsToBlockTemplateKey.getCall(0);
+
+        await waitFor(() => {
+            expect(deleteCall).toBeNull();
+            expect(addCall.firstArg).toEqual('key');
+            expect(addCall.lastArg).toEqual([2, 1]);
+            expect(result.current.blockTemplates.key.map((template) => template.id)).toEqual([2, 1]);
+        });
     });
 
     it('should notify about updated templates on delete', async () => {

--- a/packages/app-bridge/src/react/useBlockTemplates.ts
+++ b/packages/app-bridge/src/react/useBlockTemplates.ts
@@ -86,7 +86,9 @@ export const useBlockTemplates = (appBridge: AppBridgeBlock) => {
         const oldTemplateIds = currentBlockTemplates[key]?.map((template) => template.id) ?? [];
 
         try {
-            await appBridge.deleteTemplateIdsFromBlockTemplateKey(key, oldTemplateIds);
+            if (oldTemplateIds.length > 0) {
+                await appBridge.deleteTemplateIdsFromBlockTemplateKey(key, oldTemplateIds);
+            }
             await appBridge.addTemplateIdsToBlockTemplateKey(key, newTemplateIds);
         } catch (error) {
             handleErrorMessage(error);


### PR DESCRIPTION
TASK-12885

This fixes an issue where a request to delete existing template ids before adding new ones returned an error if an empty array was submitted in the request parameter.