### PR TITLE
fix: better logs on deploy error

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -145,7 +145,13 @@ export const createDeployment = async (
             }
         }
     } catch (error) {
-        Logger.error('The deployment has failed and was aborted due to an error:', error as string);
+        if (typeof error === 'string') {
+            Logger.error('The deployment has failed and was aborted due to an error:', error);
+        } else if (error instanceof Error) {
+            Logger.error('The deployment has failed and was aborted due to an error:', error.message);
+        } else {
+            Logger.error('The deployment has failed and was aborted due to an unknown error.');
+        }
         process.exit(-1);
     }
 };


### PR DESCRIPTION
We are getting this error for a client trying to deploy a new Theme. The error doesn't help much. Let's show a better message depending on what's there.

```
 The deployment has failed and was aborted due to an error: TypeError: Cannot read properties of undefined (reading 'error')
 ```
 
**Note for reviewers**: if you think it's not needed feel free to close the PR