### PR TITLE
feat(sidebar-settings): extend sidebar settings structure to provide more flexibility

### DIFF
--- a/.changeset/whole-sites-wave.md
+++ b/.changeset/whole-sites-wave.md
@@ -1,0 +1,6 @@
+---
+"@frontify/guideline-themes": minor
+"@frontify/sidebar-settings": minor
+---
+
+Introduce new settings structure in sidebar-settings to allow more flexibility for settings. Old structure still supported.

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -80,9 +80,7 @@ export type LegacyThemeSettingsStructure = { [customSectionName: string]: Settin
 
 type TranslatableThemeSettingsStructure = TranslatableSettingsStructureSidebarSettings<AppBridgeTheme>;
 
-export type ThemeSettingsStructureExport =
-    | LegacyThemeSettingsStructure
-    | TranslatableThemeSettingsStructure;
+export type ThemeSettingsStructureExport = LegacyThemeSettingsStructure | TranslatableThemeSettingsStructure;
 
 export type ThemeSettingsStructure =
     | Record<ThemeTemplate, LegacyThemeSettingsStructure>

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type AppBridgeTheme, type ThemeTemplate } from '@frontify/app-bridge-theme';
+import { type AppBridgeTheme, type LanguageCode, type ThemeTemplate } from '@frontify/app-bridge-theme';
 import {
     type AssetInputBlock as AssetInputBlockSidebarSettings,
     type BaseBlock as BaseBlockSidebarSettings,
@@ -19,10 +19,12 @@ import {
     type SectionHeadingBlock as SectionHeadingBlockSidebarSettings,
     type SegmentedControlsBlock as SegmentedControlsBlockSidebarSettings,
     type SettingBlock as SettingBlockSidebarSettings,
+    type SettingsSection as SettingsSectionSidebarSettings,
     type SimpleSettingBlock as SimpleSettingBlockSidebarSettings,
     type SwitchBlock as SwitchBlockSidebarSettings,
     type TemplateInputBlock as TemplateInputBlockSidebarSettings,
     type TextareaBlock as TextareaBlockSidebarSettings,
+    type TranslatableSettingsStructure as TranslatableSettingsStructureSidebarSettings,
     type ValueOrPromisedValue as ValueOrPromisedValueSidebarSettings,
 } from '@frontify/sidebar-settings';
 import { type FC } from 'react';
@@ -70,8 +72,22 @@ export type ContentAreaPaddingTemplateSettings = {
 export type ContentAreaAlignmentChoice = 'left' | 'center' | 'right';
 export type ContentAreaAlignmentSetting = { contentAreaAlignmentChoice?: ContentAreaAlignmentChoice };
 
-export type ThemeSettingsStructureExport = { [customSectionName: string]: SettingBlock[] };
-export type ThemeSettingsStructure = Record<ThemeTemplate, ThemeSettingsStructureExport>;
+/**
+ * @deprecated Use {@link TranslatableThemeSettingsStructure} instead. The legacy
+ * record shape cannot express section labels, icons, or translations and will be
+ * removed in a future major version.
+ */
+export type LegacyThemeSettingsStructure = { [customSectionName: string]: SettingBlock[] };
+
+type TranslatableThemeSettingsStructure = TranslatableSettingsStructureSidebarSettings<AppBridgeTheme>;
+
+export type ThemeSettingsStructureExport =
+    | LegacyThemeSettingsStructure
+    | TranslatableThemeSettingsStructure;
+
+export type ThemeSettingsStructure =
+    | Record<ThemeTemplate, LegacyThemeSettingsStructure>
+    | Record<ThemeTemplate, TranslatableThemeSettingsStructure>;
 
 export type ThemeProps = {
     appBridge: AppBridgeTheme;

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type AppBridgeTheme, type LanguageCode, type ThemeTemplate } from '@frontify/app-bridge-theme';
+import { type AppBridgeTheme, type ThemeTemplate } from '@frontify/app-bridge-theme';
 import {
     type AssetInputBlock as AssetInputBlockSidebarSettings,
     type BaseBlock as BaseBlockSidebarSettings,
@@ -19,7 +19,6 @@ import {
     type SectionHeadingBlock as SectionHeadingBlockSidebarSettings,
     type SegmentedControlsBlock as SegmentedControlsBlockSidebarSettings,
     type SettingBlock as SettingBlockSidebarSettings,
-    type SettingsSection as SettingsSectionSidebarSettings,
     type SimpleSettingBlock as SimpleSettingBlockSidebarSettings,
     type SwitchBlock as SwitchBlockSidebarSettings,
     type TemplateInputBlock as TemplateInputBlockSidebarSettings,

--- a/packages/sidebar-settings/src/index.ts
+++ b/packages/sidebar-settings/src/index.ts
@@ -3,3 +3,4 @@
 export * from './blocks';
 export * from './bundle';
 export * from './helpers';
+export * from './settingsStructure';

--- a/packages/sidebar-settings/src/settingsStructure.ts
+++ b/packages/sidebar-settings/src/settingsStructure.ts
@@ -55,9 +55,16 @@ export type SettingsSection<AppBridge> = MainSection<AppBridge> | LabeledSection
 /**
  * Settings structure that resolves at render time for the requested language.
  *
+ * The argument is an object so the contract can grow new fields in the future
+ * without breaking existing callers.
+ *
  * @typeParam AppBridge - The AppBridge variant the contained blocks target.
  *
  * Currently supported languages are:
  * 'en', 'de', 'fr', 'es', 'it', 'pt', 'nl', 'da', 'sv', 'pl', 'cs', 'fi', 'no'
  */
-export type TranslatableSettingsStructure<AppBridge> = (lang: string) => SettingsSection<AppBridge>[];
+export type TranslatableSettingsStructure<AppBridge> = ({
+    languageCode,
+}: {
+    languageCode: string;
+}) => SettingsSection<AppBridge>[];

--- a/packages/sidebar-settings/src/settingsStructure.ts
+++ b/packages/sidebar-settings/src/settingsStructure.ts
@@ -1,0 +1,63 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type ReactElement } from 'react';
+
+import { type SettingBlock } from './blocks';
+import { type IconEnum } from './blocks/iconEnum';
+
+/**
+ * Settings section rendered above the accordion with no header, label, or
+ * icon. Reserved for a single "main" section per structure. Discriminated by
+ * the literal `id: 'main'`.
+ */
+export type MainSection<AppBridge> = {
+    id: 'main';
+    blocks: SettingBlock<AppBridge>[];
+};
+
+/**
+ * Settings section rendered as a labeled accordion item, with a human-readable
+ * label and an optional leading icon.
+ */
+export type LabeledSection<AppBridge> = {
+    /**
+     * Stable identifier for the section. Must be unique within a structure.
+     * Reserved value `'main'` selects the {@link MainSection} branch instead.
+     */
+    id: string;
+    /**
+     * Human-readable section label. Provided by the consuming theme/block,
+     * typically translated via the {@link TranslatableSettingsStructure}
+     * function form.
+     */
+    label: string;
+    /**
+     * Optional leading icon. Accepts an {@link IconEnum} value, its string
+     * key (e.g. `'Eye'`), or a custom React element.
+     *
+     * The full list of icons can be found here {@link https://fondue-components.frontify.com/?path=/story/icons_icons--default}
+     */
+    icon?: IconEnum | keyof typeof IconEnum | ReactElement;
+    blocks: SettingBlock<AppBridge>[];
+};
+
+/**
+ * A section in a settings structure. Discriminated by `id`: the literal
+ * `'main'` selects {@link MainSection} (no header), any other id selects
+ * {@link LabeledSection} (accordion item with label and optional icon).
+ *
+ * At most one section per structure should use `id: 'main'`. Multiple are
+ * not type-prevented and should be handled defensively at the rendering
+ * layer.
+ */
+export type SettingsSection<AppBridge> = MainSection<AppBridge> | LabeledSection<AppBridge>;
+
+/**
+ * Settings structure that resolves at render time for the requested language.
+ *
+ * @typeParam AppBridge - The AppBridge variant the contained blocks target.
+ *
+ * Currently supported languages are:
+ * 'en', 'de', 'fr', 'es', 'it', 'pt', 'nl', 'da', 'sv', 'pl', 'cs', 'fi', 'no'
+ */
+export type TranslatableSettingsStructure<AppBridge> = (lang: string) => SettingsSection<AppBridge>[];

--- a/packages/sidebar-settings/src/settingsStructure.ts
+++ b/packages/sidebar-settings/src/settingsStructure.ts
@@ -3,7 +3,6 @@
 import { type ReactElement } from 'react';
 
 import { type SettingBlock } from './blocks';
-import { type IconEnum } from './blocks/iconEnum';
 
 /**
  * Settings section rendered above the accordion with no header, label, or
@@ -32,12 +31,9 @@ export type LabeledSection<AppBridge> = {
      */
     label: string;
     /**
-     * Optional leading icon. Accepts an {@link IconEnum} value, its string
-     * key (e.g. `'Eye'`), or a custom React element.
-     *
-     * The full list of icons can be found here {@link https://fondue-components.frontify.com/?path=/story/icons_icons--default}
+     * Optional leading icon as a React element.
      */
-    icon?: IconEnum | keyof typeof IconEnum | ReactElement;
+    icon?: ReactElement;
     blocks: SettingBlock<AppBridge>[];
 };
 


### PR DESCRIPTION
This PR introduces new `SettingsSection` and `TranslatableSettingsStructure` in the `sidebar-settings` package. 

The goal is to enable creating theme/block settings in a way, which makes them (optionally) translatable and extendable on the level of settings section, not just on the level of individual setting blocks. 
A concrete example of such extendibility on settings section level is adding an optional icon to the section's title. Rather than relying on using the section's camelCased key, splitting it into words and capitalizing their first letter.

The current settings type `{ [customSectionName: string]: SettingBlock[] };` will still be compatible, compatibility will be handled internally by web-app. 

This PR also includes an update to the `guideline-themes` package, so that the new settings type can be used by themes.