### PR TITLE
fix(cli): unbreak content-block templates (IconEnum + plate-common pin)

### DIFF
--- a/.changeset/fluffy-jobs-fry.md
+++ b/.changeset/fluffy-jobs-fry.md
@@ -6,3 +6,4 @@ fix(cli): repair content-block templates
 
 - Replace removed `IconEnum` import with string icon name in `settings.ts`
 - Pin `@udecode/plate-common` to `36.5.9` via `overrides`/`resolutions` to avoid the deprecated `42.0.0` shim that breaks Rollup builds
+- Pin `zustand` to `4.5.7` so blocks don't pick up `zustand@5` (incompatible API with `@udecode/zustood` / `zustand-x`, causing `TypeError: createState is not a function` when the block loads in the web-app)

--- a/.changeset/fluffy-jobs-fry.md
+++ b/.changeset/fluffy-jobs-fry.md
@@ -1,0 +1,8 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+fix(cli): repair content-block templates
+
+- Replace removed `IconEnum` import with string icon name in `settings.ts`
+- Pin `@udecode/plate-common` to `36.5.9` via `overrides`/`resolutions` to avoid the deprecated `42.0.0` shim that breaks Rollup builds

--- a/.changeset/fluffy-jobs-fry.md
+++ b/.changeset/fluffy-jobs-fry.md
@@ -7,3 +7,4 @@ fix(cli): repair content-block templates
 - Replace removed `IconEnum` import with string icon name in `settings.ts`
 - Pin `@udecode/plate-common` to `36.5.9` via `overrides`/`resolutions` to avoid the deprecated `42.0.0` shim that breaks Rollup builds
 - Pin `zustand` to `4.5.7` so blocks don't pick up `zustand@5` (incompatible API with `@udecode/zustood` / `zustand-x`, causing `TypeError: createState is not a function` when the block loads in the web-app)
+- Use arbitrary-value color classes in the Tailwind template so the example renders correctly under the Frontify Tailwind preset (which replaces the default `blue`/`green`/`red` palette)

--- a/packages/cli/templates/content-block-css-modules/package.json
+++ b/packages/cli/templates/content-block-css-modules/package.json
@@ -15,6 +15,12 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },
+    "overrides": {
+        "@udecode/plate-common": "36.5.9"
+    },
+    "resolutions": {
+        "@udecode/plate-common": "36.5.9"
+    },
     "devDependencies": {
         "@frontify/eslint-config-react": "^0.17.6",
         "@frontify/frontify-cli": "^6.0.0",

--- a/packages/cli/templates/content-block-css-modules/package.json
+++ b/packages/cli/templates/content-block-css-modules/package.json
@@ -16,14 +16,16 @@
         "react-dom": "^18.3.1"
     },
     "overrides": {
-        "@udecode/plate-common": "36.5.9"
+        "@udecode/plate-common": "36.5.9",
+        "zustand": "4.5.7"
     },
     "resolutions": {
-        "@udecode/plate-common": "36.5.9"
+        "@udecode/plate-common": "36.5.9",
+        "zustand": "4.5.7"
     },
     "devDependencies": {
         "@frontify/eslint-config-react": "^0.17.6",
-        "@frontify/frontify-cli": "^6.0.0",
+        "@frontify/frontify-cli": "^6.0.3",
         "@frontify/guideline-blocks-settings": "^2.1.8",
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.7",

--- a/packages/cli/templates/content-block-css-modules/src/settings.ts
+++ b/packages/cli/templates/content-block-css-modules/src/settings.ts
@@ -1,4 +1,4 @@
-import { IconEnum, defineSettings } from '@frontify/guideline-blocks-settings';
+import { defineSettings } from '@frontify/guideline-blocks-settings';
 
 export const settings = defineSettings({
     main: [
@@ -11,7 +11,7 @@ export const settings = defineSettings({
             choices: [
                 {
                     value: 'content_block',
-                    icon: IconEnum.BuildingBlock,
+                    icon: 'BuildingBlock',
                     label: 'Content Block',
                 },
             ],

--- a/packages/cli/templates/content-block-css/package.json
+++ b/packages/cli/templates/content-block-css/package.json
@@ -16,10 +16,12 @@
         "react-dom": "^18.3.1"
     },
     "overrides": {
-        "@udecode/plate-common": "36.5.9"
+        "@udecode/plate-common": "36.5.9",
+        "zustand": "4.5.7"
     },
     "resolutions": {
-        "@udecode/plate-common": "36.5.9"
+        "@udecode/plate-common": "36.5.9",
+        "zustand": "4.5.7"
     },
     "devDependencies": {
         "@frontify/eslint-config-react": "^0.17.6",

--- a/packages/cli/templates/content-block-css/package.json
+++ b/packages/cli/templates/content-block-css/package.json
@@ -15,6 +15,12 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },
+    "overrides": {
+        "@udecode/plate-common": "36.5.9"
+    },
+    "resolutions": {
+        "@udecode/plate-common": "36.5.9"
+    },
     "devDependencies": {
         "@frontify/eslint-config-react": "^0.17.6",
         "@frontify/frontify-cli": "^6.0.0",

--- a/packages/cli/templates/content-block-css/src/settings.ts
+++ b/packages/cli/templates/content-block-css/src/settings.ts
@@ -1,4 +1,4 @@
-import { IconEnum, defineSettings } from '@frontify/guideline-blocks-settings';
+import { defineSettings } from '@frontify/guideline-blocks-settings';
 
 export const settings = defineSettings({
     main: [
@@ -11,7 +11,7 @@ export const settings = defineSettings({
             choices: [
                 {
                     value: 'content_block',
-                    icon: IconEnum.BuildingBlock,
+                    icon: 'BuildingBlock',
                     label: 'Content Block',
                 },
             ],

--- a/packages/cli/templates/content-block-tailwind/package.json
+++ b/packages/cli/templates/content-block-tailwind/package.json
@@ -16,10 +16,12 @@
         "react-dom": "^18.3.1"
     },
     "overrides": {
-        "@udecode/plate-common": "36.5.9"
+        "@udecode/plate-common": "36.5.9",
+        "zustand": "4.5.7"
     },
     "resolutions": {
-        "@udecode/plate-common": "36.5.9"
+        "@udecode/plate-common": "36.5.9",
+        "zustand": "4.5.7"
     },
     "devDependencies": {
         "@frontify/eslint-config-react": "^0.17.6",

--- a/packages/cli/templates/content-block-tailwind/package.json
+++ b/packages/cli/templates/content-block-tailwind/package.json
@@ -15,6 +15,12 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },
+    "overrides": {
+        "@udecode/plate-common": "36.5.9"
+    },
+    "resolutions": {
+        "@udecode/plate-common": "36.5.9"
+    },
     "devDependencies": {
         "@frontify/eslint-config-react": "^0.17.6",
         "@frontify/frontify-cli": "^6.0.0",

--- a/packages/cli/templates/content-block-tailwind/src/Block.tsx
+++ b/packages/cli/templates/content-block-tailwind/src/Block.tsx
@@ -8,9 +8,9 @@ type Settings = {
 
 const colorTailwindMap: Record<Settings['color'], string> = {
     violet: 'tw-text-[rgb(113,89,215)]',
-    blue: 'tw-text-blue-600',
-    green: 'tw-text-green-600',
-    red: 'tw-text-red-600',
+    blue: 'tw-text-[rgb(37,99,235)]',
+    green: 'tw-text-[rgb(22,163,74)]',
+    red: 'tw-text-[rgb(220,38,38)]',
 };
 
 export const AnExampleBlock: FC<BlockProps> = ({ appBridge }) => {

--- a/packages/cli/templates/content-block-tailwind/src/settings.ts
+++ b/packages/cli/templates/content-block-tailwind/src/settings.ts
@@ -1,4 +1,4 @@
-import { IconEnum, defineSettings } from '@frontify/guideline-blocks-settings';
+import { defineSettings } from '@frontify/guideline-blocks-settings';
 
 export const settings = defineSettings({
     main: [
@@ -11,7 +11,7 @@ export const settings = defineSettings({
             choices: [
                 {
                     value: 'content_block',
-                    icon: IconEnum.BuildingBlock,
+                    icon: 'BuildingBlock',
                     label: 'Content Block',
                 },
             ],


### PR DESCRIPTION
## Summary

Fresh installs of the content-block templates were broken. Two independent upstream regressions:

1. **`IconEnum` removed from `@frontify/guideline-blocks-settings`** — templates imported `IconEnum.BuildingBlock`, which no longer exists. The `choices[].icon` field still accepts `keyof typeof IconEnum` from `@frontify/sidebar-settings`, so the string literal `'BuildingBlock'` is the drop-in replacement.

2. **Rollup `MISSING_EXPORT: sanitizeUrl` at build time** — `@udecode/plate-link@31` imports `sanitizeUrl` from `@udecode/plate-common`, but no package in the `fondue` → `fondue-rte` → `plate-*@31` chain pins `plate-common`. With the templates shipping no lockfile, fresh installs auto-resolved the loose `>=31.0.0` peer up to `plate-common@42.0.0` — a deprecated shim that no longer exports `sanitizeUrl`.

Fix: pin `@udecode/plate-common` to `36.5.9` via `overrides` (npm) + `resolutions` (yarn + pnpm fallback) in all three content-block templates. `36.5.9` is what `fondue-rte@0.1.3` expects (its direct deps on `plate-core`/`plate-utils` are `^36.5.9`).

## Test plan

- [ ] `pnpm --filter @frontify/frontify-cli build`
- [ ] `cd /tmp && node <repo>/packages/cli/dist/index.mjs create` → scaffold each of the 3 styling options (Tailwind / CSS Modules / None)
- [ ] In each scaffolded project: `npm install` then `npm ls @udecode/plate-common` → expect `36.5.9`
- [ ] `npm run serve` → dev server starts without `MISSING_EXPORT` errors
- [ ] `npm run deploy -- --dry-run --no-verify` → production Rollup bundle completes without `sanitizeUrl` errors
- [ ] `npm run typecheck` → no `IconEnum` / TS2305 errors


Summarized by AI

TASK-17830