### PR TITLE
refactor(guideline-blocks-settings): drop redundant useMemoizedId from toolbar buttons

### DIFF
--- a/.changeset/quiet-flyouts-simplify.md
+++ b/.changeset/quiet-flyouts-simplify.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+refactor: remove redundant `useMemoizedId` wrapping around `flyoutId` in `AttachmentsToolbarButton`, `FlyoutToolbarButton`, and `MenuToolbarButton`. Each component already supplies a default `flyoutId`, so the memoized id was a pass-through. Drops the `@frontify/fondue` `useMemoizedId` import from these files.

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/AttachmentsToolbarButton/AttachmentsToolbarButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/AttachmentsToolbarButton/AttachmentsToolbarButton.tsx
@@ -1,7 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useMemoizedId } from '@frontify/fondue';
-
 import { useAttachmentsContext } from '../../../../hooks';
 import { Attachments } from '../../../Attachments';
 import { useDragPreviewContext } from '../context/DragPreviewContext';
@@ -16,12 +14,10 @@ type AttachmentsToolbarButtonProps = { flyoutId?: string };
 export const AttachmentsToolbarButton = ({
     flyoutId = DEFAULT_ATTACHMENTS_BUTTON_ID,
 }: AttachmentsToolbarButtonProps) => {
-    const id = useMemoizedId(flyoutId);
-
     const { appBridge, attachments, onAttachmentsAdd, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
         useAttachmentsContext();
 
-    const { isOpen, onOpenChange } = useMultiFlyoutState(id);
+    const { isOpen, onOpenChange } = useMultiFlyoutState(flyoutId);
     const isDragPreview = useDragPreviewContext();
 
     return (

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/FlyoutToolbarButton/FlyoutToolbarButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/FlyoutToolbarButton/FlyoutToolbarButton.tsx
@@ -1,6 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useMemoizedId } from '@frontify/fondue';
 import { Flyout } from '@frontify/fondue/components';
 import { type ReactNode } from 'react';
 
@@ -26,9 +25,7 @@ export const FlyoutToolbarButton = ({
     flyoutFooter,
     flyoutHeader,
 }: FlyoutToolbarButtonProps) => {
-    const id = useMemoizedId(flyoutId);
-
-    const { isOpen, onOpenChange } = useMultiFlyoutState(id);
+    const { isOpen, onOpenChange } = useMultiFlyoutState(flyoutId);
 
     const isDragPreview = useDragPreviewContext();
 

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/MenuToolbarButton/MenuToolbarButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/MenuToolbarButton/MenuToolbarButton.tsx
@@ -1,6 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useMemoizedId } from '@frontify/fondue';
 import { Dropdown, Tooltip } from '@frontify/fondue/components';
 import { IconDotsHorizontal } from '@frontify/fondue/icons';
 
@@ -26,8 +25,7 @@ export const MenuToolbarButton = ({
     flyoutId = DEFAULT_MENU_BUTTON_ID,
     tooltip = 'Options',
 }: MenuToolbarButtonProps) => {
-    const id = useMemoizedId(flyoutId);
-    const { isOpen, onOpenChange } = useMultiFlyoutState(id);
+    const { isOpen, onOpenChange } = useMultiFlyoutState(flyoutId);
     const isDragPreview = useDragPreviewContext();
 
     return (


### PR DESCRIPTION
## Summary

- Removes `useMemoizedId(flyoutId)` from `AttachmentsToolbarButton`, `FlyoutToolbarButton`, and `MenuToolbarButton`, passing `flyoutId` directly to `useMultiFlyoutState`.
- Each component already provides a default `flyoutId` (`DEFAULT_ATTACHMENTS_BUTTON_ID`, `DEFAULT_MENU_BUTTON_ID`, or a caller-supplied value), so `useMemoizedId` was a no-op pass-through.
- Drops the now-unused `useMemoizedId` import from `@frontify/fondue` in these three files.

## Why

- it's deprecated
- `useMemoizedId` is meant to fall back to a generated id when none is provided, but `flyoutId` here is always defined. The wrapper added an indirection without affecting behavior — multi-flyout coordination via `useMultiFlyoutContext` keys on the same string either way.
