### PR TITLE
chore(cli): remove nock dependency, use vitest mocks instead

### DIFF
--- a/.changeset/remove-nock-dependency.md
+++ b/.changeset/remove-nock-dependency.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+chore: remove nock dependency, use vitest mocks instead

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,6 @@
         "@vitest/ui": "^4.1.2",
         "eslint": "^9.39.4",
         "eslint-plugin-notice": "^1.0.0",
-        "nock": "^14.0.11",
         "prettier": "^3.7.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",

--- a/packages/cli/tests/utils/httpClient.spec.ts
+++ b/packages/cli/tests/utils/httpClient.spec.ts
@@ -1,61 +1,122 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import nock from 'nock';
-import { beforeAll, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { HttpClient } from '../../src/utils/httpClient';
 
 const BODY_OBJECT = { some: 'body', told: 'me' };
 const TEST_BASE_URL = 'testing.frontify.test';
 
+const mockFetch = vi.fn();
+
 describe('HttpClient utils', () => {
-    beforeAll(() => {
-        const testMockApi = nock(`https://${TEST_BASE_URL}`);
-        testMockApi.get('/api/get-test').reply(200);
-        testMockApi.post('/api/post-test-without-body').reply(200, BODY_OBJECT);
-        testMockApi.post('/api/post-test-with-body', BODY_OBJECT).reply(200, BODY_OBJECT);
-        testMockApi.put('/api/put-test-without-body').reply(200, BODY_OBJECT);
-        testMockApi.put('/api/put-test-with-body', BODY_OBJECT).reply(200, BODY_OBJECT);
-        testMockApi.delete('/api/delete-test').reply(200);
-        testMockApi.get('/api/error-400').reply(400);
-        testMockApi.get('/api/error-500').reply(500);
+    beforeEach(() => {
+        vi.stubGlobal('fetch', mockFetch);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     const httpClient = new HttpClient(TEST_BASE_URL);
 
     test('should make GET call and resolve the response', async () => {
+        mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+
         expect(await httpClient.get('/api/get-test')).toEqual(undefined);
+        expect(mockFetch).toHaveBeenCalledWith(
+            `https://${TEST_BASE_URL}/api/get-test`,
+            expect.objectContaining({ method: 'GET' }),
+        );
     });
 
     test('should make POST call with a body and resolve the response', async () => {
+        mockFetch.mockResolvedValue(
+            new Response(JSON.stringify(BODY_OBJECT), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
         expect(await httpClient.post('/api/post-test-with-body', BODY_OBJECT)).toEqual(BODY_OBJECT);
+        expect(mockFetch).toHaveBeenCalledWith(
+            `https://${TEST_BASE_URL}/api/post-test-with-body`,
+            expect.objectContaining({ method: 'POST', body: JSON.stringify(BODY_OBJECT) }),
+        );
     });
 
     test('should make POST call without body and resolve the response', async () => {
+        mockFetch.mockResolvedValue(
+            new Response(JSON.stringify(BODY_OBJECT), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
         expect(await httpClient.post('/api/post-test-without-body')).toEqual(BODY_OBJECT);
     });
 
     test('should make PUT call with a body and resolve the response', async () => {
+        mockFetch.mockResolvedValue(
+            new Response(JSON.stringify(BODY_OBJECT), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
         expect(await httpClient.put('/api/put-test-with-body', BODY_OBJECT)).toEqual(BODY_OBJECT);
+        expect(mockFetch).toHaveBeenCalledWith(
+            `https://${TEST_BASE_URL}/api/put-test-with-body`,
+            expect.objectContaining({ method: 'PUT', body: JSON.stringify(BODY_OBJECT) }),
+        );
     });
 
     test('should make PUT call without body and resolve the response', async () => {
+        mockFetch.mockResolvedValue(
+            new Response(JSON.stringify(BODY_OBJECT), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
         expect(await httpClient.put('/api/put-test-without-body')).toEqual(BODY_OBJECT);
     });
 
     test('should make DELETE call and resolve the response', async () => {
+        mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+
         expect(await httpClient.delete('/api/delete-test')).toEqual(undefined);
+        expect(mockFetch).toHaveBeenCalledWith(
+            `https://${TEST_BASE_URL}/api/delete-test`,
+            expect.objectContaining({ method: 'DELETE' }),
+        );
     });
 
-    test("should throw error when host doesn't exist", async () => {
+    test('should throw error when fetch rejects', async () => {
+        mockFetch.mockRejectedValue(new Error('Network error'));
+
         await expect(httpClient.get('/api/doesnt-exist-url')).rejects.toThrowError();
     });
 
     test('should throw error when 4XX', async () => {
+        mockFetch.mockResolvedValue(
+            new Response(JSON.stringify({ success: false, error: 'Bad Request' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
         await expect(httpClient.get('/api/error-400')).rejects.toThrowError();
     });
 
     test('should throw error when 5XX', async () => {
+        mockFetch.mockResolvedValue(
+            new Response(JSON.stringify({ success: false, error: 'Internal Server Error' }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
         await expect(httpClient.get('/api/error-500')).rejects.toThrowError();
     });
 });

--- a/packages/cli/tests/utils/user.spec.ts
+++ b/packages/cli/tests/utils/user.spec.ts
@@ -1,7 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import nock from 'nock';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Configuration } from '../../src/utils/configuration';
 import { getUser } from '../../src/utils/user';
@@ -23,15 +22,27 @@ const GET_USER_API_RESPONSE = {
 
 const TEST_BASE_URL = 'testing.frontify.test';
 
+const { mockHttpPost } = vi.hoisted(() => ({
+    mockHttpPost: vi.fn(),
+}));
+
+vi.mock('../../src/utils/httpClient', () => {
+    const MockHttpClient = vi.fn();
+    MockHttpClient.prototype.post = mockHttpPost;
+    return { HttpClient: MockHttpClient };
+});
+
 describe('User utils', () => {
     beforeEach(() => {
-        const testMockApi = nock(`https://${TEST_BASE_URL}`);
-        testMockApi.post('/graphql', { query: '{ currentUser { email name } }' }).reply(200, GET_USER_API_RESPONSE);
+        mockHttpPost.mockResolvedValue(GET_USER_API_RESPONSE);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
     });
 
     describe('getUser', () => {
         test('should get user object', async () => {
-            // TODO: We shall have a different object for test and prod/dev as it would override existing tokens from the user if testing locally
             const oldTokens = Configuration.get('tokens') || {};
             Configuration.set('tokens', DUMMY_TOKENS.tokens);
             expect(await getUser(TEST_BASE_URL)).toEqual(DUMMY_TOKENS);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,9 +345,6 @@ importers:
       eslint-plugin-notice:
         specifier: ^1.0.0
         version: 1.0.0(eslint@9.39.4(jiti@2.6.1))
-      nock:
-        specifier: ^14.0.11
-        version: 14.0.11
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
@@ -7480,10 +7477,6 @@ packages:
     resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
     engines: {node: '>=12.0.0'}
 
-  nock@14.0.11:
-    resolution: {integrity: sha512-u5xUnYE+UOOBA6SpELJheMCtj2Laqx15Vl70QxKo43Wz/6nMHXS7PrEioXLjXAwhmawdEMNImwKCcPhBJWbKVw==}
-    engines: {node: '>=18.20.0 <20 || >=20.12.1'}
-
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -7956,10 +7949,6 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
-  propagate@2.0.1:
-    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
-    engines: {node: '>= 8'}
 
   proxy-compare@2.6.0:
     resolution: {integrity: sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw==}
@@ -15004,7 +14993,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@24.12.0)(@vitest/ui@4.1.2)(happy-dom@20.8.9)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.1)(yaml@2.8.3))
+      vitest: 4.1.2(@types/node@22.19.15)(@vitest/ui@4.1.2)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.15)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.31.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -15073,7 +15062,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@24.12.0)(@vitest/ui@4.1.2)(happy-dom@20.8.9)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.1)(yaml@2.8.3))
+      vitest: 4.1.2(@types/node@22.19.15)(@vitest/ui@4.1.2)(happy-dom@20.8.9)(msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.15)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.31.1)(yaml@2.8.3))
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -18800,12 +18789,6 @@ snapshots:
   nocache@3.0.4:
     optional: true
 
-  nock@14.0.11:
-    dependencies:
-      '@mswjs/interceptors': 0.41.3
-      json-stringify-safe: 5.0.1
-      propagate: 2.0.1
-
   node-abort-controller@3.1.1:
     optional: true
 
@@ -19269,8 +19252,6 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  propagate@2.0.1: {}
 
   proxy-compare@2.6.0: {}
 


### PR DESCRIPTION
Replace nock HTTP interceptor with native vitest mocking:
- httpClient.spec.ts: use vi.stubGlobal('fetch', ...) to mock fetch directly
- user.spec.ts: use vi.mock to mock HttpClient module (consistent with publish.spec.ts)