### PR TITLE
Support for automation surface and action settings

### DIFF
--- a/.changeset/nice-cups-sparkle.md
+++ b/.changeset/nice-cups-sparkle.md
@@ -1,0 +1,13 @@
+---
+"@frontify/platform-app": minor
+"@frontify/frontify-cli": patch
+---
+
+**Manifest validation**
+With the additional validation rules, we make sure that the automation surface definition adheres to the schema.
+
+**Support for automation action settings**
+The settings for automation actions can now be defined – in the exact same way as the default settings – via the `settings` property in the `defineApp` method.
+This approach is very flexible, allowing to add further settings (e.g. for project, libraries or brand-level settings) easily without the need to adjust the bundler or add additional parameters to the `defineApp` method.
+This makes it easier to evolve app settings in the future,
+

--- a/packages/cli/src/utils/verifyManifest.ts
+++ b/packages/cli/src/utils/verifyManifest.ts
@@ -82,6 +82,7 @@ const variableTypes = z.enum([
     'DATE',
     'OPTIONS',
     'USER',
+    'ASSET',
     'CUSTOM_METADATA_PROPERTY',
     'WORKFLOW_TASK_STATUS',
 ]);

--- a/packages/cli/src/utils/verifyManifest.ts
+++ b/packages/cli/src/utils/verifyManifest.ts
@@ -91,7 +91,7 @@ const variablesSchema = object({
         .max(80)
         .refine(
             (key) => {
-                return /^[._a-zA-Z]*$/.test(key);
+                return /^[.A-Z_a-z]*$/.test(key);
             },
             {
                 message: "Variable key must only contain letters from a-z, A-Z, '.' and '_' without any spaces",
@@ -108,7 +108,7 @@ const automationActionSchema = object({
         .max(80)
         .refine(
             (id) => {
-                return /^[_a-zA-Z]*$/.test(id);
+                return /^[A-Z_a-z]*$/.test(id);
             },
             {
                 message: "Automation action id must only contain letters from a-z, A-Z, and '_' without any spaces",
@@ -129,8 +129,8 @@ const automationActionSchema = object({
         ),
     name: string().min(1).max(80),
     workflowId: string()
-        .min(15)
-        .max(15)
+        .min(16)
+        .max(16)
         .refine(
             (workflowId) => {
                 return /^\w+$/.test(workflowId);
@@ -151,7 +151,7 @@ const automationTriggerSchema = object({
         .max(80)
         .refine(
             (id) => {
-                return /^[_a-zA-Z]*$/.test(id);
+                return /^[A-Z_a-z]*$/.test(id);
             },
             {
                 message: "Automation trigger id must only contain letters from a-z, A-Z, and '_' without any spaces",

--- a/packages/cli/src/utils/verifyManifest.ts
+++ b/packages/cli/src/utils/verifyManifest.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { array, number, object, string, z } from 'zod';
+import { array, number, object, string, record, z } from 'zod';
 
 const forbiddenExtensions = ['exe', 'dmg', 'cmd', 'sh', 'bat'];
 const getForbiddenExtensionsErrorMessage = (surfaceName: string) =>
@@ -87,47 +87,11 @@ const variableTypes = z.enum([
     'WORKFLOW_TASK_STATUS',
 ]);
 const variablesSchema = object({
-    key: string()
-        .min(1)
-        .max(80)
-        .refine(
-            (key) => {
-                return /^[.A-Z_a-z]*$/.test(key);
-            },
-            {
-                message: "Variable key must only contain letters from a-z, A-Z, '.' and '_' without any spaces",
-            },
-        ),
     name: string().min(1).max(80),
     type: variableTypes,
 });
 
-const actionIdSet = new Set();
 const automationActionSchema = object({
-    id: string()
-        .min(1)
-        .max(80)
-        .refine(
-            (id) => {
-                return /^[A-Z_a-z]*$/.test(id);
-            },
-            {
-                message: "Automation action id must only contain letters from a-z, A-Z, and '_' without any spaces",
-            },
-        )
-        .refine(
-            (id) => {
-                if (actionIdSet.has(id)) {
-                    return false;
-                }
-
-                actionIdSet.add(id);
-                return true;
-            },
-            {
-                message: 'Automation action id must be unique',
-            },
-        ),
     name: string().min(1).max(80),
     workflowId: string()
         .min(16)
@@ -142,38 +106,13 @@ const automationActionSchema = object({
             },
         ),
     description: string().optional(),
-    variables: array(variablesSchema),
+    variables: record(variablesSchema),
 });
 
-const triggerIdSet = new Set();
 const automationTriggerSchema = object({
-    id: string()
-        .min(1)
-        .max(80)
-        .refine(
-            (id) => {
-                return /^[A-Z_a-z]*$/.test(id);
-            },
-            {
-                message: "Automation trigger id must only contain letters from a-z, A-Z, and '_' without any spaces",
-            },
-        )
-        .refine(
-            (id) => {
-                if (triggerIdSet.has(id)) {
-                    return false;
-                }
-
-                triggerIdSet.add(id);
-                return true;
-            },
-            {
-                message: 'Automation trigger id must be unique',
-            },
-        ),
     name: string().min(1).max(80),
     description: string().optional(),
-    variables: array(variablesSchema),
+    variables: record(variablesSchema),
 });
 
 const hostnameRegex =
@@ -302,8 +241,8 @@ export const platformAppManifestSchemaV1 = object({
             assetCreation: assetCreationShape,
         }).optional(),
         automation: object({
-            actions: array(automationActionSchema).optional(),
-            triggers: array(automationTriggerSchema).optional(),
+            actions: record(automationActionSchema).optional(),
+            triggers: record(automationTriggerSchema).optional(),
         }).optional(),
     }).optional(),
     metadata: object({

--- a/packages/cli/src/utils/verifyManifest.ts
+++ b/packages/cli/src/utils/verifyManifest.ts
@@ -91,10 +91,10 @@ const variablesSchema = object({
         .max(80)
         .refine(
             (key) => {
-                return /^[._a-z]*$/.test(key);
+                return /^[._a-zA-Z]*$/.test(key);
             },
             {
-                message: "Variable key must only contain letters from a-z, '.' and '_' without any spaces",
+                message: "Variable key must only contain letters from a-z, A-Z, '.' and '_' without any spaces",
             },
         ),
     name: string().min(1).max(80),
@@ -108,10 +108,10 @@ const automationActionSchema = object({
         .max(80)
         .refine(
             (id) => {
-                return /^[_a-z]*$/.test(id);
+                return /^[_a-zA-Z]*$/.test(id);
             },
             {
-                message: "Automation action id must only contain letters from a-z and '_' without any spaces",
+                message: "Automation action id must only contain letters from a-z, A-Z, and '_' without any spaces",
             },
         )
         .refine(
@@ -151,10 +151,10 @@ const automationTriggerSchema = object({
         .max(80)
         .refine(
             (id) => {
-                return /^[_a-z]*$/.test(id);
+                return /^[_a-zA-Z]*$/.test(id);
             },
             {
-                message: "Automation trigger id must only contain letters from a-z and '_' without any spaces",
+                message: "Automation trigger id must only contain letters from a-z, A-Z, and '_' without any spaces",
             },
         )
         .refine(

--- a/packages/cli/src/utils/verifyManifest.ts
+++ b/packages/cli/src/utils/verifyManifest.ts
@@ -73,6 +73,108 @@ const endpointCallSchema = object({
     options: requestOptionsSchema,
 });
 
+const variableTypes = z.enum([
+    'STRING',
+    'NUMBER',
+    'URL',
+    'EMAIL',
+    'BOOLEAN',
+    'DATE',
+    'OPTIONS',
+    'USER',
+    'CUSTOM_METADATA_PROPERTY',
+    'WORKFLOW_TASK_STATUS',
+]);
+const variablesSchema = object({
+    key: string()
+        .min(1)
+        .max(80)
+        .refine(
+            (key) => {
+                return /^[._a-z]*$/.test(key);
+            },
+            {
+                message: "Variable key must only contain letters from a-z, '.' and '_' without any spaces",
+            },
+        ),
+    name: string().min(1).max(80),
+    type: variableTypes,
+});
+
+const actionIdSet = new Set();
+const automationActionSchema = object({
+    id: string()
+        .min(1)
+        .max(80)
+        .refine(
+            (id) => {
+                return /^[_a-z]*$/.test(id);
+            },
+            {
+                message: "Automation action id must only contain letters from a-z and '_' without any spaces",
+            },
+        )
+        .refine(
+            (id) => {
+                if (actionIdSet.has(id)) {
+                    return false;
+                }
+
+                actionIdSet.add(id);
+                return true;
+            },
+            {
+                message: 'Automation action id must be unique',
+            },
+        ),
+    name: string().min(1).max(80),
+    workflowId: string()
+        .min(15)
+        .max(15)
+        .refine(
+            (workflowId) => {
+                return /^\w+$/.test(workflowId);
+            },
+            {
+                message:
+                    "Workflow Id must be unique and should only contain letters from a-z, A-Z, numbers from 0-9 and '_' without any spaces",
+            },
+        ),
+    description: string().optional(),
+    variables: array(variablesSchema),
+});
+
+const triggerIdSet = new Set();
+const automationTriggerSchema = object({
+    id: string()
+        .min(1)
+        .max(80)
+        .refine(
+            (id) => {
+                return /^[_a-z]*$/.test(id);
+            },
+            {
+                message: "Automation trigger id must only contain letters from a-z and '_' without any spaces",
+            },
+        )
+        .refine(
+            (id) => {
+                if (triggerIdSet.has(id)) {
+                    return false;
+                }
+
+                triggerIdSet.add(id);
+                return true;
+            },
+            {
+                message: 'Automation trigger id must be unique',
+            },
+        ),
+    name: string().min(1).max(80),
+    description: string().optional(),
+    variables: array(variablesSchema),
+});
+
 const hostnameRegex =
     /^(([\dA-Za-z]|[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z])\.)*([\dA-Za-z]|[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z])$/;
 
@@ -197,6 +299,10 @@ export const platformAppManifestSchemaV1 = object({
                 ),
             }).optional(),
             assetCreation: assetCreationShape,
+        }).optional(),
+        automation: object({
+            actions: array(automationActionSchema).optional(),
+            triggers: array(automationTriggerSchema).optional(),
         }).optional(),
     }).optional(),
     metadata: object({

--- a/packages/cli/tests/utils/verifyManifest.spec.ts
+++ b/packages/cli/tests/utils/verifyManifest.spec.ts
@@ -26,7 +26,7 @@ const VALID_MANIFEST = {
         automation: {
             actions: [
                 {
-                    id: 'set_asset_title',
+                    id: 'setAssetTitle',
                     name: 'Set asset title',
                     variables: [
                         {
@@ -41,7 +41,7 @@ const VALID_MANIFEST = {
             ],
             triggers: [
                 {
-                    id: 'assets_created',
+                    id: 'assetsCreated',
                     name: 'Assets created',
                     variables: [
                         {
@@ -318,12 +318,12 @@ const MANIFEST_WITH_DUPLICATE_ACTION_IDS = {
         automation: {
             actions: [
                 {
-                    id: 'set_asset_title',
+                    id: 'setAssetTitle',
                     name: 'Set asset title',
                     workflowId: '7DQ92y5AldGBwZ3',
                 },
                 {
-                    id: 'set_asset_title',
+                    id: 'setAssetTitle',
                     name: 'Set asset title duplicate',
                     workflowId: '7DQ92y5AldGBwZ3',
                 },
@@ -342,7 +342,7 @@ const MANIFEST_WITH_INVALID_VARIABLE_TYPE = {
         automation: {
             actions: [
                 {
-                    id: 'set_asset_title',
+                    id: 'setAssetTitle',
                     name: 'Set asset title',
                     workflowId: '7DQ92y5AldGBwZ3',
                     variables: [

--- a/packages/cli/tests/utils/verifyManifest.spec.ts
+++ b/packages/cli/tests/utils/verifyManifest.spec.ts
@@ -24,40 +24,36 @@ const VALID_MANIFEST = {
             },
         },
         automation: {
-            actions: [
-                {
-                    id: 'setAssetTitle',
+            actions: {
+                setAssetTitle: {
                     name: 'Set asset title',
-                    variables: [
-                        {
-                            key: 'asset.title',
+                    variables: {
+                        title: {
                             name: 'Asset title',
                             type: 'STRING',
                         },
-                    ],
-                    workflowId: '7DQ92y5AldGBwZ3',
+                    },
+                    workflowId: '7DQ92y5AldGBwZ34',
                     description: 'Changes the title of an asset',
                 },
-            ],
-            triggers: [
-                {
-                    id: 'assetsCreated',
+            },
+            triggers: {
+                assetsCreated: {
                     name: 'Assets created',
-                    variables: [
-                        {
+                    variables: {
+                        id: {
                             key: 'asset.id',
                             name: 'Asset Id',
                             type: 'NUMBER',
                         },
-                        {
-                            key: 'asset.title',
+                        title: {
                             name: 'Asset title',
                             type: 'STRING',
                         },
-                    ],
+                    },
                     description: 'Triggered when assets are created',
                 },
-            ],
+            },
         },
     },
     metadata: {
@@ -311,49 +307,23 @@ const MANIFEST_WITH_SECRET_BUT_NO_LABEL = {
     },
 };
 
-const MANIFEST_WITH_DUPLICATE_ACTION_IDS = {
-    appType: 'platform-app',
-    appId: 'abcdabcdabcdabcdabcdabcda',
-    surfaces: {
-        automation: {
-            actions: [
-                {
-                    id: 'setAssetTitle',
-                    name: 'Set asset title',
-                    workflowId: '7DQ92y5AldGBwZ3',
-                },
-                {
-                    id: 'setAssetTitle',
-                    name: 'Set asset title duplicate',
-                    workflowId: '7DQ92y5AldGBwZ3',
-                },
-            ],
-        },
-    },
-    metadata: {
-        version: 1,
-    },
-};
-
 const MANIFEST_WITH_INVALID_VARIABLE_TYPE = {
     appType: 'platform-app',
     appId: 'abcdabcdabcdabcdabcdabcda',
     surfaces: {
         automation: {
-            actions: [
-                {
-                    id: 'setAssetTitle',
+            actions: {
+                setAssetTitle: {
                     name: 'Set asset title',
-                    workflowId: '7DQ92y5AldGBwZ3',
-                    variables: [
-                        {
-                            key: 'asset.title',
+                    workflowId: '7DQ92y5AldGBwZ32',
+                    variables: {
+                        title: {
                             name: 'Asset title',
                             type: 'VARCHAR',
                         },
-                    ],
+                    },
                 },
-            ],
+            },
         },
     },
     metadata: {
@@ -957,11 +927,9 @@ describe('Verify Platform App Manifest', () => {
         ).toThrow();
     });
 
-    it('should detect when automation action ids are not unique', () => {
-        expect(() => verifyManifest(MANIFEST_WITH_DUPLICATE_ACTION_IDS, platformAppManifestSchemaV1)).toThrow('Automation action id must be unique');
-    });
-
     it('should detect when action variables have invalid types ', () => {
-        expect(() => verifyManifest(MANIFEST_WITH_INVALID_VARIABLE_TYPE, platformAppManifestSchemaV1)).toThrow('VARCHAR');
+        expect(() => verifyManifest(MANIFEST_WITH_INVALID_VARIABLE_TYPE, platformAppManifestSchemaV1)).toThrow(
+            'VARCHAR',
+        );
     });
 });

--- a/packages/cli/tests/utils/verifyManifest.spec.ts
+++ b/packages/cli/tests/utils/verifyManifest.spec.ts
@@ -23,6 +23,42 @@ const VALID_MANIFEST = {
                 title: 'action title',
             },
         },
+        automation: {
+            actions: [
+                {
+                    id: 'set_asset_title',
+                    name: 'Set asset title',
+                    variables: [
+                        {
+                            key: 'asset.title',
+                            name: 'Asset title',
+                            type: 'STRING',
+                        },
+                    ],
+                    workflowId: '7DQ92y5AldGBwZ3',
+                    description: 'Changes the title of an asset',
+                },
+            ],
+            triggers: [
+                {
+                    id: 'assets_created',
+                    name: 'Assets created',
+                    variables: [
+                        {
+                            key: 'asset.id',
+                            name: 'Asset Id',
+                            type: 'NUMBER',
+                        },
+                        {
+                            key: 'asset.title',
+                            name: 'Asset title',
+                            type: 'STRING',
+                        },
+                    ],
+                    description: 'Triggered when assets are created',
+                },
+            ],
+        },
     },
     metadata: {
         version: 1,
@@ -268,6 +304,56 @@ const MANIFEST_WITH_SECRET_BUT_NO_LABEL = {
             assetCreation: {
                 title: 'action title',
             },
+        },
+    },
+    metadata: {
+        version: 1,
+    },
+};
+
+const MANIFEST_WITH_DUPLICATE_ACTION_IDS = {
+    appType: 'platform-app',
+    appId: 'abcdabcdabcdabcdabcdabcda',
+    surfaces: {
+        automation: {
+            actions: [
+                {
+                    id: 'set_asset_title',
+                    name: 'Set asset title',
+                    workflowId: '7DQ92y5AldGBwZ3',
+                },
+                {
+                    id: 'set_asset_title',
+                    name: 'Set asset title duplicate',
+                    workflowId: '7DQ92y5AldGBwZ3',
+                },
+            ],
+        },
+    },
+    metadata: {
+        version: 1,
+    },
+};
+
+const MANIFEST_WITH_INVALID_VARIABLE_TYPE = {
+    appType: 'platform-app',
+    appId: 'abcdabcdabcdabcdabcdabcda',
+    surfaces: {
+        automation: {
+            actions: [
+                {
+                    id: 'set_asset_title',
+                    name: 'Set asset title',
+                    workflowId: '7DQ92y5AldGBwZ3',
+                    variables: [
+                        {
+                            key: 'asset.title',
+                            name: 'Asset title',
+                            type: 'VARCHAR',
+                        },
+                    ],
+                },
+            ],
         },
     },
     metadata: {
@@ -869,5 +955,13 @@ describe('Verify Platform App Manifest', () => {
         expect(() =>
             verifyManifest(INVALID_MANIFEST_NETWORK_ALLOWED_HOST_UNDESCORE, platformAppManifestSchemaV1),
         ).toThrow();
+    });
+
+    it('should detect when automation action ids are not unique', () => {
+        expect(() => verifyManifest(MANIFEST_WITH_DUPLICATE_ACTION_IDS, platformAppManifestSchemaV1)).toThrow('Automation action id must be unique');
+    });
+
+    it('should detect when action variables have invalid types ', () => {
+        expect(() => verifyManifest(MANIFEST_WITH_INVALID_VARIABLE_TYPE, platformAppManifestSchemaV1)).toThrow('VARCHAR');
     });
 });

--- a/packages/platform-app/src/platformApps.ts
+++ b/packages/platform-app/src/platformApps.ts
@@ -44,10 +44,18 @@ export type PlatformAppSimpleBlock =
 export type PlatformAppSettings = PlatformAppSimpleBlock | DynamicSettingBlock<AppBridgePlatformApp>;
 
 export type PlatformAppSettingsStructureExport = { [customSectionName: string]: PlatformAppSettings[] };
+export type PlatformAppMultiSettingsStructureExport = {
+    default: PlatformAppSettingsStructureExport;
+    automation?: {
+        actions?: {
+            [customActionId: string]: PlatformAppSettingsStructureExport;
+        };
+    };
+};
 
 export type PlatformAppConfigExport = {
     app: FC;
-    settings: PlatformAppSettingsStructureExport;
+    settings: PlatformAppMultiSettingsStructureExport | PlatformAppSettingsStructureExport;
 };
 
 /**


### PR DESCRIPTION
The changes include:

* Manifest validation for automations (incl. Actions | Triggers with Variables)
* Support for Automation settings (by allowing to have multiple `PlatformAppSettingsStructureExport` in the settings object)

**Manifest validation**
Currently the automations surface definition has not been validated (unknowns are just bypassed). With the addition to the `verifyManifest.ts `, we make sure that the automation surface definition adheres to the schema.

**Support for Automation settings**
We iterated on the solution together with @getflourish and @olivereisenhut. The current approach is very flexible, allowing to add further settings (e.g. for project, libraries or brand-level settings) easily without the need to adjust the bundler or add additional parameters to the `defineApp`method. This makes it easier to evolve app settings in the future, which was also a wish from @SamuelAlev.

Please note: the changes to the `packages/platform-app/src/platformApps.ts` require changes in the `web-app` in order to work and provide the right default settings (e.g. in the marketplace).