### PR TITLE
feat(Attachments): improve a11y labels

### DIFF
--- a/.changeset/olive-clocks-listen.md
+++ b/.changeset/olive-clocks-listen.md
@@ -1,0 +1,7 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(Attachments): improve the accessibility of the flyout trigger
+
+The trigger now has an accessible name that describes the action and the number of attachments (e.g. `Open attachments, 1 attachment`) instead of only exposing the bare count, and it announces `aria-haspopup="menu"` instead of `dialog`.

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.spec.tsx
@@ -71,6 +71,32 @@ describe('Attachments', () => {
         expect(screen.queryByTestId(FLYOUT_TRIGGER_TEST_ID)).not.toBeInTheDocument();
     });
 
+    it('should announce the action and the number of attachments on the trigger', () => {
+        renderAttachments({ items: [AssetDummy.with(1)] });
+
+        expect(screen.getAllByTestId(FLYOUT_TRIGGER_TEST_ID)[0]).toHaveAccessibleName('Open attachments, 1 attachment');
+    });
+
+    it('should pluralize the number of attachments on the trigger', () => {
+        renderAttachments({ items: [AssetDummy.with(1), AssetDummy.with(2)] });
+
+        expect(screen.getAllByTestId(FLYOUT_TRIGGER_TEST_ID)[0]).toHaveAccessibleName(
+            'Open attachments, 2 attachments',
+        );
+    });
+
+    it('should announce the add action on the trigger if there are no attachments', () => {
+        renderAttachments({ appBridge: getAppBridgeBlockStub({ editorState: true }), items: [] });
+
+        expect(screen.getAllByTestId(FLYOUT_TRIGGER_TEST_ID)[0]).toHaveAccessibleName('Add attachments');
+    });
+
+    it('should mark the trigger as having a menu popup', () => {
+        renderAttachments({ items: [AssetDummy.with(1)] });
+
+        expect(screen.getAllByTestId(FLYOUT_TRIGGER_TEST_ID)[0]).toHaveAttribute('aria-haspopup', 'menu');
+    });
+
     it('should render the asset input if it is in edit mode', async () => {
         renderAttachments({ appBridge: getAppBridgeBlockStub({ editorState: true }), items: [AssetDummy.with(1)] });
 

--- a/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/Attachments.tsx
@@ -49,6 +49,12 @@ export const Attachments = ({
 
     const draggedItem = internalItems?.find((item) => item.id === draggedAssetId);
 
+    const attachmentCount = items.length;
+    const triggerLabel =
+        attachmentCount > 0
+            ? `Open attachments, ${attachmentCount} ${attachmentCount === 1 ? 'attachment' : 'attachments'}`
+            : 'Add attachments';
+
     const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload({
         onUploadProgress: () => !isUploadLoading && setIsUploadLoading(true),
     });
@@ -157,8 +163,8 @@ export const Attachments = ({
                 <Tooltip.Root enterDelay={500}>
                     <Tooltip.Trigger asChild>
                         <Flyout.Trigger asChild data-test-id="attachments-button-trigger">
-                            <TriggerComponent isFlyoutOpen={isFlyoutOpen}>
-                                <div>{items.length > 0 ? items.length : 'Add'}</div>
+                            <TriggerComponent isFlyoutOpen={isFlyoutOpen} aria-label={triggerLabel}>
+                                <div aria-hidden="true">{attachmentCount > 0 ? attachmentCount : 'Add'}</div>
                             </TriggerComponent>
                         </Flyout.Trigger>
                     </Tooltip.Trigger>

--- a/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/Attachments/AttachmentsButtonTrigger.tsx
@@ -16,6 +16,7 @@ export const AttachmentsButtonTrigger = forwardRef<HTMLButtonElement, Attachment
             data-test-id="attachments-button-trigger"
             className="tw-body-medium"
             {...props}
+            aria-haspopup="menu"
         >
             <IconPaperclip size="16" />
             {children}

--- a/packages/guideline-blocks-settings/src/components/Attachments/types.ts
+++ b/packages/guideline-blocks-settings/src/components/Attachments/types.ts
@@ -1,12 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { type AppBridgeBlock, type Asset } from '@frontify/app-bridge';
-import { type ReactNode } from 'react';
+import { type AriaAttributes, type ReactNode } from 'react';
 
 export type AttachmentsTriggerProps = {
     children: ReactNode;
     isFlyoutOpen: boolean;
-};
+} & Pick<AriaAttributes, 'aria-label'>;
 
 export type AttachmentsProps = {
     items?: Asset[];

--- a/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/AttachmentsToolbarButton/AttachmentsToolbarButtonTrigger.tsx
+++ b/packages/guideline-blocks-settings/src/components/BlockItemWrapper/Toolbar/AttachmentsToolbarButton/AttachmentsToolbarButtonTrigger.tsx
@@ -13,6 +13,7 @@ export const AttachmentsToolbarButtonTrigger = forwardRef<HTMLButtonElement, Att
             data-test-id="attachments-toolbar-button-trigger"
             ref={ref}
             {...props}
+            aria-haspopup="menu"
         >
             <IconPaperclip size="16" />
             {children}


### PR DESCRIPTION
1. The trigger now has an accessible name that describes the action and the number of attachments (e.g. `Open attachments, 1 attachment`)
2. `aria-haspopup="menu"` instead of `dialog`.