### PR TITLE
refactor(useBlockAssets): move event emitting to web-app and use context

### DIFF
--- a/.changeset/calm-rabbits-listen.md
+++ b/.changeset/calm-rabbits-listen.md
@@ -2,7 +2,6 @@
 "@frontify/app-bridge": minor
 ---
 
-refactor(useBlockAssets): drive state from `Context.assets` instead of `BlockAssetsUpdated`
+refactor(useBlockAssets): source state from `Context.assets`
 
-- The hook now subscribes to `appBridge.context('assets')` for updates and no longer listens to or emits `AppBridge:BlockAssetsUpdated`.
-- Mutation helpers (`addAssetIdsToKey`, `deleteAssetIdsFromKey`, `updateAssetIdsFromKey`) just call the AppBridge API; the host is responsible for refreshing `context('assets')` after each mutation.
+The hook now seeds and updates `blockAssets` from `appBridge.context('assets')` and no longer fetches via `getBlockAssets()` on mount. It also no longer listens to or emits `AppBridge:BlockAssetsUpdated`; mutation helpers (`addAssetIdsToKey`, `deleteAssetIdsFromKey`, `updateAssetIdsFromKey`) just call the AppBridge API, and the host is responsible for refreshing `context('assets')` after each mutation.

--- a/.changeset/calm-rabbits-listen.md
+++ b/.changeset/calm-rabbits-listen.md
@@ -1,0 +1,8 @@
+---
+"@frontify/app-bridge": minor
+---
+
+refactor(useBlockAssets): drive state from `Context.assets` instead of `BlockAssetsUpdated`
+
+- The hook now subscribes to `appBridge.context('assets')` for updates and no longer listens to or emits `AppBridge:BlockAssetsUpdated`.
+- Mutation helpers (`addAssetIdsToKey`, `deleteAssetIdsFromKey`, `updateAssetIdsFromKey`) just call the AppBridge API; the host is responsible for refreshing `context('assets')` after each mutation.

--- a/packages/app-bridge/src/react/useBlockAssets.spec.ts
+++ b/packages/app-bridge/src/react/useBlockAssets.spec.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
-import sinon, { type SinonStub } from 'sinon';
+import sinon from 'sinon';
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AssetDummy, getAppBridgeBlockStub } from '../tests';
@@ -41,7 +41,7 @@ describe('useBlockAssets hook', () => {
             blockId: 123,
             blockAssets: { key: [AssetDummy.with(1)] },
         });
-        appBridgeStub.context.withArgs('assets').returns({ get: () => undefined });
+        appBridgeStub.context.withArgs('assets').returns({ get: () => undefined, subscribe: () => () => undefined });
 
         const { result } = renderHook(() => useBlockAssets(appBridgeStub));
 
@@ -110,36 +110,37 @@ describe('useBlockAssets hook', () => {
         });
     });
 
-    it('should notify about updated assets on delete', async () => {
-        const { result, asset } = loadUseBlockAssets();
+    it('does not fetch block assets after a mutation', async () => {
+        const { result, appBridgeStub } = loadUseBlockAssets();
 
         await act(async () => {
             await result.current.deleteAssetIdsFromKey('key', [1]);
         });
-
-        const call = (window.emitter.emit as SinonStub).getCall(0);
-
-        await waitFor(() => {
-            expect(call.firstArg).toEqual('AppBridge:BlockAssetsUpdated');
-            expect(call.lastArg.blockId).toEqual(123);
-            expect(call.lastArg.prevBlockAssets).toMatchObject({ key: [asset] });
-            expect(call.lastArg.blockAssets).toStrictEqual({ key: [] });
+        await act(async () => {
+            await result.current.addAssetIdsToKey('key', [2]);
         });
+        await act(async () => {
+            await result.current.updateAssetIdsFromKey('key', [3]);
+        });
+
+        sinon.assert.notCalled(appBridgeStub.getBlockAssets);
     });
 
-    it('should notify about updated assets on add asset ids to key', async () => {
-        const { result, asset } = loadUseBlockAssets();
-        const assetToAdd = AssetDummy.with(2);
-        await act(async () => {
-            await result.current.addAssetIdsToKey('key', [assetToAdd.id]);
+    it('unsubscribes from Context.assets on unmount', () => {
+        const appBridgeStub = getAppBridgeBlockStub({
+            blockId: 123,
+            blockAssets: { key: [AssetDummy.with(1)] },
+        });
+        const unsubscribe = sinon.spy();
+        appBridgeStub.context.withArgs('assets').returns({
+            get: () => ({}),
+            subscribe: () => unsubscribe,
         });
 
-        const call = (window.emitter.emit as SinonStub).getCall(0);
-        await waitFor(() => {
-            expect(call.firstArg).toEqual('AppBridge:BlockAssetsUpdated');
-            expect(call.lastArg.blockId).toEqual(123);
-            expect(call.lastArg.blockAssets).toMatchObject({ key: [asset, assetToAdd] });
-            expect(call.lastArg.prevBlockAssets).toMatchObject({ key: [asset] });
-        });
+        const { unmount } = renderHook(() => useBlockAssets(appBridgeStub));
+        sinon.assert.notCalled(unsubscribe);
+
+        unmount();
+        sinon.assert.calledOnce(unsubscribe);
     });
 });

--- a/packages/app-bridge/src/react/useBlockAssets.ts
+++ b/packages/app-bridge/src/react/useBlockAssets.ts
@@ -4,42 +4,18 @@ import { useEffect, useState } from 'react';
 
 import { type AppBridgeBlock } from '../AppBridgeBlock';
 import { type Asset } from '../types';
-import { compareObjects } from '../utilities';
 
 export const useBlockAssets = (appBridge: AppBridgeBlock) => {
-    const blockId = appBridge.context('blockId').get();
-
     const [blockAssets, setBlockAssets] = useState<Record<string, Asset[]>>(
         () => appBridge.context('assets').get() ?? {},
     );
 
-    const updateBlockAssetsFromEvent = (event: {
-        blockId: number;
-        blockAssets: Record<string, Asset[]>;
-        prevBlockAssets: Record<string, Asset[]>;
-    }) => {
-        if (event.blockId === blockId && !compareObjects(event.blockAssets, event.prevBlockAssets)) {
-            setBlockAssets(event.blockAssets);
-        }
-    };
-
-    // Add listener for block assets updates.
     useEffect(() => {
-        window.emitter.on('AppBridge:BlockAssetsUpdated', updateBlockAssetsFromEvent);
-
-        return () => {
-            window.emitter.off('AppBridge:BlockAssetsUpdated', updateBlockAssetsFromEvent);
-        };
-        // eslint-disable-next-line @eslint-react/exhaustive-deps
-    }, [appBridge]);
-
-    const emitUpdatedBlockAssets = async () => {
-        window.emitter.emit('AppBridge:BlockAssetsUpdated', {
-            blockId,
-            blockAssets: await appBridge.getBlockAssets(),
-            prevBlockAssets: { ...blockAssets },
+        setBlockAssets(appBridge.context('assets').get() ?? {});
+        return appBridge.context('assets').subscribe((nextAssets) => {
+            setBlockAssets(nextAssets ?? {});
         });
-    };
+    }, [appBridge]);
 
     const updateAssetIdsFromKey = async (key: string, newAssetIds: number[]) => {
         try {
@@ -47,17 +23,14 @@ export const useBlockAssets = (appBridge: AppBridgeBlock) => {
         } catch (error) {
             console.error(error);
         }
-        emitUpdatedBlockAssets();
     };
 
     const deleteAssetIdsFromKey = async (key: string, assetIds: number[]) => {
         await appBridge.deleteAssetIdsFromBlockAssetKey(key, assetIds);
-        emitUpdatedBlockAssets();
     };
 
     const addAssetIdsToKey = async (key: string, assetIds: number[]) => {
         await appBridge.addAssetIdsToBlockAssetKey(key, assetIds);
-        emitUpdatedBlockAssets();
     };
 
     return {

--- a/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
@@ -69,6 +69,22 @@ export const getAppBridgeBlockStub = ({
 
     const contextAssetsSubscribers: Set<(nextAssets: Record<string, Asset[]>) => void> = new Set();
 
+    const computeBlockAssets = (): Record<string, Asset[]> =>
+        Object.entries(blockAssets).reduce<Record<string, Asset[]>>((assetsDiff, [key, assets]) => {
+            const addedAssetIdsList = addedAssetIds[key] ?? [];
+            const deletedAssetIdsList = deletedAssetIds[key] ?? [];
+            assetsDiff[key] = [
+                ...assets.filter((asset) => !deletedAssetIdsList.includes(asset.id)),
+                ...addedAssetIdsList.map((id) => AssetDummy.with(id)),
+            ];
+            return assetsDiff;
+        }, {});
+
+    const notifyContextAssetsSubscribers = () => {
+        const next = computeBlockAssets();
+        contextAssetsSubscribers.forEach((subscriber) => subscriber(next));
+    };
+
     return {
         getProjectId: stub<Parameters<AppBridgeBlock['getProjectId']>>().returns(projectId),
         getEditorState: stub<Parameters<AppBridgeBlock['getEditorState']>>().returns(editorState),
@@ -80,26 +96,18 @@ export const getAppBridgeBlockStub = ({
         getAssetById: stub<Parameters<AppBridgeBlock['getAssetById']>>().callsFake((assetId) =>
             Promise.resolve(AssetDummy.with(assetId)),
         ),
-        getBlockAssets: stub<Parameters<AppBridgeBlock['getBlockAssets']>>().callsFake(() => {
-            return Object.entries(blockAssets).reduce<Record<string, Asset[]>>((assetsDiff, [key, assets]) => {
-                const addedAssetIdsList = addedAssetIds[key] ?? [];
-                const deletedAssetIdsList = deletedAssetIds[key] ?? [];
-                assetsDiff[key] = [
-                    ...assets.filter((asset) => !deletedAssetIdsList.includes(asset.id)),
-                    ...addedAssetIdsList.map((id) => AssetDummy.with(id)),
-                ];
-                return assetsDiff;
-            }, {});
-        }),
+        getBlockAssets: stub<Parameters<AppBridgeBlock['getBlockAssets']>>().callsFake(() => computeBlockAssets()),
         addAssetIdsToBlockAssetKey: stub<Parameters<AppBridgeBlock['addAssetIdsToBlockAssetKey']>>().callsFake(
             (key, assetsIds) => {
                 addedAssetIds[key] = [...(addedAssetIds[key] ?? []), ...assetsIds];
+                notifyContextAssetsSubscribers();
             },
         ),
         deleteAssetIdsFromBlockAssetKey: stub<
             Parameters<AppBridgeBlock['deleteAssetIdsFromBlockAssetKey']>
         >().callsFake((key, assetIds) => {
             deletedAssetIds[key] = [...(deletedAssetIds[key] ?? []), ...assetIds];
+            notifyContextAssetsSubscribers();
         }),
         getBlockTemplates: stub<Parameters<AppBridgeBlock['getBlockTemplates']>>().callsFake(() => {
             return Object.entries(blockTemplates).reduce<Record<string, Template[]>>(
@@ -140,6 +148,7 @@ export const getAppBridgeBlockStub = ({
                 }
                 case 'setAssetIdsByBlockAssetKey': {
                     blockAssets[args.payload.key] = args.payload.assetIds.map((id) => AssetDummy.with(id));
+                    notifyContextAssetsSubscribers();
                     return Promise.resolve();
                 }
             }

--- a/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
@@ -82,7 +82,9 @@ export const getAppBridgeBlockStub = ({
 
     const notifyContextAssetsSubscribers = () => {
         const next = computeBlockAssets();
-        contextAssetsSubscribers.forEach((subscriber) => subscriber(next));
+        for (const subscriber of contextAssetsSubscribers) {
+            subscriber(next);
+        }
     };
 
     return {


### PR DESCRIPTION
Merge after: https://github.com/Frontify/web-app/pull/14363 (tomorrow), then we can release this one next week

## Summary
Refactors `useBlockAssets` to derive its state from `AppBridge` `Context.assets` instead of the `AppBridge:BlockAssetsUpdated` emitter event. Mutation helpers no longer emit; the host app is now responsible for refreshing `context('assets')` after a mutation.

## Motivation
`AppBridge:BlockAssetsUpdated` was a parallel update channel that could drift from the canonical assets context. Now that `Context.assets` exists (added in #1553), the hook can subscribe to it directly, single source of truth, less ceremony, and the web-app emits the update from one place rather than each consumer of `useBlockAssets`.


## Test

- [x] Manual: in the web-app, add/delete/replace block assets and confirm consumers re-render
- [x] Manual: unmount a block consuming useBlockAssets and confirm no leaked subscription