### PR TITLE
fix: Revert "feat(sidebar-settings): add optional aria-label to Choice type"

### DIFF
--- a/.changeset/eight-candles-agree.md
+++ b/.changeset/eight-candles-agree.md
@@ -1,5 +1,0 @@
----
-"@frontify/sidebar-settings": patch
----
-
-add optional ariaLabel to Choice type

--- a/packages/sidebar-settings/src/blocks/choices.ts
+++ b/packages/sidebar-settings/src/blocks/choices.ts
@@ -8,14 +8,9 @@ import { type IconEnum } from '.';
 
 export type Choice = {
     /**
-     * The text label of the item.
+     * The label of the item.
      */
     label?: string | number;
-
-    /**
-     * The aria label of the item.
-     */
-    ariaLabel?: string;
 
     /**
      * The icon of the item.


### PR DESCRIPTION
Reverts Frontify/brand-sdk#1194