### PR TITLE
feat(app-bridge): add openBrandChecker command

### DIFF
--- a/.changeset/open-brand-check.md
+++ b/.changeset/open-brand-check.md
@@ -1,0 +1,7 @@
+---
+'@frontify/app-bridge': minor
+---
+
+feat: add `openBrandCheck` command
+
+A content block can dispatch `openBrandCheck` to open the Brand Check dialog on a guideline page. The payload `{ tab?: 'check' | 'configuration' }` is optional. The host opens the check tab when the payload is missing.

--- a/.changeset/open-brand-check.md
+++ b/.changeset/open-brand-check.md
@@ -2,6 +2,6 @@
 '@frontify/app-bridge': minor
 ---
 
-feat: add `openBrandCheck` command
+feat: add `openBrandChecker` command
 
-A content block can dispatch `openBrandCheck` to open the Brand Check dialog on a guideline page. The payload `{ tab?: 'check' | 'configuration' }` is optional. The host opens the check tab when the payload is missing.
+A content block can dispatch `openBrandChecker` to open the Brand Check dialog on a guideline page. The payload `{ tab?: 'check' | 'configuration' }` is optional. The host opens the check tab when the payload is missing.

--- a/.changeset/open-brand-check.md
+++ b/.changeset/open-brand-check.md
@@ -4,4 +4,4 @@
 
 feat: add `openBrandChecker` command
 
-A content block can dispatch `openBrandChecker` to open the Brand Check dialog on a guideline page. The payload `{ tab?: 'check' | 'configuration' }` is optional. The host opens the check tab when the payload is missing.
+A content block can dispatch `openBrandChecker` to open the Brand Check dialog on a guideline page. The payload uses `OpenBrandCheckerPayload` (`{ tab?: BrandCheckerTab }`). `tab` is optional. The host opens the check tab when the payload is missing.

--- a/.changeset/open-brand-check.md
+++ b/.changeset/open-brand-check.md
@@ -1,7 +1,7 @@
 ---
-"@frontify/app-bridge": minor
+'@frontify/app-bridge': minor
 ---
 
 feat: add `openBrandChecker` command
 
-A content block can dispatch `openBrandChecker` to open the Brand Check dialog on a guideline page. The payload uses `OpenBrandCheckerPayload` (`{ tab?: BrandCheckerTab }`). `tab` is optional. The host opens the check tab when the payload is missing.
+A content block can dispatch `openBrandChecker` to open the Brand Check dialog on a guideline page. The payload uses `OpenBrandCheckerPayload` (`{ tab: BrandCheckerTab }`). `tab` is required.

--- a/.changeset/open-brand-check.md
+++ b/.changeset/open-brand-check.md
@@ -1,5 +1,5 @@
 ---
-'@frontify/app-bridge': minor
+"@frontify/app-bridge": minor
 ---
 
 feat: add `openBrandChecker` command

--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -46,6 +46,7 @@ export type BlockCommand = CommandNameValidator<
         | 'openTemplateChooser'
         | 'openNewPublication'
         | 'openPlatformAppDirect'
+        | 'openBrandCheck'
         | 'trackEvent'
     >
 >;

--- a/packages/app-bridge/src/AppBridgeBlock.ts
+++ b/packages/app-bridge/src/AppBridgeBlock.ts
@@ -46,7 +46,7 @@ export type BlockCommand = CommandNameValidator<
         | 'openTemplateChooser'
         | 'openNewPublication'
         | 'openPlatformAppDirect'
-        | 'openBrandCheck'
+        | 'openBrandChecker'
         | 'trackEvent'
     >
 >;

--- a/packages/app-bridge/src/registries/commands/BrandCheck.ts
+++ b/packages/app-bridge/src/registries/commands/BrandCheck.ts
@@ -1,0 +1,12 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type DispatchHandlerParameter } from '../../AppBridge';
+
+import { type CommandRegistry } from './CommandRegistry';
+
+export const openBrandCheck = (
+    payload?: CommandRegistry['openBrandCheck'],
+): DispatchHandlerParameter<'openBrandCheck', CommandRegistry> => ({
+    name: 'openBrandCheck',
+    payload,
+});

--- a/packages/app-bridge/src/registries/commands/BrandChecker.spec.ts
+++ b/packages/app-bridge/src/registries/commands/BrandChecker.spec.ts
@@ -12,11 +12,4 @@ describe('BrandChecker', () => {
         expect(command.name).toBe('openBrandChecker');
         expect(command.payload).toStrictEqual(payload);
     });
-
-    it('should return an undefined payload when called with no argument', () => {
-        const command = openBrandChecker();
-
-        expect(command.name).toBe('openBrandChecker');
-        expect(command.payload).toBeUndefined();
-    });
 });

--- a/packages/app-bridge/src/registries/commands/BrandChecker.spec.ts
+++ b/packages/app-bridge/src/registries/commands/BrandChecker.spec.ts
@@ -1,0 +1,22 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { describe, expect, it } from 'vitest';
+
+import { openBrandChecker } from './BrandChecker';
+
+describe('BrandChecker', () => {
+    it('should return the command name and payload', () => {
+        const payload = { tab: 'configuration' as const };
+        const command = openBrandChecker(payload);
+
+        expect(command.name).toBe('openBrandChecker');
+        expect(command.payload).toStrictEqual(payload);
+    });
+
+    it('should return an undefined payload when called with no argument', () => {
+        const command = openBrandChecker();
+
+        expect(command.name).toBe('openBrandChecker');
+        expect(command.payload).toBeUndefined();
+    });
+});

--- a/packages/app-bridge/src/registries/commands/BrandChecker.ts
+++ b/packages/app-bridge/src/registries/commands/BrandChecker.ts
@@ -4,9 +4,9 @@ import { type DispatchHandlerParameter } from '../../AppBridge';
 
 import { type CommandRegistry } from './CommandRegistry';
 
-export const openBrandCheck = (
-    payload?: CommandRegistry['openBrandCheck'],
-): DispatchHandlerParameter<'openBrandCheck', CommandRegistry> => ({
-    name: 'openBrandCheck',
+export const openBrandChecker = (
+    payload?: CommandRegistry['openBrandChecker'],
+): DispatchHandlerParameter<'openBrandChecker', CommandRegistry> => ({
+    name: 'openBrandChecker',
     payload,
 });

--- a/packages/app-bridge/src/registries/commands/BrandChecker.ts
+++ b/packages/app-bridge/src/registries/commands/BrandChecker.ts
@@ -5,7 +5,7 @@ import { type DispatchHandlerParameter } from '../../AppBridge';
 import { type CommandRegistry } from './CommandRegistry';
 
 export const openBrandChecker = (
-    payload?: CommandRegistry['openBrandChecker'],
+    payload: CommandRegistry['openBrandChecker'],
 ): DispatchHandlerParameter<'openBrandChecker', CommandRegistry> => ({
     name: 'openBrandChecker',
     payload,

--- a/packages/app-bridge/src/registries/commands/CommandRegistry.ts
+++ b/packages/app-bridge/src/registries/commands/CommandRegistry.ts
@@ -21,6 +21,7 @@ type DownloadAsset = Asset;
 type OpenSearchDialog = void;
 type CloseSearchDialog = void;
 type OpenPlatformAppDirect = { marketplaceAppId: string };
+export type OpenBrandCheckPayload = { tab?: 'check' | 'configuration' };
 
 export type CommandRegistry = CommandNameValidator<{
     openAssetChooser?: OpenAssetChooserPayload;
@@ -35,5 +36,6 @@ export type CommandRegistry = CommandNameValidator<{
     openSearchDialog: OpenSearchDialog;
     closeSearchDialog: CloseSearchDialog;
     openPlatformAppDirect: OpenPlatformAppDirect;
+    openBrandCheck?: OpenBrandCheckPayload;
     trackEvent: TrackPayload;
 }>;

--- a/packages/app-bridge/src/registries/commands/CommandRegistry.ts
+++ b/packages/app-bridge/src/registries/commands/CommandRegistry.ts
@@ -21,7 +21,7 @@ type DownloadAsset = Asset;
 type OpenSearchDialog = void;
 type CloseSearchDialog = void;
 type OpenPlatformAppDirect = { marketplaceAppId: string };
-export type OpenBrandCheckPayload = { tab?: 'check' | 'configuration' };
+export type OpenBrandCheckerPayload = { tab?: 'check' | 'configuration' };
 
 export type CommandRegistry = CommandNameValidator<{
     openAssetChooser?: OpenAssetChooserPayload;
@@ -36,6 +36,6 @@ export type CommandRegistry = CommandNameValidator<{
     openSearchDialog: OpenSearchDialog;
     closeSearchDialog: CloseSearchDialog;
     openPlatformAppDirect: OpenPlatformAppDirect;
-    openBrandCheck?: OpenBrandCheckPayload;
+    openBrandChecker?: OpenBrandCheckerPayload;
     trackEvent: TrackPayload;
 }>;

--- a/packages/app-bridge/src/registries/commands/CommandRegistry.ts
+++ b/packages/app-bridge/src/registries/commands/CommandRegistry.ts
@@ -36,6 +36,6 @@ export type CommandRegistry = CommandNameValidator<{
     openSearchDialog: OpenSearchDialog;
     closeSearchDialog: CloseSearchDialog;
     openPlatformAppDirect: OpenPlatformAppDirect;
-    openBrandChecker?: OpenBrandCheckerPayload;
+    openBrandChecker: OpenBrandCheckerPayload;
     trackEvent: TrackPayload;
 }>;

--- a/packages/app-bridge/src/registries/commands/CommandRegistry.ts
+++ b/packages/app-bridge/src/registries/commands/CommandRegistry.ts
@@ -6,6 +6,7 @@ import {
     type Asset,
     type AssetChooserOptions,
     type LinkChooserOptions,
+    type OpenBrandCheckerPayload,
     type OpenNewPublicationPayload,
     type TrackPayload,
 } from '../../types';
@@ -21,7 +22,6 @@ type DownloadAsset = Asset;
 type OpenSearchDialog = void;
 type CloseSearchDialog = void;
 type OpenPlatformAppDirect = { marketplaceAppId: string };
-export type OpenBrandCheckerPayload = { tab?: 'check' | 'configuration' };
 
 export type CommandRegistry = CommandNameValidator<{
     openAssetChooser?: OpenAssetChooserPayload;

--- a/packages/app-bridge/src/registries/commands/index.ts
+++ b/packages/app-bridge/src/registries/commands/index.ts
@@ -2,7 +2,7 @@
 
 export * from './AssetChooser';
 export * from './AssetViewer';
-export * from './BrandCheck';
+export * from './BrandChecker';
 export * from './CommandRegistry';
 export * from './DownloadAsset';
 export * from './LinkChooser';

--- a/packages/app-bridge/src/registries/commands/index.ts
+++ b/packages/app-bridge/src/registries/commands/index.ts
@@ -2,6 +2,7 @@
 
 export * from './AssetChooser';
 export * from './AssetViewer';
+export * from './BrandCheck';
 export * from './CommandRegistry';
 export * from './DownloadAsset';
 export * from './LinkChooser';

--- a/packages/app-bridge/src/types/BrandChecker.ts
+++ b/packages/app-bridge/src/types/BrandChecker.ts
@@ -3,5 +3,5 @@
 export type BrandCheckerTab = 'check' | 'configuration';
 
 export type OpenBrandCheckerPayload = {
-    tab?: BrandCheckerTab;
+    tab: BrandCheckerTab;
 };

--- a/packages/app-bridge/src/types/BrandChecker.ts
+++ b/packages/app-bridge/src/types/BrandChecker.ts
@@ -1,0 +1,7 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export type BrandCheckerTab = 'check' | 'configuration';
+
+export type OpenBrandCheckerPayload = {
+    tab?: BrandCheckerTab;
+};

--- a/packages/app-bridge/src/types/index.ts
+++ b/packages/app-bridge/src/types/index.ts
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export * from './Asset';
+export * from './BrandChecker';
 export * from './BulkDownload';
 export * from './Color';
 export * from './ColorPalette';


### PR DESCRIPTION
### What does this PR do?

Adds the `openBrandChecker` command to `@frontify/app-bridge`.

A content block can dispatch this command to open the Brand Check dialog on a guideline page. The payload `{ tab?: 'check' | 'configuration' }` is optional. The host opens the check tab when the payload is missing.

The web-app host supplies `guidelineProjectId` and `brandId` at mount time. The command does not take those IDs.

### How to test

1. Install this package in a content block.
2. Call `appBridge.dispatch(openBrandChecker())` or `appBridge.dispatch(openBrandChecker({ tab: 'configuration' }))`.
3. Confirm TypeScript accepts the call. The web-app handler lands in a follow-up after this alpha is published.

### Related notes

Draft for the content-and-blocks team. Web-app PR: https://github.com/Frontify/web-app/pull/16648