### PR TITLE
fix(Attachments): flyout content not reachable via keyboard

### DIFF
--- a/.changeset/goofy-insects-attend.md
+++ b/.changeset/goofy-insects-attend.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(Attachments): flyout content not reachable via keyboard

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentItem.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentItem.tsx
@@ -85,7 +85,7 @@ export const AttachmentItem = forwardRef<HTMLButtonElement, AttachmentItemProps>
                     fontFamily: 'var(-f-theme-settings-body-font-family)',
                 }}
                 className={joinClassNames([
-                    'tw-cursor-pointer tw-text-left tw-w-full tw-relative tw-flex tw-gap-3 tw-px-5 tw-py-3 tw-items-center tw-group hover:tw-bg-container-secondary-hover',
+                    'tw-cursor-pointer tw-text-left tw-w-full tw-relative tw-flex tw-gap-3 tw-px-5 tw-py-3 tw-items-center tw-group hover:tw-bg-container-secondary-hover -tw-outline-offset-1',
                     isDragging ? 'tw-bg-container-secondary-hover' : '',
                 ])}
             >

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.ct.tsx
@@ -141,7 +141,6 @@ describe('Attachments', () => {
         cy.get(FlyoutButtonSelector).click();
         cy.realPress('Tab');
         cy.realPress('Tab');
-        cy.realPress('Tab');
         cy.realPress('Enter');
         cy.get(MenuItemSelector).should('exist');
     });

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -138,9 +138,6 @@ export const Attachments = ({
     };
 
     const autoFocusModifier = {
-        onOpenAutoFocus: (event: Event) => {
-            event.preventDefault();
-        },
         onEscapeKeyDown: (event: Event) => {
             event.stopPropagation();
             handleFlyoutOpenChange(false);


### PR DESCRIPTION
Changes:

- remove `onOpenAutoFocus` since it's preventing keyboard navigation hindering a11y
- tweak AttachmentItems outline ring since it's not entirely visible