### PR TITLE
refactor(Attachments): replace legacy fondue components

### DIFF
--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -14,9 +14,9 @@ import {
 import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable';
 import { type Asset, useAssetChooser, useAssetUpload, useEditorState } from '@frontify/app-bridge';
-import { AssetInput, AssetInputSize, Flyout, FlyoutPlacement } from '@frontify/fondue';
-import { Tooltip } from '@frontify/fondue/components';
-import { type MutableRefObject, useEffect, useState } from 'react';
+import { AssetInput, AssetInputSize } from '@frontify/fondue';
+import { Tooltip, Flyout } from '@frontify/fondue/components';
+import { useEffect, useState } from 'react';
 
 import { AttachmentItem, SortableAttachmentItem } from './AttachmentItem';
 import { AttachmentsButtonTrigger } from './AttachmentsButtonTrigger';
@@ -141,88 +141,82 @@ export const Attachments = ({
         <Tooltip.Root enterDelay={500}>
             <Tooltip.Trigger asChild>
                 <div data-test-id="attachments-flyout-button">
-                    <Flyout
-                        placement={FlyoutPlacement.BottomRight}
+                    <Flyout.Root
+                        open={isFlyoutOpen}
                         onOpenChange={(isOpen) => handleFlyoutOpenChange(draggedItem ? true : isOpen)}
-                        isOpen={isFlyoutOpen}
-                        hug={false}
-                        fitContent
-                        legacyFooter={false}
-                        trigger={(triggerProps, triggerRef) => (
-                            <TriggerComponent
-                                isFlyoutOpen={isFlyoutOpen}
-                                triggerProps={triggerProps}
-                                triggerRef={triggerRef as MutableRefObject<HTMLButtonElement>}
-                            >
+                    >
+                        <Flyout.Trigger asChild>
+                            <TriggerComponent isFlyoutOpen={isFlyoutOpen}>
                                 <div>{items.length > 0 ? items.length : 'Add'}</div>
                             </TriggerComponent>
-                        )}
-                    >
-                        <div className="tw-w-[300px]" data-test-id="attachments-flyout-content">
-                            {internalItems.length > 0 && (
-                                <DndContext
-                                    sensors={sensors}
-                                    collisionDetection={closestCenter}
-                                    onDragStart={handleDragStart}
-                                    onDragEnd={handleDragEnd}
-                                    modifiers={[restrictToWindowEdges]}
-                                >
-                                    <SortableContext items={internalItems} strategy={rectSortingStrategy}>
-                                        <div className="tw-border-b tw-border-b-line">
-                                            {internalItems.map((item) => (
-                                                <SortableAttachmentItem
+                        </Flyout.Trigger>
+                        <Flyout.Content side="bottom" align="end">
+                            <div className="tw-w-[300px]" data-test-id="attachments-flyout-content">
+                                {internalItems.length > 0 && (
+                                    <DndContext
+                                        sensors={sensors}
+                                        collisionDetection={closestCenter}
+                                        onDragStart={handleDragStart}
+                                        onDragEnd={handleDragEnd}
+                                        modifiers={[restrictToWindowEdges]}
+                                    >
+                                        <SortableContext items={internalItems} strategy={rectSortingStrategy}>
+                                            <div className="tw-border-b tw-border-b-line">
+                                                {internalItems.map((item) => (
+                                                    <SortableAttachmentItem
+                                                        isEditing={isEditing}
+                                                        isLoading={assetIdsLoading.includes(item.id)}
+                                                        key={item.id}
+                                                        item={item}
+                                                        onDelete={() => onDelete(item)}
+                                                        onReplaceWithBrowse={() => onReplaceItemWithBrowse(item)}
+                                                        onReplaceWithUpload={(uploadedAsset: Asset) =>
+                                                            onReplaceItemWithUpload(item, uploadedAsset)
+                                                        }
+                                                        onDownload={() =>
+                                                            appBridge.dispatch({
+                                                                name: 'downloadAsset',
+                                                                payload: item,
+                                                            })
+                                                        }
+                                                    />
+                                                ))}
+                                            </div>
+                                        </SortableContext>
+                                        <DragOverlay>
+                                            {draggedItem && (
+                                                <AttachmentItem
+                                                    isOverlay={true}
                                                     isEditing={isEditing}
-                                                    isLoading={assetIdsLoading.includes(item.id)}
-                                                    key={item.id}
-                                                    item={item}
-                                                    onDelete={() => onDelete(item)}
-                                                    onReplaceWithBrowse={() => onReplaceItemWithBrowse(item)}
+                                                    key={draggedAssetId}
+                                                    item={draggedItem}
+                                                    isDragging={true}
+                                                    onDelete={() => onDelete(draggedItem)}
+                                                    onReplaceWithBrowse={() => onReplaceItemWithBrowse(draggedItem)}
                                                     onReplaceWithUpload={(uploadedAsset: Asset) =>
-                                                        onReplaceItemWithUpload(item, uploadedAsset)
-                                                    }
-                                                    onDownload={() =>
-                                                        appBridge.dispatch({
-                                                            name: 'downloadAsset',
-                                                            payload: item,
-                                                        })
+                                                        onReplaceItemWithUpload(draggedItem, uploadedAsset)
                                                     }
                                                 />
-                                            ))}
+                                            )}
+                                        </DragOverlay>
+                                    </DndContext>
+                                )}
+                                {isEditing && (
+                                    <div className="tw-px-5 tw-py-3">
+                                        <div className="tw-font-body tw-font-medium tw-text-text tw-text-s tw-my-4">
+                                            Add attachments
                                         </div>
-                                    </SortableContext>
-                                    <DragOverlay>
-                                        {draggedItem && (
-                                            <AttachmentItem
-                                                isOverlay={true}
-                                                isEditing={isEditing}
-                                                key={draggedAssetId}
-                                                item={draggedItem}
-                                                isDragging={true}
-                                                onDelete={() => onDelete(draggedItem)}
-                                                onReplaceWithBrowse={() => onReplaceItemWithBrowse(draggedItem)}
-                                                onReplaceWithUpload={(uploadedAsset: Asset) =>
-                                                    onReplaceItemWithUpload(draggedItem, uploadedAsset)
-                                                }
-                                            />
-                                        )}
-                                    </DragOverlay>
-                                </DndContext>
-                            )}
-                            {isEditing && (
-                                <div className="tw-px-5 tw-py-3">
-                                    <div className="tw-font-body tw-font-medium tw-text-text tw-text-s tw-my-4">
-                                        Add attachments
+                                        <AssetInput
+                                            isLoading={isUploadLoading}
+                                            size={AssetInputSize.Small}
+                                            onUploadClick={(fileList) => setSelectedFiles(fileList)}
+                                            onLibraryClick={onOpenAssetChooser}
+                                        />
                                     </div>
-                                    <AssetInput
-                                        isLoading={isUploadLoading}
-                                        size={AssetInputSize.Small}
-                                        onUploadClick={(fileList) => setSelectedFiles(fileList)}
-                                        onLibraryClick={onOpenAssetChooser}
-                                    />
-                                </div>
-                            )}
-                        </div>
-                    </Flyout>
+                                )}
+                            </div>
+                        </Flyout.Content>
+                    </Flyout.Root>
                 </div>
             </Tooltip.Trigger>
             <Tooltip.Content side="top">Attachments</Tooltip.Content>

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
@@ -1,30 +1,30 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { IconCaretDown12, IconPaperclip16 } from '@frontify/fondue';
+import { forwardRef } from 'react';
 
 import { joinClassNames } from '../../utilities';
 
 import { type AttachmentsTriggerProps } from './types';
 
-export const AttachmentsButtonTrigger = ({
-    children,
-    isFlyoutOpen,
-    triggerProps,
-    triggerRef,
-}: AttachmentsTriggerProps) => (
-    <button
-        className={joinClassNames([
-            'tw-flex tw-text-xs tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-outline tw-outline-1 tw-outline-offset-1 tw-p-1.5 tw-outline-line',
-            isFlyoutOpen
-                ? 'tw-bg-box-neutral-pressed tw-text-box-neutral-inverse-pressed'
-                : 'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-text-box-neutral-inverse hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
-        ])}
-        {...triggerProps}
-        ref={triggerRef}
-        data-test-id="attachments-button-trigger"
-    >
-        <IconPaperclip16 />
-        {children}
-        <IconCaretDown12 />
-    </button>
+export const AttachmentsButtonTrigger = forwardRef<HTMLButtonElement, AttachmentsTriggerProps>(
+    ({ children, isFlyoutOpen, ...props }, ref) => (
+        <button
+            ref={ref}
+            className={joinClassNames([
+                'tw-flex tw-text-xs tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-outline tw-outline-1 tw-outline-offset-1 tw-p-1.5 tw-outline-line',
+                isFlyoutOpen
+                    ? 'tw-bg-box-neutral-pressed tw-text-box-neutral-inverse-pressed'
+                    : 'tw-bg-base hover:tw-bg-box-neutral-hover active:tw-bg-box-neutral-pressed tw-text-box-neutral-inverse hover:tw-text-box-neutral-inverse-hover active:tw-text-box-neutral-inverse-pressed',
+            ])}
+            data-test-id="attachments-button-trigger"
+            {...props}
+        >
+            <IconPaperclip16 />
+            {children}
+            <IconCaretDown12 />
+        </button>
+    ),
 );
+
+AttachmentsButtonTrigger.displayName = 'AttachmentsButtonTrigger';

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -1,13 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { type AppBridgeBlock, type Asset } from '@frontify/app-bridge';
-import { type HTMLAttributes, type MutableRefObject, type ReactElement, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 export type AttachmentsTriggerProps = {
     children: ReactNode;
     isFlyoutOpen: boolean;
-    triggerProps: HTMLAttributes<HTMLButtonElement>;
-    triggerRef: MutableRefObject<HTMLButtonElement>;
 };
 
 export type AttachmentsProps = {
@@ -19,7 +17,9 @@ export type AttachmentsProps = {
     onUpload: (uploadedAttachments: Asset[]) => Promise<void>;
     onBrowse: (browserAttachments: Asset[]) => void;
     onSorted: (sortedAttachments: Asset[]) => void;
-    triggerComponent?: (props: AttachmentsTriggerProps) => ReactElement;
+    triggerComponent?: React.ForwardRefExoticComponent<
+        AttachmentsTriggerProps & React.RefAttributes<HTMLButtonElement>
+    >;
 } & ({ isOpen?: never; onOpenChange?: never } | { isOpen: boolean; onOpenChange: (isOpen: boolean) => void });
 
 export type AttachmentItemProps = SortableAttachmentItemProps & {

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/AttachmentsToolbarButton/AttachmentsToolbarButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/AttachmentsToolbarButton/AttachmentsToolbarButtonTrigger.tsx
@@ -1,24 +1,24 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { IconCaretDown12, IconPaperclip16 } from '@frontify/fondue';
+import { forwardRef } from 'react';
 
 import { type AttachmentsTriggerProps } from '../../../Attachments/types';
 import { BaseToolbarButton } from '../BaseToolbarButton';
 
-export const AttachmentsToolbarButtonTrigger = ({
-    children,
-    isFlyoutOpen,
-    triggerProps,
-    triggerRef,
-}: AttachmentsTriggerProps) => (
-    <BaseToolbarButton
-        forceActiveStyle={isFlyoutOpen}
-        data-test-id="attachments-toolbar-button-trigger"
-        {...triggerProps}
-        ref={triggerRef}
-    >
-        <IconPaperclip16 />
-        {children}
-        <IconCaretDown12 />
-    </BaseToolbarButton>
+export const AttachmentsToolbarButtonTrigger = forwardRef<HTMLButtonElement, AttachmentsTriggerProps>(
+    ({ children, isFlyoutOpen, ...props }, ref) => (
+        <BaseToolbarButton
+            forceActiveStyle={isFlyoutOpen}
+            data-test-id="attachments-toolbar-button-trigger"
+            ref={ref}
+            {...props}
+        >
+            <IconPaperclip16 />
+            {children}
+            <IconCaretDown12 />
+        </BaseToolbarButton>
+    ),
 );
+
+AttachmentsToolbarButtonTrigger.displayName = 'AttachmentsToolbarButtonTrigger';


### PR DESCRIPTION
BREAKING CHANGES:
`Attachments.tsx` => `triggerComponent` type changed to ` triggerComponent?: React.ForwardRefExoticComponent<
        AttachmentsTriggerProps & React.RefAttributes<HTMLButtonElement>
    >;`
    
    
Changeset will be bumped by 1 major once all legacy components are replaced