### PR TITLE
fix(cli):  make eslint usage optional during deploy

### DIFF
--- a/.changeset/eager-webs-drop.md
+++ b/.changeset/eager-webs-drop.md
@@ -1,0 +1,5 @@
+---
+"@frontify/frontify-cli": patch
+---
+
+fix(deploy): prevent script from crashing if package does not use eslint

--- a/.changeset/eager-webs-drop.md
+++ b/.changeset/eager-webs-drop.md
@@ -2,4 +2,6 @@
 "@frontify/frontify-cli": patch
 ---
 
-fix(deploy): prevent script from crashing if package does not use eslint
+fix(deploy): skip eslint checks when no eslint config is present
+
+The deploy command previously failed when a project had no ESLint config file. It now detects a missing config and skips the ESLint step, so projects that lint with another tool (e.g. oxlint) can deploy. Run your  linter manually before deploying if you don't use ESLint.

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -81,6 +81,16 @@ export const verifyCode = async (noVerify: boolean) => {
     Logger.info('Performing type checks...');
     await promiseExec('npx tsc --noEmit');
 
+    const eslintConfigFiles = await fastGlob(
+        ['.eslintrc', '.eslintrc.{js,cjs,mjs,json,yaml,yml}', 'eslint.config.{js,cjs,mjs,ts,cts,mts}'],
+        { dot: true },
+    );
+
+    if (eslintConfigFiles.length === 0) {
+        Logger.info('Eslint config file not found, skipping eslint checks...');
+        return;
+    }
+
     Logger.info('Performing eslint checks...');
     await promiseExec('npx eslint src');
 };


### PR DESCRIPTION
The deploy command should not crash/stop if it cannot find an `eslint` config file.

We're migrating `guideline-blocks` packages to `oxlint` and the current deploy setup does not work anymore.
The current changes will fix the issue making the deploy script a bit more flexible.

P.S: current changes will require the consumers to run a `pnpm lint` command before the deploy manually (if they are not using eslint) but as discussed within the team we think this should be the way to go as deployment script should not be responsible for linting.