### PR TITLE
chore(ci): bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/app-bridge-app-continuous-integration.yml
+++ b/.github/workflows/app-bridge-app-continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       should_run: ${{ steps.filter.outputs['app-bridge-app'] }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/app-bridge-continuous-integration.yml
+++ b/.github/workflows/app-bridge-continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       should_run: ${{ steps.filter.outputs['app-bridge'] }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -42,7 +42,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
@@ -60,7 +60,7 @@ jobs:
         run: pnpm --stream --filter {packages/app-bridge} test:coverage
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v6
+        uses: sonarsource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/app-bridge-theme-continuous-integration.yml
+++ b/.github/workflows/app-bridge-theme-continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       should_run: ${{ steps.filter.outputs['app-bridge-theme'] }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -42,7 +42,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/cli-continuous-integration.yml
+++ b/.github/workflows/cli-continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       should_run: ${{ steps.filter.outputs.cli }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -42,7 +42,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
@@ -60,7 +60,7 @@ jobs:
         run: pnpm --stream --filter {packages/cli} test:coverage
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v6
+        uses: sonarsource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/guideline-blocks-continuous-integration.yml
+++ b/.github/workflows/guideline-blocks-continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       should_run: ${{ steps.filter.outputs['guideline-blocks'] }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Use Node.js
         if: needs.changes.outputs.should_run == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
@@ -96,7 +96,7 @@ jobs:
 
       - name: Use Node.js
         if: needs.changes.outputs.should_run == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -158,7 +158,7 @@ jobs:
 
       - name: Use Node.js
         if: needs.changes.outputs.should_run == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/guideline-themes-continuous-integration.yml
+++ b/.github/workflows/guideline-themes-continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       should_run: ${{ steps.filter.outputs['guideline-themes'] }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -48,7 +48,7 @@ jobs:
 
       - name: Use Node.js
         if: needs.changes.outputs.should_run == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
@@ -93,7 +93,7 @@ jobs:
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/typing-continuous-integration.yml
+++ b/.github/workflows/typing-continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
             should_run: ${{ steps.filter.outputs['sidebar-settings'] }}
         steps:
             - uses: actions/checkout@v6
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
                   filters: |
@@ -42,7 +42,7 @@ jobs:
                   run_install: false
 
             - name: Use Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: ".nvmrc"
                   cache: "pnpm"


### PR DESCRIPTION
Bumps pinned GitHub Actions versions across the continuous-integration workflows:

- `dorny/paths-filter` v3 → v4
- `actions/setup-node` v4 → v6
- `sonarsource/sonarqube-scan-action` v6 → v8