### PR TITLE
feat(app-bridge): add link chooser related commands

### DIFF
--- a/.changeset/gentle-otters-open.md
+++ b/.changeset/gentle-otters-open.md
@@ -9,7 +9,7 @@ Adds a `linkChosen` event and a `useLinkChooser` hook.
 ```ts
 import { openLinkChooser, closeLinkChooser } from "@frontify/app-bridge";
 
-await appBridge.dispatch(openLinkChooser({ hubId: 123, selectedItem: currentUrl }));
+await appBridge.dispatch(openLinkChooser({ selectedUrl: currentUrl }));
 // ...
 await appBridge.dispatch(closeLinkChooser());
 ```

--- a/.changeset/gentle-otters-open.md
+++ b/.changeset/gentle-otters-open.md
@@ -1,0 +1,15 @@
+---
+"@frontify/app-bridge": minor
+---
+
+feat: add `openLinkChooser`/`closeLinkChooser` block commands to open the in-sourced link chooser
+
+Adds a `linkChosen` event and a `useLinkChooser` hook.
+
+```ts
+import { openLinkChooser, closeLinkChooser } from "@frontify/app-bridge";
+
+await appBridge.dispatch(openLinkChooser({ hubId: 123, selectedItem: currentUrl }));
+// ...
+await appBridge.dispatch(closeLinkChooser());
+```

--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -40,10 +40,12 @@ export type BlockCommand = CommandNameValidator<
     Pick<
         CommandRegistry,
         | 'closeAssetChooser'
+        | 'closeLinkChooser'
         | 'closeTemplateChooser'
         | 'downloadAsset'
         | 'openAssetChooser'
         | 'openAssetViewer'
+        | 'openLinkChooser'
         | 'openTemplateChooser'
         | 'openNewPublication'
         | 'openPlatformAppDirect'
@@ -67,7 +69,7 @@ export type BlockContext = {
 };
 
 export type BlockEvent = EventNameValidator<
-    Pick<EventRegistry, 'assetsChosen' | 'templateChosen'> &
+    Pick<EventRegistry, 'assetsChosen' | 'linkChosen' | 'templateChosen'> &
         StateAsEventName<BlockState & { '*': BlockState }> &
         ContextAsEventName<BlockContext & { '*': BlockContext }>
 >;

--- a/packages/app-bridge/src/react/index.ts
+++ b/packages/app-bridge/src/react/index.ts
@@ -11,6 +11,7 @@ export * from './useBlockTemplates';
 export * from './useEditorState';
 export * from './useFileInput';
 export * from './useFileUpload';
+export * from './useLinkChooser';
 export * from './usePrivacySettings';
 export * from './useReadyForPrint';
 export * from './useTemplateChooser';

--- a/packages/app-bridge/src/react/useLinkChooser.spec.tsx
+++ b/packages/app-bridge/src/react/useLinkChooser.spec.tsx
@@ -25,7 +25,7 @@ const LinkChooserDummy = ({
         <>
             <button
                 data-test-id={OPEN_LINK_CHOOSER_BUTTON_ID}
-                onClick={() => openLinkChooser(onLinkChosen ?? (() => null), { hubId: 123 })}
+                onClick={() => openLinkChooser(onLinkChosen ?? (() => null), {})}
                 type="button"
             >
                 Open Link Chooser

--- a/packages/app-bridge/src/react/useLinkChooser.spec.tsx
+++ b/packages/app-bridge/src/react/useLinkChooser.spec.tsx
@@ -1,0 +1,90 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { cleanup, render } from '@testing-library/react';
+import sinon from 'sinon';
+import { afterEach, describe, it } from 'vitest';
+
+import { type AppBridgeBlock } from '../AppBridgeBlock';
+import { withAppBridgeBlockStubs } from '../tests/withAppBridgeBlockStubs';
+
+import { useLinkChooser } from './useLinkChooser';
+
+const OPEN_LINK_CHOOSER_BUTTON_ID = 'open-link-chooser';
+const CLOSE_LINK_CHOOSER_BUTTON_ID = 'close-link-chooser';
+
+const LinkChooserDummy = ({
+    appBridge,
+    onLinkChosen,
+}: {
+    appBridge: AppBridgeBlock;
+    onLinkChosen?: (url: string) => void;
+}) => {
+    const { openLinkChooser, closeLinkChooser } = useLinkChooser(appBridge);
+
+    return (
+        <>
+            <button
+                data-test-id={OPEN_LINK_CHOOSER_BUTTON_ID}
+                onClick={() => openLinkChooser(onLinkChosen ?? (() => null), { hubId: 123 })}
+                type="button"
+            >
+                Open Link Chooser
+            </button>
+            <button data-test-id={CLOSE_LINK_CHOOSER_BUTTON_ID} onClick={() => closeLinkChooser()} type="button">
+                Close Link Chooser
+            </button>
+        </>
+    );
+};
+
+describe('useLinkChooser hook', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('should open the link chooser', () => {
+        const [BlockWithStubs, appBridge] = withAppBridgeBlockStubs(LinkChooserDummy);
+        const { getByTestId } = render(<BlockWithStubs />);
+        const openLinkChooserButton = getByTestId(OPEN_LINK_CHOOSER_BUTTON_ID) as HTMLButtonElement;
+        openLinkChooserButton.click();
+        sinon.assert.calledWith(appBridge.dispatch, sinon.match.has('name', 'openLinkChooser'));
+    });
+
+    it('should close the link chooser', () => {
+        const [BlockWithStubs, appBridge] = withAppBridgeBlockStubs(LinkChooserDummy);
+        const { getByTestId } = render(<BlockWithStubs />);
+        const closeLinkChooserButton = getByTestId(CLOSE_LINK_CHOOSER_BUTTON_ID) as HTMLButtonElement;
+        closeLinkChooserButton.click();
+        sinon.assert.calledWith(appBridge.dispatch, sinon.match.has('name', 'closeLinkChooser'));
+    });
+
+    it('should call the onLinkChosen callback when a link is chosen', () => {
+        const [BlockWithStubs] = withAppBridgeBlockStubs(LinkChooserDummy);
+        const onLinkChosen = sinon.spy();
+        const { getByTestId } = render(<BlockWithStubs onLinkChosen={onLinkChosen} />);
+        const openLinkChooserButton = getByTestId(OPEN_LINK_CHOOSER_BUTTON_ID) as HTMLButtonElement;
+        openLinkChooserButton.click();
+        sinon.assert.calledWith(onLinkChosen, 'https://example.com');
+    });
+
+    it('should unsubscribe if link chooser gets opened and closed', () => {
+        const unsubscribeSpy = sinon.spy();
+        const [BlockWithStubs] = withAppBridgeBlockStubs(LinkChooserDummy, { unsubscribe: unsubscribeSpy });
+        const { getByTestId } = render(<BlockWithStubs />);
+        const openLinkChooserButton = getByTestId(OPEN_LINK_CHOOSER_BUTTON_ID) as HTMLButtonElement;
+        openLinkChooserButton.click();
+        const closeLinkChooserButton = getByTestId(CLOSE_LINK_CHOOSER_BUTTON_ID) as HTMLButtonElement;
+        closeLinkChooserButton.click();
+        sinon.assert.calledOnce(unsubscribeSpy);
+    });
+
+    it('should unsubscribe the previous subscription if opened again without closing', () => {
+        const unsubscribeSpy = sinon.spy();
+        const [BlockWithStubs] = withAppBridgeBlockStubs(LinkChooserDummy, { unsubscribe: unsubscribeSpy });
+        const { getByTestId } = render(<BlockWithStubs />);
+        const openLinkChooserButton = getByTestId(OPEN_LINK_CHOOSER_BUTTON_ID) as HTMLButtonElement;
+        openLinkChooserButton.click();
+        openLinkChooserButton.click();
+        sinon.assert.calledOnce(unsubscribeSpy);
+    });
+});

--- a/packages/app-bridge/src/react/useLinkChooser.ts
+++ b/packages/app-bridge/src/react/useLinkChooser.ts
@@ -1,0 +1,30 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type EventUnsubscribeFunction } from '../AppBridge';
+import { type AppBridgeBlock } from '../AppBridgeBlock';
+import { closeLinkChooser, openLinkChooser } from '../registries/commands/LinkChooser';
+import { type LinkChooserOptions } from '../types';
+
+type UseLinkChooserType = {
+    openLinkChooser: (callback: (url: string) => void, options: LinkChooserOptions) => Promise<void>;
+    closeLinkChooser: () => Promise<void>;
+};
+
+// oxlint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+export const useLinkChooser = (appBridge: AppBridgeBlock): UseLinkChooserType => {
+    let unsubscribe: EventUnsubscribeFunction;
+
+    return {
+        openLinkChooser: async (callback, options) => {
+            unsubscribe?.();
+            unsubscribe = appBridge.subscribe('linkChosen', (chosenLink) => {
+                callback(chosenLink.url);
+            });
+            await appBridge.dispatch(openLinkChooser(options));
+        },
+        closeLinkChooser: async () => {
+            unsubscribe?.();
+            await appBridge.dispatch(closeLinkChooser());
+        },
+    };
+};

--- a/packages/app-bridge/src/registries/commands/CommandRegistry.ts
+++ b/packages/app-bridge/src/registries/commands/CommandRegistry.ts
@@ -5,6 +5,7 @@ import {
     type AssetViewerOptions,
     type Asset,
     type AssetChooserOptions,
+    type LinkChooserOptions,
     type OpenNewPublicationPayload,
     type TrackPayload,
 } from '../../types';
@@ -14,6 +15,8 @@ type CloseAssetChooserPayload = void;
 type OpenAssetViewerPayload = AssetViewerOptions;
 type OpenTemplateChooser = void;
 type CloseTemplateChooser = void;
+type OpenLinkChooserPayload = LinkChooserOptions;
+type CloseLinkChooserPayload = void;
 type DownloadAsset = Asset;
 type OpenSearchDialog = void;
 type CloseSearchDialog = void;
@@ -25,6 +28,8 @@ export type CommandRegistry = CommandNameValidator<{
     openAssetViewer: OpenAssetViewerPayload;
     openTemplateChooser: OpenTemplateChooser;
     closeTemplateChooser: CloseTemplateChooser;
+    openLinkChooser: OpenLinkChooserPayload;
+    closeLinkChooser: CloseLinkChooserPayload;
     downloadAsset: DownloadAsset;
     openNewPublication: OpenNewPublicationPayload;
     openSearchDialog: OpenSearchDialog;

--- a/packages/app-bridge/src/registries/commands/CommandRegistry.ts
+++ b/packages/app-bridge/src/registries/commands/CommandRegistry.ts
@@ -28,7 +28,7 @@ export type CommandRegistry = CommandNameValidator<{
     openAssetViewer: OpenAssetViewerPayload;
     openTemplateChooser: OpenTemplateChooser;
     closeTemplateChooser: CloseTemplateChooser;
-    openLinkChooser: OpenLinkChooserPayload;
+    openLinkChooser?: OpenLinkChooserPayload;
     closeLinkChooser: CloseLinkChooserPayload;
     downloadAsset: DownloadAsset;
     openNewPublication: OpenNewPublicationPayload;

--- a/packages/app-bridge/src/registries/commands/LinkChooser.ts
+++ b/packages/app-bridge/src/registries/commands/LinkChooser.ts
@@ -1,0 +1,16 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type DispatchHandlerParameter } from '../../AppBridge';
+
+import { type CommandRegistry } from './CommandRegistry';
+
+export const openLinkChooser = (
+    options: CommandRegistry['openLinkChooser'],
+): DispatchHandlerParameter<'openLinkChooser', CommandRegistry> => ({
+    name: 'openLinkChooser',
+    payload: options,
+});
+
+export const closeLinkChooser = (): DispatchHandlerParameter<'closeLinkChooser', CommandRegistry> => ({
+    name: 'closeLinkChooser',
+});

--- a/packages/app-bridge/src/registries/commands/LinkChooser.ts
+++ b/packages/app-bridge/src/registries/commands/LinkChooser.ts
@@ -5,7 +5,7 @@ import { type DispatchHandlerParameter } from '../../AppBridge';
 import { type CommandRegistry } from './CommandRegistry';
 
 export const openLinkChooser = (
-    options: CommandRegistry['openLinkChooser'],
+    options?: CommandRegistry['openLinkChooser'],
 ): DispatchHandlerParameter<'openLinkChooser', CommandRegistry> => ({
     name: 'openLinkChooser',
     payload: options,

--- a/packages/app-bridge/src/registries/commands/index.ts
+++ b/packages/app-bridge/src/registries/commands/index.ts
@@ -4,6 +4,7 @@ export * from './AssetChooser';
 export * from './AssetViewer';
 export * from './CommandRegistry';
 export * from './DownloadAsset';
+export * from './LinkChooser';
 export * from './NewPublication';
 export * from './PlatformApp';
 export * from './SearchDialog';

--- a/packages/app-bridge/src/registries/events/EventRegistry.ts
+++ b/packages/app-bridge/src/registries/events/EventRegistry.ts
@@ -6,4 +6,5 @@ import { type Asset, type TemplateLegacy } from '../../types';
 export type EventRegistry = EventNameValidator<{
     assetsChosen: { assets: Asset[] };
     templateChosen: { template: TemplateLegacy };
+    linkChosen: { url: string };
 }>;

--- a/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
+++ b/packages/app-bridge/src/tests/AppBridgeBlockStub.ts
@@ -206,6 +206,8 @@ export const getAppBridgeBlockStub = ({
                 (callback as EventCallbackParameter<'templateChosen', BlockEvent>)({
                     template: TemplateLegacyDummy.with(234),
                 });
+            } else if (eventName === 'linkChosen') {
+                (callback as EventCallbackParameter<'linkChosen', BlockEvent>)({ url: 'https://example.com' });
             }
             return unsubscribe;
         }),

--- a/packages/app-bridge/src/types/LinkChooserOptions.ts
+++ b/packages/app-bridge/src/types/LinkChooserOptions.ts
@@ -1,6 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export type LinkChooserOptions = {
-    hubId: number;
-    selectedItem?: string;
+    selectedUrl?: string;
 };

--- a/packages/app-bridge/src/types/LinkChooserOptions.ts
+++ b/packages/app-bridge/src/types/LinkChooserOptions.ts
@@ -1,0 +1,6 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export type LinkChooserOptions = {
+    hubId: number;
+    selectedItem?: string;
+};

--- a/packages/app-bridge/src/types/index.ts
+++ b/packages/app-bridge/src/types/index.ts
@@ -13,6 +13,7 @@ export * from './File';
 export * from './FileExtension';
 export * from './FileExtensionSets';
 export * from './FileType';
+export * from './LinkChooserOptions';
 export * from './PrivacySettings';
 export * from './SubscriptionHandler';
 export * from './Targets';


### PR DESCRIPTION
## What this PR adds

Adds `openLinkChooser`/`closeLinkChooser` block commands, a `linkChosen` event, and a `useLinkChooser` hook — mirroring the existing `openAssetChooser`/`assetsChosen` pattern to drive the in-sourced link chooser.

## Usage

```ts
import { openLinkChooser, closeLinkChooser } from '@frontify/app-bridge';

await appBridge.dispatch(openLinkChooser({ selectedUrl: currentUrl }));
// ...
await appBridge.dispatch(closeLinkChooser());
```
Or via the hook:

```ts 
const { openLinkChooser, closeLinkChooser } = useLinkChooser(appBridge);
await openLinkChooser((url) => setUrl(url), { selectedUrl: 'xxx' });
````
