### PR TITLE
feat(BlockItemWrapper): only show dnd tooltip if activated by keyboard

### DIFF
--- a/.changeset/bright-camels-flow.md
+++ b/.changeset/bright-camels-flow.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+feat(BlockItemWrapper): only show drag and drop tooltip if it was activated by keyboard

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/DragHandleToolbarButton/DragHandleToolbarButton.spec.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/DragHandleToolbarButton/DragHandleToolbarButton.spec.tsx
@@ -13,12 +13,21 @@ const TOOLTIP_ID = 'fondue-tooltip-content';
 
 const TOOLTIP_CONTENT = 'content';
 
+vi.mock('@dnd-kit/core', () => ({
+    useDndContext: vi.fn(() => ({ activatorEvent: null })),
+}));
+
 /**
  * @vitest-environment happy-dom
  */
 
 describe('DragHandleToolbarButton', () => {
-    it('should show tooltip and activeStyles when item is in drag preview context', () => {
+    it('should show tooltip and activeStyles when item is in keyboard drag preview context', async () => {
+        const { useDndContext } = await import('@dnd-kit/core');
+        vi.mocked(useDndContext).mockReturnValue({
+            activatorEvent: new KeyboardEvent('keydown'),
+        } as unknown as ReturnType<typeof useDndContext>);
+
         const { getByTestId } = render(
             <DragPreviewContextProvider isDragPreview>
                 <DragHandleToolbarButton
@@ -30,6 +39,26 @@ describe('DragHandleToolbarButton', () => {
         );
 
         expect(getByTestId(TOOLTIP_ID)).not.toHaveClass('tw-opacity-0');
+        expect(getByTestId(TOOLBAR_BUTTON_ID)).toHaveClass('tw-cursor-grabbing');
+    });
+
+    it('should not force tooltip open when item is in pointer drag preview context', async () => {
+        const { useDndContext } = await import('@dnd-kit/core');
+        vi.mocked(useDndContext).mockReturnValue({
+            activatorEvent: new PointerEvent('pointerdown'),
+        } as unknown as ReturnType<typeof useDndContext>);
+
+        const { queryByTestId, getByTestId } = render(
+            <DragPreviewContextProvider isDragPreview>
+                <DragHandleToolbarButton
+                    tooltip={TOOLTIP_CONTENT}
+                    icon={<IconAdobeCreativeCloud />}
+                    draggableProps={{}}
+                />
+            </DragPreviewContextProvider>,
+        );
+
+        expect(queryByTestId(TOOLTIP_ID)).not.toBeInTheDocument();
         expect(getByTestId(TOOLBAR_BUTTON_ID)).toHaveClass('tw-cursor-grabbing');
     });
 

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/DragHandleToolbarButton/DragHandleToolbarButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/DragHandleToolbarButton/DragHandleToolbarButton.tsx
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { useDndContext } from '@dnd-kit/core';
 import { type ReactNode } from 'react';
 
 import { DEFAULT_DRAGGING_TOOLTIP, DEFAULT_DRAG_TOOLTIP } from '../../constants';
@@ -21,10 +22,12 @@ export const DragHandleToolbarButton = ({
     draggableProps,
 }: DragHandleToolbarButtonProps) => {
     const isDragPreview = useDragPreviewContext();
+    const { activatorEvent } = useDndContext();
+    const activatedByKeyboard = activatorEvent instanceof KeyboardEvent;
 
     return (
         <ToolbarButtonTooltip
-            {...(isDragPreview && { open: isDragPreview })}
+            {...(isDragPreview && activatedByKeyboard && { open: true })}
             content={<div>{isDragPreview ? DEFAULT_DRAGGING_TOOLTIP : (tooltip ?? DEFAULT_DRAG_TOOLTIP)}</div>}
         >
             <BaseToolbarButton


### PR DESCRIPTION
Only show dnd tooltip if it was activated by keyboard, when dragging by mouse we don't need the tooltip.