### PR TITLE
refactor(RTE): always use a randomized id

### DIFF
--- a/.changeset/curvy-mirrors-pay.md
+++ b/.changeset/curvy-mirrors-pay.md
@@ -2,4 +2,4 @@
 "@frontify/guideline-blocks-settings": patch
 ---
 
-refactor(RTE): always use a randomized ID for the RTE
+refactor(RTE): deprecated id prop, `useId` for unique editor ID

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/RichTextEditor.tsx
@@ -12,7 +12,6 @@ import { type RichTextEditorProps } from './types';
 
 const InternalRichTextEditor = memo(
     ({
-        id = 'rte',
         isEnabled,
         value,
         columns,
@@ -24,7 +23,7 @@ const InternalRichTextEditor = memo(
     }: Omit<RichTextEditorProps, 'isEditing'> & { isEnabled: boolean }) => {
         const customClass = getResponsiveColumnClasses(columns);
         const [shouldPreventPageLeave, setShouldPreventPageLeave] = useState(false);
-        const randomizedId = useId() + id;
+        const editorId = useId();
 
         const handleTextChange = useCallback(
             (newContent: string) => {
@@ -60,7 +59,7 @@ const InternalRichTextEditor = memo(
         if (isEnabled) {
             return (
                 <FondueRichTextEditor
-                    id={randomizedId}
+                    id={editorId}
                     value={value}
                     border={false}
                     placeholder={placeholder}

--- a/packages/guideline-blocks-settings/src/components/RichTextEditor/types.ts
+++ b/packages/guideline-blocks-settings/src/components/RichTextEditor/types.ts
@@ -3,6 +3,9 @@
 import { type PluginComposer } from '@frontify/fondue';
 
 export type RichTextEditorProps = {
+    /**
+     * @deprecated not needed anymore, handled automatically
+     */
     id?: string;
     isEditing: boolean;
     value?: string;


### PR DESCRIPTION
This way we make it easier for our partners as they don't need to care about if the ID is only once per page which is needed to make it work properly in the long run we should remove the id prop for this one anyway.

@fulopdaniel do you see any issue in doing this? 

Coming from this end: https://app.clickup.com/t/2523021/TASK-15013