### PR TITLE
feat: add context instead of single contexts

### DIFF
--- a/.changeset/thirty-chicken-play.md
+++ b/.changeset/thirty-chicken-play.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge-app": patch
+---
+
+feat: add context instead of single contexts

--- a/packages/app-bridge-app/src/react/appContext.ts
+++ b/packages/app-bridge-app/src/react/appContext.ts
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { AppBridgePlatformApp, type AssetActionContext, type AssetCreationContext } from '../AppBridgePlatformApp.ts';
+import { AppBridgePlatformApp, type PlatformAppContext } from '../AppBridgePlatformApp.ts';
 
 /**
  * This function just helps to get the Context
  */
-export const appContext = <T extends AssetActionContext | AssetCreationContext>(): T => {
+export const appContext = <T extends PlatformAppContext>(): T => {
     const appBridge = new AppBridgePlatformApp();
     return appBridge.context().get() as T;
 };


### PR DESCRIPTION
-> uses the platformAppContext instead of the single contexts to help with typing.