### PR TITLE
feat(appBridgeTheme): add `url()` to `PageCategoryNavigationItem`

### DIFF
--- a/.changeset/neat-jars-shine.md
+++ b/.changeset/neat-jars-shine.md
@@ -1,0 +1,7 @@
+---
+"@frontify/app-bridge-theme": minor
+---
+
+feat(theme): add `url()` to `PageCategoryNavigationItem`
+
+`PageCategoryNavigationItem` now exposes a `url(language?: string)` method that returns the navigable URL of the page category, matching the `url()` already available on documents, document pages, and cover pages.

--- a/packages/app-bridge-theme/src/types/Guideline.ts
+++ b/packages/app-bridge-theme/src/types/Guideline.ts
@@ -76,6 +76,7 @@ export interface PageCategoryNavigationItem {
     id(): number;
     title(language?: string): string;
     slug(language?: string): string;
+    url(language?: string): string;
     children(): (DocumentPageNavigationItem | DocumentPageLinkNavigationItem)[];
     type: 'page-category';
 }


### PR DESCRIPTION
`PageCategoryNavigationItem` now exposes a `url(language?: string)` method that returns the navigable URL of the page category, matching the `url()` already available on documents, document pages, and cover pages.