### PR TITLE
fix(ci): upgrade changesets/action to v2

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -1,207 +1,205 @@
 name: Continuous Deployment
 
 on:
-  push:
-    branches:
-      - main
-      - dev
+    push:
+        branches:
+            - main
+            - dev
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    build:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-    steps:
-      - name: Checkout default branch
-        uses: actions/checkout@v6
+        steps:
+            - name: Checkout default branch
+              uses: actions/checkout@v6
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          run_install: false
+            - name: Use pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  run_install: false
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: ".nvmrc"
+                  cache: "pnpm"
 
-      - name: Install npm dependencies
-        run: pnpm i --frozen-lockfile
+            - name: Install npm dependencies
+              run: pnpm i --frozen-lockfile
 
-      - name: Build the packages
-        run: pnpm build
+            - name: Build the packages
+              run: pnpm build
 
-      - name: Cache the built artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: built-artifacts
-          path: packages/*/dist
-          if-no-files-found: error
+            - name: Cache the built artifacts
+              uses: actions/upload-artifact@v7
+              with:
+                  name: built-artifacts
+                  path: packages/*/dist
+                  if-no-files-found: error
 
-  lint:
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    lint:
+        needs: build
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-    steps:
-      - name: Checkout default branch
-        uses: actions/checkout@v6
+        steps:
+            - name: Checkout default branch
+              uses: actions/checkout@v6
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          run_install: false
+            - name: Use pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  run_install: false
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: ".nvmrc"
+                  cache: "pnpm"
 
-      - name: Install npm dependencies
-        run: pnpm i --frozen-lockfile
+            - name: Install npm dependencies
+              run: pnpm i --frozen-lockfile
 
-      - name: Download built artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: built-artifacts
-          path: packages
+            - name: Download built artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  name: built-artifacts
+                  path: packages
 
-      - name: Add app-bridge dependency for guideline-blocks-settings
-        run: pnpm add @frontify/app-bridge@workspace:^ --filter {packages/guideline-blocks-settings}
+            - name: Add app-bridge dependency for guideline-blocks-settings
+              run: pnpm add @frontify/app-bridge@workspace:^ --filter {packages/guideline-blocks-settings}
 
-      - name: Lint code
-        run: pnpm lint
+            - name: Lint code
+              run: pnpm lint
 
-  typecheck:
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    typecheck:
+        needs: build
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-    steps:
-      - name: Checkout default branch
-        uses: actions/checkout@v6
+        steps:
+            - name: Checkout default branch
+              uses: actions/checkout@v6
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          run_install: false
+            - name: Use pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  run_install: false
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: ".nvmrc"
+                  cache: "pnpm"
 
-      - name: Install npm dependencies
-        run: pnpm i --frozen-lockfile
+            - name: Install npm dependencies
+              run: pnpm i --frozen-lockfile
 
-      - name: Download built artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: built-artifacts
-          path: packages
+            - name: Download built artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  name: built-artifacts
+                  path: packages
 
-      - name: Add app-bridge dependency for guideline-blocks-settings
-        run: pnpm add @frontify/app-bridge@workspace:^ --filter {packages/guideline-blocks-settings}
+            - name: Add app-bridge dependency for guideline-blocks-settings
+              run: pnpm add @frontify/app-bridge@workspace:^ --filter {packages/guideline-blocks-settings}
 
-      - name: Typecheck code
-        run: pnpm typecheck
+            - name: Typecheck code
+              run: pnpm typecheck
 
-  unit-tests:
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    unit-tests:
+        needs: build
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-    permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
+        permissions:
+            id-token: write
+            contents: write
+            pull-requests: write
 
-    steps:
-      - name: Checkout default branch
-        uses: actions/checkout@v6
+        steps:
+            - name: Checkout default branch
+              uses: actions/checkout@v6
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          run_install: false
+            - name: Use pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  run_install: false
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: ".nvmrc"
+                  cache: "pnpm"
 
-      - name: Install npm dependencies
-        run: pnpm i --frozen-lockfile
+            - name: Install npm dependencies
+              run: pnpm i --frozen-lockfile
 
-      - name: Download built artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: built-artifacts
-          path: packages
+            - name: Download built artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  name: built-artifacts
+                  path: packages
 
-      - name: Add app-bridge dependency for guideline-blocks-settings
-        run: pnpm add @frontify/app-bridge@workspace:^ --filter {packages/guideline-blocks-settings}
+            - name: Add app-bridge dependency for guideline-blocks-settings
+              run: pnpm add @frontify/app-bridge@workspace:^ --filter {packages/guideline-blocks-settings}
 
-      - name: Test code
-        run: pnpm test
+            - name: Test code
+              run: pnpm test
 
-  publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    publish:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-    needs: [lint, typecheck, unit-tests]
+        needs: [lint, typecheck, unit-tests]
 
-    permissions:
-      contents: write # to create release (changesets/action)
-      pull-requests: write # to create pull request (changesets/action)
-      id-token: write # to authenticate with npm registry via OIDC
+        permissions:
+            contents: write # to create release (changesets/action)
+            pull-requests: write # to create pull request (changesets/action)
+            id-token: write # to authenticate with npm registry via OIDC
 
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.FRONTIFY_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.FRONTIFY_RELEASE_APP_PRIVATE_KEY }}
-          repositories: brand-sdk
-          permission-contents: write
-          permission-pull-requests: write
+        steps:
+            - name: Generate GitHub App token
+              id: generate-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.FRONTIFY_RELEASE_APP_CLIENT_ID }}
+                  private-key: ${{ secrets.FRONTIFY_RELEASE_APP_PRIVATE_KEY }}
+                  repositories: brand-sdk
+                  permission-contents: write
+                  permission-pull-requests: write
 
-      - name: Checkout default branch
-        uses: actions/checkout@v6
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
+            - name: Checkout default branch
+              uses: actions/checkout@v6
+              with:
+                  token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          run_install: false
+            - name: Use pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  run_install: false
 
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: ".nvmrc"
+                  cache: "pnpm"
 
-      - name: Install npm dependencies
-        run: pnpm i --frozen-lockfile
+            - name: Install npm dependencies
+              run: pnpm i --frozen-lockfile
 
-      - name: Create release PR or publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          commit: "chore: release packages"
-          title: "chore: release packages"
-          createGithubReleases: true
-          publish: pnpm release
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          NPM_CONFIG_PROVENANCE: true
-          # Use OIDC for npm authentication instead of NPM_TOKEN
-          NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
+            - name: Create release PR or publish to npm
+              id: changesets
+              uses: changesets/action@v2
+              with:
+                  github-token: ${{ steps.generate-token.outputs.token }}
+                  commit-message: "chore: release packages"
+                  pr-title: "chore: release packages"
+                  create-github-releases: true
+                  publish-script: pnpm release
+              env:
+                  NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Problem

The publish job on `dev` fails after every release commit with:

```
ENOENT: no such file or directory, open '/home/runner/work/brand-sdk/brand-sdk/.changeset/pre/changes.md'
```

Nothing gets published — the action throws at startup, before `pnpm release` runs. npm is still at `@frontify/app-bridge@4.0.0-alpha.68` while `dev` already carries the `4.0.0-alpha.69` bumps.

## Cause

#1663 bumped `@changesets/cli` to `^3.0.1`. Changesets v3 changed the pre-mode layout: `changeset version` now **moves** the applied changeset files into `.changeset/pre/` instead of listing them in `pre.json`'s `changesets` array. That is exactly what the release commit did (102 files renamed into `.changeset/pre/`, `pre.json` reduced to `{mode, tag}`).

`changesets/action@v1` bundles `@changesets/read` v2, which still supports the *legacy Changesets v1* format where a changeset is a **directory** containing `changes.md`. It reads `.changeset/`, sees the new `pre` directory, treats it as a legacy changeset, and tries to open `.changeset/pre/changes.md`. `@changesets/read@1.0.1` (shipped with CLI v3) instead reads `.changeset/pre/*` explicitly.

changesets/action v2.0.0 was released for exactly this — it updates to the Changesets v3 packages, drops the Changesets v1 compatibility path, and validates that projects use CLI v3, pointing CLI v2 users back at `@v1`.

## Change

Upgrade the action to `@v2` and migrate the renamed inputs:

| v1 | v2 |
| --- | --- |
| `publish` | `publish-script` |
| `commit` | `commit-message` |
| `title` | `pr-title` |
| `createGithubReleases` | `create-github-releases` |
| `GITHUB_TOKEN` env | `github-token` input |

`NPM_TOKEN: ""` is dropped — it worked around v1 writing an `.npmrc` when `NPM_TOKEN` was set, and v2 removed `.npmrc` handling entirely in favour of trusted publishing.

## Notes on v2 behaviour

- Release commits and tags are now pushed through the **GitHub API** rather than the git CLI, signed and attributed to the app owning `github-token`. The `FRONTIFY_RELEASE_APP` token already has `contents: write`, so this works as-is; `push-with-git-cli: true` restores the old behaviour if preferred.
- Published-package detection moved from stdout parsing to a `CHANGESETS_OUTPUT` file, which custom publish scripts must forward to the CLI. `pnpm release` → `changeset publish` inherits the environment, so no change needed.
- `.nvmrc` is Node 24, satisfying CLI v3's `^22.11 || ^24 || >=26` engine range.
- The `.changeset/pre/` directory on `dev` is the correct v3 layout and should stay.

Once this lands, the publish job re-runs against the committed bumps and publishes `@frontify/app-bridge@4.0.0-alpha.69` and `@frontify/guideline-blocks-settings@4.0.0-alpha.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
