### PR TITLE
fix(BlockItemWrapper): prevent showing the tooltip when dragging by mouse

### DIFF
--- a/.changeset/cute-years-scream.md
+++ b/.changeset/cute-years-scream.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(BlockItemWrapper): prevent showing the tooltip when dragging by mouse

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/DragHandleToolbarButton/DragHandleToolbarButton.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/DragHandleToolbarButton/DragHandleToolbarButton.tsx
@@ -27,7 +27,7 @@ export const DragHandleToolbarButton = ({
 
     return (
         <ToolbarButtonTooltip
-            {...(isDragPreview && activatedByKeyboard && { open: true })}
+            {...(isDragPreview && { open: activatedByKeyboard })}
             content={<div>{isDragPreview ? DEFAULT_DRAGGING_TOOLTIP : (tooltip ?? DEFAULT_DRAG_TOOLTIP)}</div>}
         >
             <BaseToolbarButton


### PR DESCRIPTION
Small tweak in logic to prevent showing tooltip when dragging by mouse.