### PR TITLE
fix(Link): keep root-relative urls untouched

### DIFF
--- a/.changeset/lucky-hounds-wander.md
+++ b/.changeset/lucky-hounds-wander.md
@@ -1,0 +1,7 @@
+---
+"@frontify/guideline-blocks-settings": patch
+---
+
+fix(Link): keep root-relative urls untouched
+
+Root-relative urls entered in the link and button flyouts — such as `/hub/167` — were treated as invalid and turned into a broken absolute url like `https:///hub/167`. Any path starting with `/` is now accepted and stored as-is, so links keep working across multiple domains and sites. Previously only `/document/…` and `/r/…` were preserved.

--- a/packages/guideline-blocks-settings/src/components/Link/utils/relativeUrlRegex.spec.ts
+++ b/packages/guideline-blocks-settings/src/components/Link/utils/relativeUrlRegex.spec.ts
@@ -15,18 +15,38 @@ describe('Regex values', () => {
             shouldMatch: true,
         },
         {
-            input: '/wrong/123',
-            shouldMatch: false,
+            input: '/hub/167',
+            shouldMatch: true,
+        },
+        {
+            input: '/hub/167?tab=overview#section',
+            shouldMatch: true,
+        },
+        {
+            input: '/',
+            shouldMatch: true,
         },
         {
             input: '/r/',
+            shouldMatch: true,
+        },
+        {
+            input: '//example.com',
             shouldMatch: false,
         },
         {
-            input: '/document/',
+            input: 'hub/167',
             shouldMatch: false,
         },
-    ])('should only match internal documents starting with /r/ or /document/', ({ input, shouldMatch }) => {
+        {
+            input: 'https://example.com/hub/167',
+            shouldMatch: false,
+        },
+        {
+            input: '/hub/with space',
+            shouldMatch: false,
+        },
+    ])('should only match root-relative urls ($input)', ({ input, shouldMatch }) => {
         const isMatching = relativeUrlRegex.test(input);
         expect(isMatching).toBe(shouldMatch);
     });

--- a/packages/guideline-blocks-settings/src/components/Link/utils/relativeUrlRegex.ts
+++ b/packages/guideline-blocks-settings/src/components/Link/utils/relativeUrlRegex.ts
@@ -1,3 +1,3 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export const relativeUrlRegex = /^\/(document|r)\/\S+$/i;
+export const relativeUrlRegex = /^\/(?!\/)\S*$/;

--- a/packages/guideline-blocks-settings/src/components/Link/utils/url.spec.ts
+++ b/packages/guideline-blocks-settings/src/components/Link/utils/url.spec.ts
@@ -48,7 +48,19 @@ describe('LinkPlugin URL utils', () => {
                 shouldBeValid: true,
             },
             {
-                input: '/wrongpage/123',
+                input: '/hub/167',
+                shouldBeValid: true,
+            },
+            {
+                input: '/any/relative/path?query=1#hash',
+                shouldBeValid: true,
+            },
+            {
+                input: '/',
+                shouldBeValid: true,
+            },
+            {
+                input: '//example.com',
                 shouldBeValid: false,
             },
             {

--- a/packages/guideline-blocks-settings/src/helpers/addHttps.spec.ts
+++ b/packages/guideline-blocks-settings/src/helpers/addHttps.spec.ts
@@ -35,6 +35,13 @@ describe('String converted to Richtext value', () => {
         expect(result).toBe(url);
     });
 
+    it.each(['/hub/167', '/hub/167?tab=overview#section', '/', '/any/relative/path'])(
+        'should not add https:// for the root-relative url %s',
+        (url) => {
+            expect(addHttps(url)).toBe(url);
+        },
+    );
+
     it('should not add https:// for http://', () => {
         const url = 'http://localhost:3000/document/123';
         const result = addHttps(url);


### PR DESCRIPTION
Fixes [GCM-578](https://linear.app/frontify/issue/GCM-578).

## Problem

The only supported relative URLs were the ones that started with `/r/` or `/document`.

I don't see a reason for this, as we never want to prefix other relative URLs with https:// so I removed this rule and made it looser.