### PR TITLE
fix(cli): Improves react and peer package version parsing.

### DIFF
--- a/.changeset/calm-clocks-burn.md
+++ b/.changeset/calm-clocks-burn.md
@@ -1,0 +1,9 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+fix(cli): resolve dependency versions from node_modules instead of package.json specifiers
+
+The development server and platform app compiler were reading React and App Bridge versions directly from the consumer's `package.json` `dependencies` field. This broke when using pnpm workspaces with the `catalog:` or `workspace:*` protocols, since those specifiers were passed as-is to the bundler instead of actual version numbers.
+
+Version resolution now uses Node's built-in `findPackageJSON` (available since Node 22.14.0, matching the CLI's `>=22` engine requirement) to directly locate each package's `package.json` in `node_modules`. A fallback to the consumer's `package.json` is preserved for environments where `node_modules` is not yet populated, and checks `devDependencies` and `peerDependencies` in addition to `dependencies`.

--- a/packages/cli/src/servers/blockDevelopmentServer.ts
+++ b/packages/cli/src/servers/blockDevelopmentServer.ts
@@ -76,7 +76,7 @@ export class BlockDevelopmentServer {
                         version: pkg.version,
                         dependencies: {
                             ...(appBridgeVersion ? { '@frontify/app-bridge': appBridgeVersion } : {}),
-                            react: reactVersion,
+                            ...(reactVersion ? { react: reactVersion } : {}),
                         },
                     }),
                 );

--- a/packages/cli/src/servers/themeDevelopmentServer.ts
+++ b/packages/cli/src/servers/themeDevelopmentServer.ts
@@ -76,7 +76,7 @@ export class ThemeDevelopmentServer {
                         version: pkg.version,
                         dependencies: {
                             ...(appBridgeThemeVersion ? { '@frontify/app-bridge-theme': appBridgeThemeVersion } : {}),
-                            react: reactVersion,
+                            ...(reactVersion ? { react: reactVersion } : {}),
                         },
                     }),
                 );

--- a/packages/cli/src/utils/compiler/compilePlatformApp.ts
+++ b/packages/cli/src/utils/compiler/compilePlatformApp.ts
@@ -45,7 +45,7 @@ export const compilePlatformApp = async ({ outputName, entryFile, projectPath = 
                     footer: `
                         window.${outputName} = ${outputName};
                         window.${outputName}.dependencies = window.${outputName}.packages || {};
-                        window.${outputName}.dependencies['@frontify/app-bridge-app'] = '${appBridgeVersion}';
+                        ${appBridgeVersion ? `window.${outputName}.dependencies['@frontify/app-bridge-app'] = '${appBridgeVersion}';` : ''}
                     `,
                 },
             },

--- a/packages/cli/src/utils/getPackageVersion.ts
+++ b/packages/cli/src/utils/getPackageVersion.ts
@@ -1,21 +1,44 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { readFileSync } from 'node:fs';
+import { findPackageJSON } from 'node:module';
 import { join } from 'node:path';
 
-import { type PackageJson } from './npm';
-import { reactiveJson } from './reactiveJson';
+const getInstalledPackageVersion = (rootPath: string, packageName: string): string | undefined => {
+    try {
+        const pkgJsonPath = findPackageJSON(packageName, join(rootPath, 'package.json'));
 
-export const getAppBridgeVersion = (rootPath: string) => {
-    const packageJson = reactiveJson<PackageJson>(join(rootPath, 'package.json'));
-    return packageJson.dependencies['@frontify/app-bridge'];
+        if (pkgJsonPath === undefined) {
+            throw new Error(`Package "${packageName}" not found from "${rootPath}"`);
+        }
+
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as { version?: string };
+
+        return pkg.version;
+    } catch {
+        try {
+            const pkgContent = readFileSync(join(rootPath, 'package.json'), 'utf-8');
+            const pkg = JSON.parse(pkgContent) as Record<string, Record<string, string> | undefined>;
+
+            return (
+                pkg.dependencies?.[packageName] ||
+                pkg.devDependencies?.[packageName] ||
+                pkg.peerDependencies?.[packageName]
+            );
+        } catch {
+            return undefined;
+        }
+    }
 };
 
-export const getAppBridgeThemeVersion = (rootPath: string) => {
-    const packageJson = reactiveJson<PackageJson>(join(rootPath, 'package.json'));
-    return packageJson.dependencies['@frontify/app-bridge-theme'];
+export const getAppBridgeVersion = (rootPath: string): string | undefined => {
+    return getInstalledPackageVersion(rootPath, '@frontify/app-bridge');
 };
 
-export const getReactVersion = (rootPath: string) => {
-    const packageJson = reactiveJson<PackageJson>(join(rootPath, 'package.json'));
-    return packageJson.dependencies.react;
+export const getAppBridgeThemeVersion = (rootPath: string): string | undefined => {
+    return getInstalledPackageVersion(rootPath, '@frontify/app-bridge-theme');
+};
+
+export const getReactVersion = (rootPath: string): string | undefined => {
+    return getInstalledPackageVersion(rootPath, 'react');
 };

--- a/packages/cli/tests/utils/appBridgeThemeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeThemeVersion.spec.ts
@@ -1,39 +1,86 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { readFileSync } from 'node:fs';
+import { findPackageJSON } from 'node:module';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getAppBridgeThemeVersion } from '../../src/utils/getPackageVersion';
 
-const rootPath = 'frontify-cli';
+const rootPath = '/project';
 
 vi.mock('node:fs', () => {
     return {
         readFileSync: vi.fn(),
-        writeFileSync: vi.fn(),
+    };
+});
+
+vi.mock('node:module', () => {
+    return {
+        findPackageJSON: vi.fn(),
     };
 });
 
 describe('appBridgeThemeVersion utils', () => {
+    beforeEach(() => {
+        vi.mocked(readFileSync).mockReset();
+        vi.mocked(findPackageJSON).mockReset();
+    });
+
     afterEach(() => {
         vi.clearAllMocks();
     });
 
-    it('should return the 3 as version from package.json', () => {
-        vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"@frontify/app-bridge-theme": "3"}}');
-        expect(getAppBridgeThemeVersion(rootPath)).toEqual('3');
-    });
+    describe('getAppBridgeThemeVersion', () => {
+        test('should return the installed version from node_modules', () => {
+            vi.mocked(findPackageJSON).mockReturnValue('/project/node_modules/@frontify/app-bridge-theme/package.json');
+            vi.mocked(readFileSync).mockReturnValueOnce('{"name": "@frontify/app-bridge-theme", "version": "3.2.1"}');
 
-    it('should return the 3.0.0-beta.99 as version from package.json', () => {
-        vi.mocked(readFileSync).mockReturnValueOnce(
-            '{"dependencies": {"@frontify/app-bridge-theme": "3.0.0-beta.99"}}',
-        );
-        expect(getAppBridgeThemeVersion(rootPath)).toEqual('3.0.0-beta.99');
-    });
+            expect(getAppBridgeThemeVersion(rootPath)).toEqual('3.2.1');
+            expect(findPackageJSON).toHaveBeenCalledWith('@frontify/app-bridge-theme', '/project/package.json');
+        });
 
-    it('should return the ^3.0.0 as version from package.json', () => {
-        vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"@frontify/app-bridge-theme": "^3.0.0"}}');
-        expect(getAppBridgeThemeVersion(rootPath)).toEqual('^3.0.0');
+        test('should return the installed pre-release version from node_modules', () => {
+            vi.mocked(findPackageJSON).mockReturnValue('/project/node_modules/@frontify/app-bridge-theme/package.json');
+            vi.mocked(readFileSync).mockReturnValueOnce(
+                '{"name": "@frontify/app-bridge-theme", "version": "3.0.0-beta.99"}',
+            );
+
+            expect(getAppBridgeThemeVersion(rootPath)).toEqual('3.0.0-beta.99');
+        });
+
+        test('should fall back to dependencies in package.json when module cannot be resolved', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"@frontify/app-bridge-theme": "^3.0.0"}}');
+
+            expect(getAppBridgeThemeVersion(rootPath)).toEqual('^3.0.0');
+        });
+
+        test('should fall back to devDependencies in package.json when not in dependencies', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce(
+                '{"devDependencies": {"@frontify/app-bridge-theme": "^3.0.0"}}',
+            );
+
+            expect(getAppBridgeThemeVersion(rootPath)).toEqual('^3.0.0');
+        });
+
+        test('should fall back to peerDependencies in package.json when not in dependencies or devDependencies', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce(
+                '{"peerDependencies": {"@frontify/app-bridge-theme": ">=3.0.0"}}',
+            );
+
+            expect(getAppBridgeThemeVersion(rootPath)).toEqual('>=3.0.0');
+        });
+
+        test('should return undefined when both resolution and fallback fail', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockImplementation(() => {
+                throw new Error('ENOENT');
+            });
+
+            expect(getAppBridgeThemeVersion(rootPath)).toBeUndefined();
+        });
     });
 });

--- a/packages/cli/tests/utils/appBridgeVersion.spec.ts
+++ b/packages/cli/tests/utils/appBridgeVersion.spec.ts
@@ -1,37 +1,80 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { readFileSync } from 'node:fs';
+import { findPackageJSON } from 'node:module';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getAppBridgeVersion } from '../../src/utils/getPackageVersion';
 
-const rootPath = 'frontify-cli';
+const rootPath = '/project';
 
 vi.mock('node:fs', () => {
     return {
         readFileSync: vi.fn(),
-        writeFileSync: vi.fn(),
+    };
+});
+
+vi.mock('node:module', () => {
+    return {
+        findPackageJSON: vi.fn(),
     };
 });
 
 describe('AppBridgeVersion utils', () => {
+    beforeEach(() => {
+        vi.mocked(readFileSync).mockReset();
+        vi.mocked(findPackageJSON).mockReset();
+    });
+
     afterEach(() => {
         vi.clearAllMocks();
     });
 
-    it('should return the 3 as version from package.json', () => {
-        vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"@frontify/app-bridge": "3"}}');
-        expect(getAppBridgeVersion(rootPath)).toEqual('3');
-    });
+    describe('getAppBridgeVersion', () => {
+        test('should return the installed version from node_modules', () => {
+            vi.mocked(findPackageJSON).mockReturnValue('/project/node_modules/@frontify/app-bridge/package.json');
+            vi.mocked(readFileSync).mockReturnValueOnce('{"name": "@frontify/app-bridge", "version": "3.5.2"}');
 
-    it('should return the 3.0.0-beta.99 as version from package.json', () => {
-        vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"@frontify/app-bridge": "3.0.0-beta.99"}}');
-        expect(getAppBridgeVersion(rootPath)).toEqual('3.0.0-beta.99');
-    });
+            expect(getAppBridgeVersion(rootPath)).toEqual('3.5.2');
+            expect(findPackageJSON).toHaveBeenCalledWith('@frontify/app-bridge', '/project/package.json');
+        });
 
-    it('should return the ^3.0.0 as version from package.json', () => {
-        vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"@frontify/app-bridge": "^3.0.0"}}');
-        expect(getAppBridgeVersion(rootPath)).toEqual('^3.0.0');
+        test('should return the installed pre-release version from node_modules', () => {
+            vi.mocked(findPackageJSON).mockReturnValue('/project/node_modules/@frontify/app-bridge/package.json');
+            vi.mocked(readFileSync).mockReturnValueOnce('{"name": "@frontify/app-bridge", "version": "3.0.0-beta.99"}');
+
+            expect(getAppBridgeVersion(rootPath)).toEqual('3.0.0-beta.99');
+        });
+
+        test('should fall back to dependencies in package.json when module cannot be resolved', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"@frontify/app-bridge": "^3.0.0"}}');
+
+            expect(getAppBridgeVersion(rootPath)).toEqual('^3.0.0');
+        });
+
+        test('should fall back to devDependencies in package.json when not in dependencies', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce('{"devDependencies": {"@frontify/app-bridge": "^3.0.0"}}');
+
+            expect(getAppBridgeVersion(rootPath)).toEqual('^3.0.0');
+        });
+
+        test('should fall back to peerDependencies in package.json when not in dependencies or devDependencies', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce('{"peerDependencies": {"@frontify/app-bridge": ">=3.0.0"}}');
+
+            expect(getAppBridgeVersion(rootPath)).toEqual('>=3.0.0');
+        });
+
+        test('should return undefined when both resolution and fallback fail', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockImplementation(() => {
+                throw new Error('ENOENT');
+            });
+
+            expect(getAppBridgeVersion(rootPath)).toBeUndefined();
+        });
     });
 });

--- a/packages/cli/tests/utils/reactVersion.spec.ts
+++ b/packages/cli/tests/utils/reactVersion.spec.ts
@@ -1,27 +1,73 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { readFileSync } from 'node:fs';
+import { findPackageJSON } from 'node:module';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getReactVersion } from '../../src/utils/getPackageVersion';
 
-const rootPath = 'frontify-cli';
+const rootPath = '/project';
 
 vi.mock('node:fs', () => {
     return {
         readFileSync: vi.fn(),
-        writeFileSync: vi.fn(),
+    };
+});
+
+vi.mock('node:module', () => {
+    return {
+        findPackageJSON: vi.fn(),
     };
 });
 
 describe('ReactVersion utils', () => {
+    beforeEach(() => {
+        vi.mocked(readFileSync).mockReset();
+        vi.mocked(findPackageJSON).mockReset();
+    });
+
     afterEach(() => {
         vi.clearAllMocks();
     });
 
-    it('should return the 18 as version from package.json', () => {
-        vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"react": "18"}}');
-        expect(getReactVersion(rootPath)).toEqual('18');
+    describe('getReactVersion', () => {
+        test('should return the installed version from node_modules', () => {
+            vi.mocked(findPackageJSON).mockReturnValue('/project/node_modules/react/package.json');
+            vi.mocked(readFileSync).mockReturnValueOnce('{"name": "react", "version": "18.2.0"}');
+
+            expect(getReactVersion(rootPath)).toEqual('18.2.0');
+            expect(findPackageJSON).toHaveBeenCalledWith('react', '/project/package.json');
+        });
+
+        test('should fall back to dependencies in package.json when module cannot be resolved', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce('{"dependencies": {"react": "^18.0.0"}}');
+
+            expect(getReactVersion(rootPath)).toEqual('^18.0.0');
+        });
+
+        test('should fall back to devDependencies in package.json when not in dependencies', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce('{"devDependencies": {"react": "^18.0.0"}}');
+
+            expect(getReactVersion(rootPath)).toEqual('^18.0.0');
+        });
+
+        test('should fall back to peerDependencies in package.json when not in dependencies or devDependencies', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockReturnValueOnce('{"peerDependencies": {"react": ">=18.0.0"}}');
+
+            expect(getReactVersion(rootPath)).toEqual('>=18.0.0');
+        });
+
+        test('should return undefined when both resolution and fallback fail', () => {
+            vi.mocked(findPackageJSON).mockReturnValue(undefined);
+            vi.mocked(readFileSync).mockImplementation(() => {
+                throw new Error('ENOENT');
+            });
+
+            expect(getReactVersion(rootPath)).toBeUndefined();
+        });
     });
 });


### PR DESCRIPTION
**Issue**

The CLI reads react, @frontify/app-bridge, and @frontify/app-bridge-theme versions from the consumer's package.json dependencies field. This breaks in pnpm workspaces that use the catalog: or workspace:* protocols, since those specifiers are passed as-is to the bundler and development servers instead of actual version numbers, making workspace-based block development unusable.

**Solution**

Version resolution now uses Node's built-in `findPackageJSON` (available since Node 22.14.0, matching the CLI's `>=22` engine requirement) to directly locate each package's `package.json` in `node_modules`. A fallback to the consumer's `package.json` is preserved for environments where `node_modules` is not yet populated, and checks `devDependencies` and `peerDependencies` in addition to `dependencies`.

**Note**

Some of the solutions here are a bit opinionated. For example wether or not devDeps and peerDeps should also be considered for the resolution logic or not would need your guys' input.