### PR TITLE
feat(Attachments): several qol changes

### DIFF
--- a/.changeset/tricky-pants-grab.md
+++ b/.changeset/tricky-pants-grab.md
@@ -1,0 +1,5 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+feat(Attachments): several qol changes

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentItem.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentItem.tsx
@@ -14,8 +14,7 @@ import {
     IconMusicNote,
     IconGrabHandle,
 } from '@frontify/fondue/icons';
-import { useFocusRing } from '@react-aria/focus';
-import { type MutableRefObject, forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 
 import { joinClassNames } from '../../utilities';
 
@@ -54,8 +53,6 @@ export const AttachmentItem = forwardRef<HTMLButtonElement, AttachmentItemProps>
         const [openFileDialog, { selectedFiles }] = useFileInput({ multiple: true, accept: 'image/*' });
         const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload();
 
-        const { focusProps, isFocusVisible } = useFocusRing();
-
         useEffect(() => {
             if (selectedFiles) {
                 uploadFile(selectedFiles[0]);
@@ -85,8 +82,8 @@ export const AttachmentItem = forwardRef<HTMLButtonElement, AttachmentItemProps>
                     fontFamily: 'var(-f-theme-settings-body-font-family)',
                 }}
                 className={joinClassNames([
-                    'tw-cursor-pointer tw-text-left tw-w-full tw-relative tw-flex tw-gap-3 tw-px-5 tw-py-3 tw-items-center tw-group hover:tw-bg-container-secondary-hover -tw-outline-offset-1',
-                    isDragging ? 'tw-bg-container-secondary-hover' : '',
+                    'tw-cursor-pointer tw-text-left tw-w-full tw-relative tw-flex tw-gap-3 tw-px-5 tw-py-3 tw-items-center tw-group hover:tw-bg-surface-hover focus-visible:tw-outline focus-visible:!-tw-outline-offset-4',
+                    isDragging ? 'tw-bg-surface-hover' : '',
                 ])}
             >
                 <div className="tw-text-secondary group-hover:tw-text-container-secondary-on-secondary-container">
@@ -102,27 +99,22 @@ export const AttachmentItem = forwardRef<HTMLButtonElement, AttachmentItemProps>
                     <div
                         data-test-id="attachments-actionbar"
                         className={joinClassNames([
-                            'tw-flex tw-gap-0.5 group-focus:tw-opacity-100 focus-visible:tw-opacity-100 focus-within:tw-opacity-100 group-hover:tw-opacity-100',
+                            'tw-flex tw-gap-0.5 group-hover:tw-opacity-100 group-focus-visible:tw-opacity-100 has-[:focus-visible]:tw-opacity-100',
                             isOverlay || selectedAsset?.id === item.id ? 'tw-opacity-100' : 'tw-opacity-0',
                         ])}
                     >
-                        <button
-                            type="button"
-                            {...focusProps}
-                            {...draggableProps}
+                        <Button
+                            aspect="square"
+                            emphasis="weak"
                             aria-label="Drag attachment"
                             className={joinClassNames([
-                                ' tw-border-primary tw-bg-container-secondary active:tw-bg-container-secondary-active tw-group tw-border tw-box-box tw-relative tw-flex tw-items-center tw-justify-center tw-outline-none tw-font-medium tw-rounded-medium tw-h-9 tw-w-9 ',
-                                isDragging || isOverlay
-                                    ? 'tw-cursor-grabbing tw-bg-container-secondary-active hover:tw-bg-container-secondary-active'
-                                    : 'tw-cursor-grab hover:tw-bg-container-secondary-hover',
-                                isFocusVisible &&
-                                    'tw-ring-4 tw-ring-blue tw-ring-offset-2 dark:tw-ring-offset-black tw-outline-none',
-                                isFocusVisible && 'tw-z-[2]',
+                                isDragging || isOverlay ? 'tw-cursor-grabbing' : 'tw-cursor-grab',
+                                'focus-visible:tw-z-[2]',
                             ])}
+                            {...draggableProps}
                         >
                             <IconGrabHandle />
-                        </button>
+                        </Button>
                         <div data-test-id="attachments-actionbar-flyout">
                             <Dropdown.Root
                                 open={selectedAsset?.id === item.id}
@@ -131,12 +123,11 @@ export const AttachmentItem = forwardRef<HTMLButtonElement, AttachmentItemProps>
                                 <Dropdown.Trigger>
                                     <Button
                                         aspect="square"
-                                        ref={ref as MutableRefObject<HTMLButtonElement>}
+                                        emphasis={selectedAsset?.id === item.id ? 'default' : 'weak'}
                                         onPress={(e) => {
                                             e?.stopPropagation();
                                             e?.preventDefault();
                                         }}
-                                        emphasis="default"
                                     >
                                         <IconPen size="20" />
                                     </Button>

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -10,11 +10,11 @@ import {
     useSensor,
     useSensors,
 } from '@dnd-kit/core';
-import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import { restrictToParentElement } from '@dnd-kit/modifiers';
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable';
 import { type Asset, useAssetChooser, useAssetUpload, useEditorState } from '@frontify/app-bridge';
-import { AssetInput, AssetInputSize } from '@frontify/fondue';
-import { Tooltip, Flyout } from '@frontify/fondue/components';
+import { Tooltip, Flyout, AssetInput, Flex } from '@frontify/fondue/components';
+import { IconArrowCircleUp, IconImageStack } from '@frontify/fondue/icons';
 import { useEffect, useState } from 'react';
 
 import { SortableAttachmentItem } from './AttachmentItem';
@@ -39,6 +39,7 @@ export const Attachments = ({
     const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
     const [draggedAssetId, setDraggedAssetId] = useState<number | undefined>(undefined);
     const [isUploadLoading, setIsUploadLoading] = useState(false);
+    const [isBrowseLoading, setIsBrowseLoading] = useState(false);
     const [assetIdsLoading, setAssetIdsLoading] = useState<number[]>([]);
     const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
     const isEditing = useEditorState(appBridge);
@@ -84,10 +85,13 @@ export const Attachments = ({
     const onOpenAssetChooser = () => {
         handleFlyoutOpenChange(false);
         openAssetChooser(
-            (result: Asset[]) => {
-                onBrowse(result);
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            async (result: Asset[]) => {
                 closeAssetChooser();
                 handleFlyoutOpenChange(true);
+                setIsBrowseLoading(true);
+                await onBrowse(result);
+                setIsBrowseLoading(false);
             },
             {
                 multiSelection: true,
@@ -158,15 +162,15 @@ export const Attachments = ({
                             </TriggerComponent>
                         </Flyout.Trigger>
                     </Tooltip.Trigger>
-                    <Flyout.Content side="bottom" align="end" {...autoFocusModifier}>
-                        <div className="tw-w-[300px]" data-test-id="attachments-flyout-content">
+                    <Flyout.Content side="bottom" align="end" width="300px" {...autoFocusModifier}>
+                        <div className="tw-w-full" data-test-id="attachments-flyout-content">
                             {internalItems.length > 0 && (
                                 <DndContext
                                     sensors={sensors}
                                     collisionDetection={closestCenter}
                                     onDragStart={handleDragStart}
                                     onDragEnd={handleDragEnd}
-                                    modifiers={[restrictToVerticalAxis]}
+                                    modifiers={[restrictToParentElement]}
                                 >
                                     <SortableContext items={internalItems} strategy={rectSortingStrategy}>
                                         <div className="tw-border-b tw-border-b-line tw-relative">
@@ -198,12 +202,34 @@ export const Attachments = ({
                                     <div className="tw-font-primary tw-font-medium tw-text-primary tw-text-small tw-my-4">
                                         Add attachments
                                     </div>
-                                    <AssetInput
-                                        isLoading={isUploadLoading}
-                                        size={AssetInputSize.Small}
-                                        onUploadClick={(fileList) => setSelectedFiles(fileList)}
-                                        onLibraryClick={onOpenAssetChooser}
-                                    />
+                                    {isUploadLoading || isBrowseLoading ? (
+                                        <AssetInput.Root orientation="horizontal">
+                                            <AssetInput.Preview>
+                                                <AssetInput.PreviewLoading />
+                                            </AssetInput.Preview>
+                                            <AssetInput.Title>Asset</AssetInput.Title>
+                                            <AssetInput.Metadata>
+                                                <AssetInput.MetadataItem>
+                                                    <Flex align="center" gap={0.5}>
+                                                        {isBrowseLoading ? (
+                                                            <IconImageStack size={16} />
+                                                        ) : (
+                                                            <IconArrowCircleUp size={16} />
+                                                        )}
+                                                        {isBrowseLoading ? 'Loading' : 'Uploading'}
+                                                    </Flex>
+                                                </AssetInput.MetadataItem>
+                                            </AssetInput.Metadata>
+                                        </AssetInput.Root>
+                                    ) : (
+                                        <AssetInput.Placeholder>
+                                            <AssetInput.UploadInput
+                                                allowMultiple
+                                                onSelect={(event) => setSelectedFiles(event.target.files)}
+                                            />
+                                            <AssetInput.BrowseInput onBrowse={onOpenAssetChooser} />
+                                        </AssetInput.Placeholder>
+                                    )}
                                 </div>
                             )}
                         </div>

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -198,7 +198,7 @@ export const Attachments = ({
                                 </DndContext>
                             )}
                             {isEditing && (
-                                <div className="tw-px-5 tw-py-3">
+                                <div className="tw-px-5 tw-py-3" data-test-id="asset-input-placeholder">
                                     <div className="tw-font-primary tw-font-medium tw-text-primary tw-text-small tw-my-4">
                                         Add attachments
                                     </div>

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -15,7 +15,7 @@ export type AttachmentsProps = {
     onReplaceWithBrowse: (attachmentToReplace: Asset, newAsset: Asset) => Promise<void>;
     onDelete: (attachmentToDelete: Asset) => void;
     onUpload: (uploadedAttachments: Asset[]) => Promise<void>;
-    onBrowse: (browserAttachments: Asset[]) => void;
+    onBrowse: (browserAttachments: Asset[]) => void | Promise<void>;
     onSorted: (sortedAttachments: Asset[]) => void;
     triggerComponent?: React.ForwardRefExoticComponent<
         AttachmentsTriggerProps & React.RefAttributes<HTMLButtonElement>


### PR DESCRIPTION
The attachments component needed quite some love so here is the list of improvements in this PR:

1. Loading indicator is now shown when selecting asset via asset chooser.
2. Hover color is now less prominent (using surface tokens)
3. On mobile it is properly taking full width now
4. Using Fondue `<Button />` components instead of native buttons
5. Migrate to the new `AssetInput` component
6. Focus visible outlines no longer clipped
7. DnD now stays inside the flyout content


https://github.com/user-attachments/assets/67ac2990-04ea-40fe-baba-bb8bfe4ae4d1

