### PR TITLE
refactor: remove the visibility property from documents and pages

### DIFF
--- a/.changeset/fifty-rice-call.md
+++ b/.changeset/fifty-rice-call.md
@@ -1,0 +1,6 @@
+---
+"@frontify/guideline-blocks-settings": patch
+"@frontify/app-bridge": patch
+---
+
+chore: remove empty visibility property from Document and DocumentPage type definitions

--- a/packages/app-bridge/src/AppBridgeTheme.ts
+++ b/packages/app-bridge/src/AppBridgeTheme.ts
@@ -252,7 +252,6 @@ export interface AppBridgeTheme<
      * @property  title - Indicates title of a page.
      * @property  documentId - Indicates to witch document the page belongs to.
      * @property  categoryId - Indicates to witch category the page belongs to.
-     * @property  visibility - Indicates whether the page is visible only to the editor or everyone.
      * @property  linkUrl - Indicates whether the page is link or not.
      */
     updateDocumentPage(documentPage: DocumentPageUpdate): Promise<DocumentPage>;

--- a/packages/app-bridge/src/react/useGuidelineActions.ts
+++ b/packages/app-bridge/src/react/useGuidelineActions.ts
@@ -282,7 +282,6 @@ export const useGuidelineActions = (appBridge: AppBridgeTheme) => {
      * @property  title - Indicates title of a page.
      * @property  documentId - Indicates to witch document the page belongs to.
      * @property  categoryId - Indicates to witch category the page belongs to.
-     * @property  visibility - Indicates whether the page is visible only to the editor or everyone.
      * @property  linkUrl - Indicates whether the page is link or not.
      */
     const updateDocumentPage = useCallback(

--- a/packages/app-bridge/src/tests/DocumentApiDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentApiDummy.ts
@@ -13,7 +13,6 @@ export class DocumentApiDummy {
             project_id: 345,
             valid_from: '2022-03-03t15:41:33.000+00:00',
             valid_to: null,
-            visibility: 'private',
             portal_id: 3495,
             title: `Document ${id}`,
             slug: `document-${id}`,

--- a/packages/app-bridge/src/tests/DocumentPageApiDummy.ts
+++ b/packages/app-bridge/src/tests/DocumentPageApiDummy.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type DocumentPageApi, DocumentPageVisibility } from '../types';
+import { type DocumentPageApi } from '../types';
 
 export class DocumentPageApiDummy {
     static with(id: number): DocumentPageApi {
@@ -21,7 +21,6 @@ export class DocumentPageApiDummy {
             link_type: 'INTERNAL',
             link_url: null,
             view_count: 0,
-            visibility: DocumentPageVisibility.Everyone,
             targets: null,
             permanent_link: `/r/document-page-${id}`,
         };
@@ -44,7 +43,6 @@ export class DocumentPageDuplicateApiDummy {
                 name: 'Document page duplicate dummy',
                 sections: [],
                 url: `document-page-duplicate-dummy-${id}`,
-                visibility: 'EVERYONE',
             },
         };
     }

--- a/packages/app-bridge/src/types/Document.ts
+++ b/packages/app-bridge/src/types/Document.ts
@@ -54,7 +54,6 @@ export type DocumentApi = Simplify<
         document_group_id?: Nullable<number>;
         valid_from: string;
         valid_to: Nullable<string>;
-        visibility: Nullable<string>;
         portal_id: Nullable<number>;
         title: string;
         slug: Nullable<string>;

--- a/packages/app-bridge/src/types/DocumentPage.ts
+++ b/packages/app-bridge/src/types/DocumentPage.ts
@@ -4,11 +4,6 @@ import { type CamelCasedPropertiesDeep, type RequireAtLeastOne, type SetRequired
 
 import { type SingleTargetApi } from './Targets';
 
-export enum DocumentPageVisibility {
-    Everyone = 'EVERYONE',
-    Editor = 'EDITOR',
-}
-
 type DocumentPageApiAsLink = {
     link_type: 'EXTERNAL';
     link_url: string;
@@ -34,7 +29,6 @@ export type DocumentPageApi = {
     slug: string;
     sort: number;
     view_count: number;
-    visibility: DocumentPageVisibility;
     targets: Nullable<SingleTargetApi['target'][]>;
     category?: Nullable<Record<string, unknown>>;
     parent_document?: Nullable<Record<string, unknown>>;
@@ -51,14 +45,13 @@ type DocumentPageRequest = {
     documentId: number;
     linkUrl?: Nullable<string>;
     categoryId?: Nullable<number>;
-    visibility?: DocumentPageVisibility;
 };
 
 export type DocumentPageCreate = Omit<SetRequired<DocumentPageRequest, 'title' | 'documentId'>, 'id'>;
 
 export type DocumentPageUpdate = RequireAtLeastOne<
     DocumentPageRequest,
-    'documentId' | 'categoryId' | 'linkUrl' | 'title' | 'visibility'
+    'documentId' | 'categoryId' | 'linkUrl' | 'title'
 >;
 
 export type DocumentPageDelete = Pick<DocumentPageRequest, 'id' | 'documentId' | 'categoryId'>;

--- a/packages/guideline-blocks-settings/src/testing/dummies/DocumentPageApiDummy.ts
+++ b/packages/guideline-blocks-settings/src/testing/dummies/DocumentPageApiDummy.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { DocumentPageVisibility, type DocumentPageApi } from '@frontify/app-bridge';
+import { type DocumentPageApi } from '@frontify/app-bridge';
 
 enum LinkType {
     External = 'EXTERNAL',
@@ -37,7 +37,6 @@ type DocumentApi = {
     document_group_id?: number | null;
     valid_from: string;
     valid_to: string | null;
-    visibility: string | null;
     portal_id: number | null;
     title: string;
     slug: string | null;
@@ -88,7 +87,6 @@ export class DocumentApiDummy {
             project_id: 345,
             valid_from: '2022-03-03t15:41:33.000+00:00',
             valid_to: null,
-            visibility: 'private',
             portal_id: 3495,
             title: `Document ${id}`,
             slug: `document-${id}`,
@@ -137,7 +135,6 @@ export class DocumentPageApiDummy {
             link_type: 'INTERNAL',
             link_url: null,
             view_count: 0,
-            visibility: DocumentPageVisibility.Everyone,
             targets: null,
             permanent_link: `/r/document-page-${id}`,
         } as DocumentPageApi;


### PR DESCRIPTION
Removing the `visibility` property from `Document` and `DocumentPage`. As the property is never actually returned from our APIs, it is always `undefined` and we do not have any use case for it at the moment. This also removes a lie from our type definitions :-) 