### PR TITLE
refactor: remove translatability from theme settings structure

### DIFF
--- a/.changeset/silver-panthers-march.md
+++ b/.changeset/silver-panthers-march.md
@@ -1,0 +1,6 @@
+---
+"@frontify/guideline-themes": minor
+"@frontify/sidebar-settings": minor
+---
+
+Revert function shape from new sidebar settings type. Only allow static array.

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -2,6 +2,7 @@
 
 import { type AppBridgeTheme, type ThemeTemplate } from '@frontify/app-bridge-theme';
 import {
+    SettingsSection,
     type AssetInputBlock as AssetInputBlockSidebarSettings,
     type BaseBlock as BaseBlockSidebarSettings,
     type Bundle as BundleSidebarSettings,
@@ -78,13 +79,13 @@ export type ContentAreaAlignmentSetting = { contentAreaAlignmentChoice?: Content
  */
 export type LegacyThemeSettingsStructure = { [customSectionName: string]: SettingBlock[] };
 
-type TranslatableThemeSettingsStructure = TranslatableSettingsStructureSidebarSettings<AppBridgeTheme>;
+type ThemeSettingsSections = SettingsSection<AppBridgeTheme>[];
 
-export type ThemeSettingsStructureExport = LegacyThemeSettingsStructure | TranslatableThemeSettingsStructure;
+export type ThemeSettingsStructureExport = LegacyThemeSettingsStructure | ThemeSettingsSections;
 
 export type ThemeSettingsStructure =
     | Record<ThemeTemplate, LegacyThemeSettingsStructure>
-    | Record<ThemeTemplate, TranslatableThemeSettingsStructure>;
+    | Record<ThemeTemplate, ThemeSettingsSections>;
 
 export type ThemeProps = {
     appBridge: AppBridgeTheme;

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -2,7 +2,7 @@
 
 import { type AppBridgeTheme, type ThemeTemplate } from '@frontify/app-bridge-theme';
 import {
-    SettingsSection,
+    type SettingsSection,
     type AssetInputBlock as AssetInputBlockSidebarSettings,
     type BaseBlock as BaseBlockSidebarSettings,
     type Bundle as BundleSidebarSettings,

--- a/packages/guideline-themes/src/index.ts
+++ b/packages/guideline-themes/src/index.ts
@@ -24,7 +24,6 @@ import {
     type SwitchBlock as SwitchBlockSidebarSettings,
     type TemplateInputBlock as TemplateInputBlockSidebarSettings,
     type TextareaBlock as TextareaBlockSidebarSettings,
-    type TranslatableSettingsStructure as TranslatableSettingsStructureSidebarSettings,
     type ValueOrPromisedValue as ValueOrPromisedValueSidebarSettings,
 } from '@frontify/sidebar-settings';
 import { type FC } from 'react';

--- a/packages/sidebar-settings/src/settingsStructure.ts
+++ b/packages/sidebar-settings/src/settingsStructure.ts
@@ -47,20 +47,3 @@ export type LabeledSection<AppBridge> = {
  * layer.
  */
 export type SettingsSection<AppBridge> = MainSection<AppBridge> | LabeledSection<AppBridge>;
-
-/**
- * Settings structure that resolves at render time for the requested language.
- *
- * The argument is an object so the contract can grow new fields in the future
- * without breaking existing callers.
- *
- * @typeParam AppBridge - The AppBridge variant the contained blocks target.
- *
- * Currently supported languages are:
- * 'en', 'de', 'fr', 'es', 'it', 'pt', 'nl', 'da', 'sv', 'pl', 'cs', 'fi', 'no'
- */
-export type TranslatableSettingsStructure<AppBridge> = ({
-    languageCode,
-}: {
-    languageCode: string;
-}) => SettingsSection<AppBridge>[];


### PR DESCRIPTION
To simplify things, we decided to not make settings translatable at this point and only allow defining an icon and a label for sections