### PR TITLE
feat: introduce state to AppBridgeTheme

### DIFF
--- a/.changeset/strange-radios-bow.md
+++ b/.changeset/strange-radios-bow.md
@@ -1,0 +1,5 @@
+---
+"@frontify/app-bridge-theme": patch
+---
+
+Introduced a State for AppBridgeTheme

--- a/.changeset/strange-radios-bow.md
+++ b/.changeset/strange-radios-bow.md
@@ -2,4 +2,4 @@
 "@frontify/app-bridge-theme": patch
 ---
 
-Introduced a State for AppBridgeTheme
+feat: Introduced a State for AppBridgeTheme

--- a/packages/app-bridge-theme/src/AppBridgeTheme.ts
+++ b/packages/app-bridge-theme/src/AppBridgeTheme.ts
@@ -10,6 +10,8 @@ import {
     type EventNameParameter,
     type EventUnsubscribeFunction,
     type GuidelineSearchResult,
+    type State,
+    type StateReturn,
 } from './types';
 
 export interface AppBridgeTheme {
@@ -20,6 +22,10 @@ export interface AppBridgeTheme {
     context(): ContextReturn<Context, void>;
     context<Key extends keyof Context>(key: Key): ContextReturn<Context, Key>;
     context(key?: keyof Context | void): unknown;
+
+    state(): StateReturn<State, void>;
+    state<Key extends keyof State>(key: Key): StateReturn<State, Key>;
+    state(key?: keyof State | void): unknown;
 
     subscribe<EventName extends keyof AppBridgeThemeEvent>(
         eventName: EventNameParameter<EventName, AppBridgeThemeEvent>,

--- a/packages/app-bridge-theme/src/types/State.ts
+++ b/packages/app-bridge-theme/src/types/State.ts
@@ -1,0 +1,42 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type EventUnsubscribeFunction } from './Event.ts';
+
+export type State = {
+    /**
+     * The total height of any sticky elements at the top of the document in pixels.
+     */
+    scrollTopOffset: number;
+};
+
+export type StateReturn<State, Key> = Key extends keyof State
+    ? {
+          /**
+           * Gets the current value of the state object at the given key.
+           */
+          get(): Readonly<State[Key]>;
+          /**
+           * Sets a new value of the state object at the given key.
+           */
+          set(nextState: State[Key]): void;
+          /**
+           * Subscribes to changes in the state object at the given key.
+           */
+          subscribe(
+              callbackFunction: (nextState: State[Key], previousState: State[Key]) => void,
+          ): EventUnsubscribeFunction;
+      }
+    : {
+          /**
+           * Gets the current value of the state object.
+           */
+          get(): Readonly<State>;
+          /**
+           * Sets a new value of the state object.
+           */
+          set(nextState: State): void;
+          /**
+           * Subscribes to changes in the state object.
+           */
+          subscribe(callbackFunction: (nextState: State, previousState: State) => void): EventUnsubscribeFunction;
+      };

--- a/packages/app-bridge-theme/src/types/index.ts
+++ b/packages/app-bridge-theme/src/types/index.ts
@@ -8,4 +8,5 @@ export * from './Event';
 export * from './Guideline';
 export * from './GuidelineSearchResult';
 export * from './Language';
+export * from './State';
 export * from './ThemeTemplate';


### PR DESCRIPTION
This will enable theme developers to store the height of any sticky elements on top of the page. The sticky elements' size is needed in web-app for properly being able to determine when a heading is in view and to be able to reliably scroll a heading to the top of the content area.