### PR TITLE
feat(sidebar-settings): add optional aria-label to Choice type

### DIFF
--- a/packages/sidebar-settings/src/blocks/choices.ts
+++ b/packages/sidebar-settings/src/blocks/choices.ts
@@ -8,9 +8,14 @@ import { type IconEnum } from '.';
 
 export type Choice = {
     /**
-     * The label of the item.
+     * The text label of the item.
      */
     label?: string | number;
+
+    /**
+     * The aria label of the item.
+     */
+    ariaLabel?: string;
 
     /**
      * The icon of the item.


### PR DESCRIPTION
This is done to enable having segmented controls choices with only an icon and no text label. In such case, aria-label must be present to ensure accessibility compliance.

[CU-8698nzzxe](https://app.clickup.com/t/8698nzzxe)
